### PR TITLE
Fix Simulation time so can be set to full precision not just to day

### DIFF
--- a/src/Simulation.js
+++ b/src/Simulation.js
@@ -677,7 +677,7 @@ export class Simulation {
    * @param {Date} date Date of simulation
    */
   setDate(date) {
-    this.setJd(julian.toJulianDay(date));
+    this.setJd(julian(date));
   }
 
   /**


### PR DESCRIPTION
Fixeds Issue #25 by using the julian full precision not just to date level converter.