### PR TITLE
Match AU in km to docs

### DIFF
--- a/build/spacekit.js
+++ b/build/spacekit.js
@@ -50918,11 +50918,11 @@ var Spacekit = (function (exports) {
 	}
 
 	function kmToAu(km) {
-	  return km / 149598000;
+	  return km / 149597870.7;
 	}
 
 	function auToKm(au) {
-	  return au * 149598000;
+	  return au * 149597870.7;
 	}
 
 	const J2000 = 2451545.0;


### PR DESCRIPTION
In `docs/file/src/Ephem.js.html` has `METERS_IN_AU` at `149597870700`, but
both `kmToAu()` and `auToKm()` used the value `149598000`.