### PR TITLE
Fix proper removal of all visual features of objects on object removal

### DIFF
--- a/build/spacekit.js
+++ b/build/spacekit.js
@@ -58,31 +58,27 @@ var Spacekit = (function (exports) {
 		// Missing in IE
 		// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
 
-		( function () {
+		Object.assign = function ( target ) {
 
-			Object.assign = function ( target ) {
+			if ( target === undefined || target === null ) {
 
-				if ( target === undefined || target === null ) {
+				throw new TypeError( 'Cannot convert undefined or null to object' );
 
-					throw new TypeError( 'Cannot convert undefined or null to object' );
+			}
 
-				}
+			var output = Object( target );
 
-				var output = Object( target );
+			for ( var index = 1; index < arguments.length; index ++ ) {
 
-				for ( var index = 1; index < arguments.length; index ++ ) {
+				var source = arguments[ index ];
 
-					var source = arguments[ index ];
+				if ( source !== undefined && source !== null ) {
 
-					if ( source !== undefined && source !== null ) {
+					for ( var nextKey in source ) {
 
-						for ( var nextKey in source ) {
+						if ( Object.prototype.hasOwnProperty.call( source, nextKey ) ) {
 
-							if ( Object.prototype.hasOwnProperty.call( source, nextKey ) ) {
-
-								output[ nextKey ] = source[ nextKey ];
-
-							}
+							output[ nextKey ] = source[ nextKey ];
 
 						}
 
@@ -90,99 +86,15 @@ var Spacekit = (function (exports) {
 
 				}
 
-				return output;
+			}
 
-			};
+			return output;
 
-		} )();
+		};
 
 	}
 
-	/**
-	 * https://github.com/mrdoob/eventdispatcher.js/
-	 */
-
-	function EventDispatcher() {}
-
-	Object.assign( EventDispatcher.prototype, {
-
-		addEventListener: function ( type, listener ) {
-
-			if ( this._listeners === undefined ) this._listeners = {};
-
-			var listeners = this._listeners;
-
-			if ( listeners[ type ] === undefined ) {
-
-				listeners[ type ] = [];
-
-			}
-
-			if ( listeners[ type ].indexOf( listener ) === - 1 ) {
-
-				listeners[ type ].push( listener );
-
-			}
-
-		},
-
-		hasEventListener: function ( type, listener ) {
-
-			if ( this._listeners === undefined ) return false;
-
-			var listeners = this._listeners;
-
-			return listeners[ type ] !== undefined && listeners[ type ].indexOf( listener ) !== - 1;
-
-		},
-
-		removeEventListener: function ( type, listener ) {
-
-			if ( this._listeners === undefined ) return;
-
-			var listeners = this._listeners;
-			var listenerArray = listeners[ type ];
-
-			if ( listenerArray !== undefined ) {
-
-				var index = listenerArray.indexOf( listener );
-
-				if ( index !== - 1 ) {
-
-					listenerArray.splice( index, 1 );
-
-				}
-
-			}
-
-		},
-
-		dispatchEvent: function ( event ) {
-
-			if ( this._listeners === undefined ) return;
-
-			var listeners = this._listeners;
-			var listenerArray = listeners[ event.type ];
-
-			if ( listenerArray !== undefined ) {
-
-				event.target = this;
-
-				var array = listenerArray.slice( 0 );
-
-				for ( var i = 0, l = array.length; i < l; i ++ ) {
-
-					array[ i ].call( this, event );
-
-				}
-
-			}
-
-		}
-
-	} );
-
-	var REVISION = '107';
+	var REVISION = '116';
 	var MOUSE = { LEFT: 0, MIDDLE: 1, RIGHT: 2, ROTATE: 0, DOLLY: 1, PAN: 2 };
 	var TOUCH = { ROTATE: 0, PAN: 1, DOLLY_PAN: 2, DOLLY_ROTATE: 3 };
 	var CullFaceNone = 0;
@@ -194,14 +106,12 @@ var Spacekit = (function (exports) {
 	var BasicShadowMap = 0;
 	var PCFShadowMap = 1;
 	var PCFSoftShadowMap = 2;
+	var VSMShadowMap = 3;
 	var FrontSide = 0;
 	var BackSide = 1;
 	var DoubleSide = 2;
 	var FlatShading = 1;
 	var SmoothShading = 2;
-	var NoColors = 0;
-	var FaceColors = 1;
-	var VertexColors = 2;
 	var NoBlending = 0;
 	var NormalBlending = 1;
 	var AdditiveBlending = 2;
@@ -284,6 +194,12 @@ var Spacekit = (function (exports) {
 	var DepthFormat = 1026;
 	var DepthStencilFormat = 1027;
 	var RedFormat = 1028;
+	var RedIntegerFormat = 1029;
+	var RGFormat = 1030;
+	var RGIntegerFormat = 1031;
+	var RGBIntegerFormat = 1032;
+	var RGBAIntegerFormat = 1033;
+
 	var RGB_S3TC_DXT1_Format = 33776;
 	var RGBA_S3TC_DXT1_Format = 33777;
 	var RGBA_S3TC_DXT3_Format = 33778;
@@ -293,6 +209,8 @@ var Spacekit = (function (exports) {
 	var RGBA_PVRTC_4BPPV1_Format = 35842;
 	var RGBA_PVRTC_2BPPV1_Format = 35843;
 	var RGB_ETC1_Format = 36196;
+	var RGB_ETC2_Format = 37492;
+	var RGBA_ETC2_EAC_Format = 37496;
 	var RGBA_ASTC_4x4_Format = 37808;
 	var RGBA_ASTC_5x4_Format = 37809;
 	var RGBA_ASTC_5x5_Format = 37810;
@@ -307,6 +225,21 @@ var Spacekit = (function (exports) {
 	var RGBA_ASTC_10x10_Format = 37819;
 	var RGBA_ASTC_12x10_Format = 37820;
 	var RGBA_ASTC_12x12_Format = 37821;
+	var RGBA_BPTC_Format = 36492;
+	var SRGB8_ALPHA8_ASTC_4x4_Format = 37840;
+	var SRGB8_ALPHA8_ASTC_5x4_Format = 37841;
+	var SRGB8_ALPHA8_ASTC_5x5_Format = 37842;
+	var SRGB8_ALPHA8_ASTC_6x5_Format = 37843;
+	var SRGB8_ALPHA8_ASTC_6x6_Format = 37844;
+	var SRGB8_ALPHA8_ASTC_8x5_Format = 37845;
+	var SRGB8_ALPHA8_ASTC_8x6_Format = 37846;
+	var SRGB8_ALPHA8_ASTC_8x8_Format = 37847;
+	var SRGB8_ALPHA8_ASTC_10x5_Format = 37848;
+	var SRGB8_ALPHA8_ASTC_10x6_Format = 37849;
+	var SRGB8_ALPHA8_ASTC_10x8_Format = 37850;
+	var SRGB8_ALPHA8_ASTC_10x10_Format = 37851;
+	var SRGB8_ALPHA8_ASTC_12x10_Format = 37852;
+	var SRGB8_ALPHA8_ASTC_12x12_Format = 37853;
 	var LoopOnce = 2200;
 	var LoopRepeat = 2201;
 	var LoopPingPong = 2202;
@@ -316,6 +249,8 @@ var Spacekit = (function (exports) {
 	var ZeroCurvatureEnding = 2400;
 	var ZeroSlopeEnding = 2401;
 	var WrapAroundEnding = 2402;
+	var NormalAnimationBlendMode = 2500;
+	var AdditiveAnimationBlendMode = 2501;
 	var TrianglesDrawMode = 0;
 	var TriangleStripDrawMode = 1;
 	var TriangleFanDrawMode = 2;
@@ -350,45 +285,138 @@ var Spacekit = (function (exports) {
 	var GreaterEqualStencilFunc = 518;
 	var AlwaysStencilFunc = 519;
 
+	var StaticDrawUsage = 35044;
+	var DynamicDrawUsage = 35048;
+	var StreamDrawUsage = 35040;
+	var StaticReadUsage = 35045;
+	var DynamicReadUsage = 35049;
+	var StreamReadUsage = 35041;
+	var StaticCopyUsage = 35046;
+	var DynamicCopyUsage = 35050;
+	var StreamCopyUsage = 35042;
+
+	/**
+	 * https://github.com/mrdoob/eventdispatcher.js/
+	 */
+
+	function EventDispatcher() {}
+
+	Object.assign( EventDispatcher.prototype, {
+
+		addEventListener: function ( type, listener ) {
+
+			if ( this._listeners === undefined ) this._listeners = {};
+
+			var listeners = this._listeners;
+
+			if ( listeners[ type ] === undefined ) {
+
+				listeners[ type ] = [];
+
+			}
+
+			if ( listeners[ type ].indexOf( listener ) === - 1 ) {
+
+				listeners[ type ].push( listener );
+
+			}
+
+		},
+
+		hasEventListener: function ( type, listener ) {
+
+			if ( this._listeners === undefined ) return false;
+
+			var listeners = this._listeners;
+
+			return listeners[ type ] !== undefined && listeners[ type ].indexOf( listener ) !== - 1;
+
+		},
+
+		removeEventListener: function ( type, listener ) {
+
+			if ( this._listeners === undefined ) return;
+
+			var listeners = this._listeners;
+			var listenerArray = listeners[ type ];
+
+			if ( listenerArray !== undefined ) {
+
+				var index = listenerArray.indexOf( listener );
+
+				if ( index !== - 1 ) {
+
+					listenerArray.splice( index, 1 );
+
+				}
+
+			}
+
+		},
+
+		dispatchEvent: function ( event ) {
+
+			if ( this._listeners === undefined ) return;
+
+			var listeners = this._listeners;
+			var listenerArray = listeners[ event.type ];
+
+			if ( listenerArray !== undefined ) {
+
+				event.target = this;
+
+				// Make a copy, in case listeners are removed while iterating.
+				var array = listenerArray.slice( 0 );
+
+				for ( var i = 0, l = array.length; i < l; i ++ ) {
+
+					array[ i ].call( this, event );
+
+				}
+
+			}
+
+		}
+
+	} );
+
 	/**
 	 * @author alteredq / http://alteredqualia.com/
 	 * @author mrdoob / http://mrdoob.com/
+	 * @author WestLangley / http://github.com/WestLangley
+	 * @author thezwap
 	 */
 
-	var _Math = {
+	var _lut = [];
+
+	for ( var i = 0; i < 256; i ++ ) {
+
+		_lut[ i ] = ( i < 16 ? '0' : '' ) + ( i ).toString( 16 );
+
+	}
+
+	var MathUtils = {
 
 		DEG2RAD: Math.PI / 180,
 		RAD2DEG: 180 / Math.PI,
 
-		generateUUID: ( function () {
+		generateUUID: function () {
 
 			// http://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid-in-javascript/21963136#21963136
 
-			var lut = [];
+			var d0 = Math.random() * 0xffffffff | 0;
+			var d1 = Math.random() * 0xffffffff | 0;
+			var d2 = Math.random() * 0xffffffff | 0;
+			var d3 = Math.random() * 0xffffffff | 0;
+			var uuid = _lut[ d0 & 0xff ] + _lut[ d0 >> 8 & 0xff ] + _lut[ d0 >> 16 & 0xff ] + _lut[ d0 >> 24 & 0xff ] + '-' +
+				_lut[ d1 & 0xff ] + _lut[ d1 >> 8 & 0xff ] + '-' + _lut[ d1 >> 16 & 0x0f | 0x40 ] + _lut[ d1 >> 24 & 0xff ] + '-' +
+				_lut[ d2 & 0x3f | 0x80 ] + _lut[ d2 >> 8 & 0xff ] + '-' + _lut[ d2 >> 16 & 0xff ] + _lut[ d2 >> 24 & 0xff ] +
+				_lut[ d3 & 0xff ] + _lut[ d3 >> 8 & 0xff ] + _lut[ d3 >> 16 & 0xff ] + _lut[ d3 >> 24 & 0xff ];
 
-			for ( var i = 0; i < 256; i ++ ) {
+			// .toUpperCase() here flattens concatenated strings to save heap memory space.
+			return uuid.toUpperCase();
 
-				lut[ i ] = ( i < 16 ? '0' : '' ) + ( i ).toString( 16 );
-
-			}
-
-			return function generateUUID() {
-
-				var d0 = Math.random() * 0xffffffff | 0;
-				var d1 = Math.random() * 0xffffffff | 0;
-				var d2 = Math.random() * 0xffffffff | 0;
-				var d3 = Math.random() * 0xffffffff | 0;
-				var uuid = lut[ d0 & 0xff ] + lut[ d0 >> 8 & 0xff ] + lut[ d0 >> 16 & 0xff ] + lut[ d0 >> 24 & 0xff ] + '-' +
-					lut[ d1 & 0xff ] + lut[ d1 >> 8 & 0xff ] + '-' + lut[ d1 >> 16 & 0x0f | 0x40 ] + lut[ d1 >> 24 & 0xff ] + '-' +
-					lut[ d2 & 0x3f | 0x80 ] + lut[ d2 >> 8 & 0xff ] + '-' + lut[ d2 >> 16 & 0xff ] + lut[ d2 >> 24 & 0xff ] +
-					lut[ d3 & 0xff ] + lut[ d3 >> 8 & 0xff ] + lut[ d3 >> 16 & 0xff ] + lut[ d3 >> 24 & 0xff ];
-
-				// .toUpperCase() here flattens concatenated strings to save heap memory space.
-				return uuid.toUpperCase();
-
-			};
-
-		} )(),
+		},
 
 		clamp: function ( value, min, max ) {
 
@@ -471,13 +499,13 @@ var Spacekit = (function (exports) {
 
 		degToRad: function ( degrees ) {
 
-			return degrees * _Math.DEG2RAD;
+			return degrees * MathUtils.DEG2RAD;
 
 		},
 
 		radToDeg: function ( radians ) {
 
-			return radians * _Math.RAD2DEG;
+			return radians * MathUtils.RAD2DEG;
 
 		},
 
@@ -496,6 +524,62 @@ var Spacekit = (function (exports) {
 		floorPowerOfTwo: function ( value ) {
 
 			return Math.pow( 2, Math.floor( Math.log( value ) / Math.LN2 ) );
+
+		},
+
+		setQuaternionFromProperEuler: function ( q, a, b, c, order ) {
+
+			// Intrinsic Proper Euler Angles - see https://en.wikipedia.org/wiki/Euler_angles
+
+			// rotations are applied to the axes in the order specified by 'order'
+			// rotation by angle 'a' is applied first, then by angle 'b', then by angle 'c'
+			// angles are in radians
+
+			var cos = Math.cos;
+			var sin = Math.sin;
+
+			var c2 = cos( b / 2 );
+			var s2 = sin( b / 2 );
+
+			var c13 = cos( ( a + c ) / 2 );
+			var s13 = sin( ( a + c ) / 2 );
+
+			var c1_3 = cos( ( a - c ) / 2 );
+			var s1_3 = sin( ( a - c ) / 2 );
+
+			var c3_1 = cos( ( c - a ) / 2 );
+			var s3_1 = sin( ( c - a ) / 2 );
+
+			switch ( order ) {
+
+				case 'XYX':
+					q.set( c2 * s13, s2 * c1_3, s2 * s1_3, c2 * c13 );
+					break;
+
+				case 'YZY':
+					q.set( s2 * s1_3, c2 * s13, s2 * c1_3, c2 * c13 );
+					break;
+
+				case 'ZXZ':
+					q.set( s2 * c1_3, s2 * s1_3, c2 * s13, c2 * c13 );
+					break;
+
+				case 'XZX':
+					q.set( c2 * s13, s2 * s3_1, s2 * c3_1, c2 * c13 );
+					break;
+
+				case 'YXY':
+					q.set( s2 * c3_1, c2 * s13, s2 * s3_1, c2 * c13 );
+					break;
+
+				case 'ZYZ':
+					q.set( s2 * s3_1, s2 * c3_1, c2 * s13, c2 * c13 );
+					break;
+
+				default:
+					console.warn( 'THREE.MathUtils: .setQuaternionFromProperEuler() encountered an unknown order: ' + order );
+
+			}
 
 		}
 
@@ -883,9 +967,7 @@ var Spacekit = (function (exports) {
 
 			// computes the angle in radians with respect to the positive x-axis
 
-			var angle = Math.atan2( this.y, this.x );
-
-			if ( angle < 0 ) angle += 2 * Math.PI;
+			var angle = Math.atan2( - this.y, - this.x ) + Math.PI;
 
 			return angle;
 
@@ -987,1351 +1069,12 @@ var Spacekit = (function (exports) {
 
 			return this;
 
-		}
-
-	} );
-
-	/**
-	 * @author mikael emtinger / http://gomo.se/
-	 * @author alteredq / http://alteredqualia.com/
-	 * @author WestLangley / http://github.com/WestLangley
-	 * @author bhouston / http://clara.io
-	 */
-
-	function Quaternion( x, y, z, w ) {
-
-		this._x = x || 0;
-		this._y = y || 0;
-		this._z = z || 0;
-		this._w = ( w !== undefined ) ? w : 1;
-
-	}
-
-	Object.assign( Quaternion, {
-
-		slerp: function ( qa, qb, qm, t ) {
-
-			return qm.copy( qa ).slerp( qb, t );
-
-		},
-
-		slerpFlat: function ( dst, dstOffset, src0, srcOffset0, src1, srcOffset1, t ) {
-
-			// fuzz-free, array-based Quaternion SLERP operation
-
-			var x0 = src0[ srcOffset0 + 0 ],
-				y0 = src0[ srcOffset0 + 1 ],
-				z0 = src0[ srcOffset0 + 2 ],
-				w0 = src0[ srcOffset0 + 3 ],
-
-				x1 = src1[ srcOffset1 + 0 ],
-				y1 = src1[ srcOffset1 + 1 ],
-				z1 = src1[ srcOffset1 + 2 ],
-				w1 = src1[ srcOffset1 + 3 ];
-
-			if ( w0 !== w1 || x0 !== x1 || y0 !== y1 || z0 !== z1 ) {
-
-				var s = 1 - t,
-
-					cos = x0 * x1 + y0 * y1 + z0 * z1 + w0 * w1,
-
-					dir = ( cos >= 0 ? 1 : - 1 ),
-					sqrSin = 1 - cos * cos;
-
-				// Skip the Slerp for tiny steps to avoid numeric problems:
-				if ( sqrSin > Number.EPSILON ) {
-
-					var sin = Math.sqrt( sqrSin ),
-						len = Math.atan2( sin, cos * dir );
-
-					s = Math.sin( s * len ) / sin;
-					t = Math.sin( t * len ) / sin;
-
-				}
-
-				var tDir = t * dir;
-
-				x0 = x0 * s + x1 * tDir;
-				y0 = y0 * s + y1 * tDir;
-				z0 = z0 * s + z1 * tDir;
-				w0 = w0 * s + w1 * tDir;
-
-				// Normalize in case we just did a lerp:
-				if ( s === 1 - t ) {
-
-					var f = 1 / Math.sqrt( x0 * x0 + y0 * y0 + z0 * z0 + w0 * w0 );
-
-					x0 *= f;
-					y0 *= f;
-					z0 *= f;
-					w0 *= f;
-
-				}
-
-			}
-
-			dst[ dstOffset ] = x0;
-			dst[ dstOffset + 1 ] = y0;
-			dst[ dstOffset + 2 ] = z0;
-			dst[ dstOffset + 3 ] = w0;
-
-		}
-
-	} );
-
-	Object.defineProperties( Quaternion.prototype, {
-
-		x: {
-
-			get: function () {
-
-				return this._x;
-
-			},
-
-			set: function ( value ) {
-
-				this._x = value;
-				this._onChangeCallback();
-
-			}
-
-		},
-
-		y: {
-
-			get: function () {
-
-				return this._y;
-
-			},
-
-			set: function ( value ) {
-
-				this._y = value;
-				this._onChangeCallback();
-
-			}
-
-		},
-
-		z: {
-
-			get: function () {
-
-				return this._z;
-
-			},
-
-			set: function ( value ) {
-
-				this._z = value;
-				this._onChangeCallback();
-
-			}
-
-		},
-
-		w: {
-
-			get: function () {
-
-				return this._w;
-
-			},
-
-			set: function ( value ) {
-
-				this._w = value;
-				this._onChangeCallback();
-
-			}
-
-		}
-
-	} );
-
-	Object.assign( Quaternion.prototype, {
-
-		isQuaternion: true,
-
-		set: function ( x, y, z, w ) {
-
-			this._x = x;
-			this._y = y;
-			this._z = z;
-			this._w = w;
-
-			this._onChangeCallback();
-
-			return this;
-
-		},
-
-		clone: function () {
-
-			return new this.constructor( this._x, this._y, this._z, this._w );
-
-		},
-
-		copy: function ( quaternion ) {
-
-			this._x = quaternion.x;
-			this._y = quaternion.y;
-			this._z = quaternion.z;
-			this._w = quaternion.w;
-
-			this._onChangeCallback();
-
-			return this;
-
-		},
-
-		setFromEuler: function ( euler, update ) {
-
-			if ( ! ( euler && euler.isEuler ) ) {
-
-				throw new Error( 'THREE.Quaternion: .setFromEuler() now expects an Euler rotation rather than a Vector3 and order.' );
-
-			}
-
-			var x = euler._x, y = euler._y, z = euler._z, order = euler.order;
-
-			// http://www.mathworks.com/matlabcentral/fileexchange/
-			// 	20696-function-to-convert-between-dcm-euler-angles-quaternions-and-euler-vectors/
-			//	content/SpinCalc.m
-
-			var cos = Math.cos;
-			var sin = Math.sin;
-
-			var c1 = cos( x / 2 );
-			var c2 = cos( y / 2 );
-			var c3 = cos( z / 2 );
-
-			var s1 = sin( x / 2 );
-			var s2 = sin( y / 2 );
-			var s3 = sin( z / 2 );
-
-			if ( order === 'XYZ' ) {
-
-				this._x = s1 * c2 * c3 + c1 * s2 * s3;
-				this._y = c1 * s2 * c3 - s1 * c2 * s3;
-				this._z = c1 * c2 * s3 + s1 * s2 * c3;
-				this._w = c1 * c2 * c3 - s1 * s2 * s3;
-
-			} else if ( order === 'YXZ' ) {
-
-				this._x = s1 * c2 * c3 + c1 * s2 * s3;
-				this._y = c1 * s2 * c3 - s1 * c2 * s3;
-				this._z = c1 * c2 * s3 - s1 * s2 * c3;
-				this._w = c1 * c2 * c3 + s1 * s2 * s3;
-
-			} else if ( order === 'ZXY' ) {
-
-				this._x = s1 * c2 * c3 - c1 * s2 * s3;
-				this._y = c1 * s2 * c3 + s1 * c2 * s3;
-				this._z = c1 * c2 * s3 + s1 * s2 * c3;
-				this._w = c1 * c2 * c3 - s1 * s2 * s3;
-
-			} else if ( order === 'ZYX' ) {
-
-				this._x = s1 * c2 * c3 - c1 * s2 * s3;
-				this._y = c1 * s2 * c3 + s1 * c2 * s3;
-				this._z = c1 * c2 * s3 - s1 * s2 * c3;
-				this._w = c1 * c2 * c3 + s1 * s2 * s3;
-
-			} else if ( order === 'YZX' ) {
-
-				this._x = s1 * c2 * c3 + c1 * s2 * s3;
-				this._y = c1 * s2 * c3 + s1 * c2 * s3;
-				this._z = c1 * c2 * s3 - s1 * s2 * c3;
-				this._w = c1 * c2 * c3 - s1 * s2 * s3;
-
-			} else if ( order === 'XZY' ) {
-
-				this._x = s1 * c2 * c3 - c1 * s2 * s3;
-				this._y = c1 * s2 * c3 - s1 * c2 * s3;
-				this._z = c1 * c2 * s3 + s1 * s2 * c3;
-				this._w = c1 * c2 * c3 + s1 * s2 * s3;
-
-			}
-
-			if ( update !== false ) this._onChangeCallback();
-
-			return this;
-
-		},
-
-		setFromAxisAngle: function ( axis, angle ) {
-
-			// http://www.euclideanspace.com/maths/geometry/rotations/conversions/angleToQuaternion/index.htm
-
-			// assumes axis is normalized
-
-			var halfAngle = angle / 2, s = Math.sin( halfAngle );
-
-			this._x = axis.x * s;
-			this._y = axis.y * s;
-			this._z = axis.z * s;
-			this._w = Math.cos( halfAngle );
-
-			this._onChangeCallback();
-
-			return this;
-
-		},
-
-		setFromRotationMatrix: function ( m ) {
-
-			// http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/index.htm
-
-			// assumes the upper 3x3 of m is a pure rotation matrix (i.e, unscaled)
-
-			var te = m.elements,
-
-				m11 = te[ 0 ], m12 = te[ 4 ], m13 = te[ 8 ],
-				m21 = te[ 1 ], m22 = te[ 5 ], m23 = te[ 9 ],
-				m31 = te[ 2 ], m32 = te[ 6 ], m33 = te[ 10 ],
-
-				trace = m11 + m22 + m33,
-				s;
-
-			if ( trace > 0 ) {
-
-				s = 0.5 / Math.sqrt( trace + 1.0 );
-
-				this._w = 0.25 / s;
-				this._x = ( m32 - m23 ) * s;
-				this._y = ( m13 - m31 ) * s;
-				this._z = ( m21 - m12 ) * s;
-
-			} else if ( m11 > m22 && m11 > m33 ) {
-
-				s = 2.0 * Math.sqrt( 1.0 + m11 - m22 - m33 );
-
-				this._w = ( m32 - m23 ) / s;
-				this._x = 0.25 * s;
-				this._y = ( m12 + m21 ) / s;
-				this._z = ( m13 + m31 ) / s;
-
-			} else if ( m22 > m33 ) {
-
-				s = 2.0 * Math.sqrt( 1.0 + m22 - m11 - m33 );
-
-				this._w = ( m13 - m31 ) / s;
-				this._x = ( m12 + m21 ) / s;
-				this._y = 0.25 * s;
-				this._z = ( m23 + m32 ) / s;
-
-			} else {
-
-				s = 2.0 * Math.sqrt( 1.0 + m33 - m11 - m22 );
-
-				this._w = ( m21 - m12 ) / s;
-				this._x = ( m13 + m31 ) / s;
-				this._y = ( m23 + m32 ) / s;
-				this._z = 0.25 * s;
-
-			}
-
-			this._onChangeCallback();
-
-			return this;
-
-		},
-
-		setFromUnitVectors: function ( vFrom, vTo ) {
-
-			// assumes direction vectors vFrom and vTo are normalized
-
-			var EPS = 0.000001;
-
-			var r = vFrom.dot( vTo ) + 1;
-
-			if ( r < EPS ) {
-
-				r = 0;
-
-				if ( Math.abs( vFrom.x ) > Math.abs( vFrom.z ) ) {
-
-					this._x = - vFrom.y;
-					this._y = vFrom.x;
-					this._z = 0;
-					this._w = r;
-
-				} else {
-
-					this._x = 0;
-					this._y = - vFrom.z;
-					this._z = vFrom.y;
-					this._w = r;
-
-				}
-
-			} else {
-
-				// crossVectors( vFrom, vTo ); // inlined to avoid cyclic dependency on Vector3
-
-				this._x = vFrom.y * vTo.z - vFrom.z * vTo.y;
-				this._y = vFrom.z * vTo.x - vFrom.x * vTo.z;
-				this._z = vFrom.x * vTo.y - vFrom.y * vTo.x;
-				this._w = r;
-
-			}
-
-			return this.normalize();
-
-		},
-
-		angleTo: function ( q ) {
-
-			return 2 * Math.acos( Math.abs( _Math.clamp( this.dot( q ), - 1, 1 ) ) );
-
-		},
-
-		rotateTowards: function ( q, step ) {
-
-			var angle = this.angleTo( q );
-
-			if ( angle === 0 ) return this;
-
-			var t = Math.min( 1, step / angle );
-
-			this.slerp( q, t );
-
-			return this;
-
-		},
-
-		inverse: function () {
-
-			// quaternion is assumed to have unit length
-
-			return this.conjugate();
-
-		},
-
-		conjugate: function () {
-
-			this._x *= - 1;
-			this._y *= - 1;
-			this._z *= - 1;
-
-			this._onChangeCallback();
-
-			return this;
-
-		},
-
-		dot: function ( v ) {
-
-			return this._x * v._x + this._y * v._y + this._z * v._z + this._w * v._w;
-
-		},
-
-		lengthSq: function () {
-
-			return this._x * this._x + this._y * this._y + this._z * this._z + this._w * this._w;
-
-		},
-
-		length: function () {
-
-			return Math.sqrt( this._x * this._x + this._y * this._y + this._z * this._z + this._w * this._w );
-
-		},
-
-		normalize: function () {
-
-			var l = this.length();
-
-			if ( l === 0 ) {
-
-				this._x = 0;
-				this._y = 0;
-				this._z = 0;
-				this._w = 1;
-
-			} else {
-
-				l = 1 / l;
-
-				this._x = this._x * l;
-				this._y = this._y * l;
-				this._z = this._z * l;
-				this._w = this._w * l;
-
-			}
-
-			this._onChangeCallback();
-
-			return this;
-
-		},
-
-		multiply: function ( q, p ) {
-
-			if ( p !== undefined ) {
-
-				console.warn( 'THREE.Quaternion: .multiply() now only accepts one argument. Use .multiplyQuaternions( a, b ) instead.' );
-				return this.multiplyQuaternions( q, p );
-
-			}
-
-			return this.multiplyQuaternions( this, q );
-
-		},
-
-		premultiply: function ( q ) {
-
-			return this.multiplyQuaternions( q, this );
-
-		},
-
-		multiplyQuaternions: function ( a, b ) {
-
-			// from http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/code/index.htm
-
-			var qax = a._x, qay = a._y, qaz = a._z, qaw = a._w;
-			var qbx = b._x, qby = b._y, qbz = b._z, qbw = b._w;
-
-			this._x = qax * qbw + qaw * qbx + qay * qbz - qaz * qby;
-			this._y = qay * qbw + qaw * qby + qaz * qbx - qax * qbz;
-			this._z = qaz * qbw + qaw * qbz + qax * qby - qay * qbx;
-			this._w = qaw * qbw - qax * qbx - qay * qby - qaz * qbz;
-
-			this._onChangeCallback();
-
-			return this;
-
-		},
-
-		slerp: function ( qb, t ) {
-
-			if ( t === 0 ) return this;
-			if ( t === 1 ) return this.copy( qb );
-
-			var x = this._x, y = this._y, z = this._z, w = this._w;
-
-			// http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/slerp/
-
-			var cosHalfTheta = w * qb._w + x * qb._x + y * qb._y + z * qb._z;
-
-			if ( cosHalfTheta < 0 ) {
-
-				this._w = - qb._w;
-				this._x = - qb._x;
-				this._y = - qb._y;
-				this._z = - qb._z;
-
-				cosHalfTheta = - cosHalfTheta;
-
-			} else {
-
-				this.copy( qb );
-
-			}
-
-			if ( cosHalfTheta >= 1.0 ) {
-
-				this._w = w;
-				this._x = x;
-				this._y = y;
-				this._z = z;
-
-				return this;
-
-			}
-
-			var sqrSinHalfTheta = 1.0 - cosHalfTheta * cosHalfTheta;
-
-			if ( sqrSinHalfTheta <= Number.EPSILON ) {
-
-				var s = 1 - t;
-				this._w = s * w + t * this._w;
-				this._x = s * x + t * this._x;
-				this._y = s * y + t * this._y;
-				this._z = s * z + t * this._z;
-
-				this.normalize();
-				this._onChangeCallback();
-
-				return this;
-
-			}
-
-			var sinHalfTheta = Math.sqrt( sqrSinHalfTheta );
-			var halfTheta = Math.atan2( sinHalfTheta, cosHalfTheta );
-			var ratioA = Math.sin( ( 1 - t ) * halfTheta ) / sinHalfTheta,
-				ratioB = Math.sin( t * halfTheta ) / sinHalfTheta;
-
-			this._w = ( w * ratioA + this._w * ratioB );
-			this._x = ( x * ratioA + this._x * ratioB );
-			this._y = ( y * ratioA + this._y * ratioB );
-			this._z = ( z * ratioA + this._z * ratioB );
-
-			this._onChangeCallback();
-
-			return this;
-
-		},
-
-		equals: function ( quaternion ) {
-
-			return ( quaternion._x === this._x ) && ( quaternion._y === this._y ) && ( quaternion._z === this._z ) && ( quaternion._w === this._w );
-
-		},
-
-		fromArray: function ( array, offset ) {
-
-			if ( offset === undefined ) offset = 0;
-
-			this._x = array[ offset ];
-			this._y = array[ offset + 1 ];
-			this._z = array[ offset + 2 ];
-			this._w = array[ offset + 3 ];
-
-			this._onChangeCallback();
-
-			return this;
-
-		},
-
-		toArray: function ( array, offset ) {
-
-			if ( array === undefined ) array = [];
-			if ( offset === undefined ) offset = 0;
-
-			array[ offset ] = this._x;
-			array[ offset + 1 ] = this._y;
-			array[ offset + 2 ] = this._z;
-			array[ offset + 3 ] = this._w;
-
-			return array;
-
-		},
-
-		_onChange: function ( callback ) {
-
-			this._onChangeCallback = callback;
-
-			return this;
-
-		},
-
-		_onChangeCallback: function () {}
-
-	} );
-
-	/**
-	 * @author mrdoob / http://mrdoob.com/
-	 * @author kile / http://kile.stravaganza.org/
-	 * @author philogb / http://blog.thejit.org/
-	 * @author mikael emtinger / http://gomo.se/
-	 * @author egraether / http://egraether.com/
-	 * @author WestLangley / http://github.com/WestLangley
-	 */
-
-	function Vector3( x, y, z ) {
-
-		this.x = x || 0;
-		this.y = y || 0;
-		this.z = z || 0;
-
-	}
-
-	Object.assign( Vector3.prototype, {
-
-		isVector3: true,
-
-		set: function ( x, y, z ) {
-
-			this.x = x;
-			this.y = y;
-			this.z = z;
-
-			return this;
-
-		},
-
-		setScalar: function ( scalar ) {
-
-			this.x = scalar;
-			this.y = scalar;
-			this.z = scalar;
-
-			return this;
-
-		},
-
-		setX: function ( x ) {
-
-			this.x = x;
-
-			return this;
-
-		},
-
-		setY: function ( y ) {
-
-			this.y = y;
-
-			return this;
-
-		},
-
-		setZ: function ( z ) {
-
-			this.z = z;
-
-			return this;
-
-		},
-
-		setComponent: function ( index, value ) {
-
-			switch ( index ) {
-
-				case 0: this.x = value; break;
-				case 1: this.y = value; break;
-				case 2: this.z = value; break;
-				default: throw new Error( 'index is out of range: ' + index );
-
-			}
-
-			return this;
-
-		},
-
-		getComponent: function ( index ) {
-
-			switch ( index ) {
-
-				case 0: return this.x;
-				case 1: return this.y;
-				case 2: return this.z;
-				default: throw new Error( 'index is out of range: ' + index );
-
-			}
-
-		},
-
-		clone: function () {
-
-			return new this.constructor( this.x, this.y, this.z );
-
-		},
-
-		copy: function ( v ) {
-
-			this.x = v.x;
-			this.y = v.y;
-			this.z = v.z;
-
-			return this;
-
-		},
-
-		add: function ( v, w ) {
-
-			if ( w !== undefined ) {
-
-				console.warn( 'THREE.Vector3: .add() now only accepts one argument. Use .addVectors( a, b ) instead.' );
-				return this.addVectors( v, w );
-
-			}
-
-			this.x += v.x;
-			this.y += v.y;
-			this.z += v.z;
-
-			return this;
-
-		},
-
-		addScalar: function ( s ) {
-
-			this.x += s;
-			this.y += s;
-			this.z += s;
-
-			return this;
-
-		},
-
-		addVectors: function ( a, b ) {
-
-			this.x = a.x + b.x;
-			this.y = a.y + b.y;
-			this.z = a.z + b.z;
-
-			return this;
-
-		},
-
-		addScaledVector: function ( v, s ) {
-
-			this.x += v.x * s;
-			this.y += v.y * s;
-			this.z += v.z * s;
-
-			return this;
-
-		},
-
-		sub: function ( v, w ) {
-
-			if ( w !== undefined ) {
-
-				console.warn( 'THREE.Vector3: .sub() now only accepts one argument. Use .subVectors( a, b ) instead.' );
-				return this.subVectors( v, w );
-
-			}
-
-			this.x -= v.x;
-			this.y -= v.y;
-			this.z -= v.z;
-
-			return this;
-
-		},
-
-		subScalar: function ( s ) {
-
-			this.x -= s;
-			this.y -= s;
-			this.z -= s;
-
-			return this;
-
-		},
-
-		subVectors: function ( a, b ) {
-
-			this.x = a.x - b.x;
-			this.y = a.y - b.y;
-			this.z = a.z - b.z;
-
-			return this;
-
-		},
-
-		multiply: function ( v, w ) {
-
-			if ( w !== undefined ) {
-
-				console.warn( 'THREE.Vector3: .multiply() now only accepts one argument. Use .multiplyVectors( a, b ) instead.' );
-				return this.multiplyVectors( v, w );
-
-			}
-
-			this.x *= v.x;
-			this.y *= v.y;
-			this.z *= v.z;
-
-			return this;
-
-		},
-
-		multiplyScalar: function ( scalar ) {
-
-			this.x *= scalar;
-			this.y *= scalar;
-			this.z *= scalar;
-
-			return this;
-
-		},
-
-		multiplyVectors: function ( a, b ) {
-
-			this.x = a.x * b.x;
-			this.y = a.y * b.y;
-			this.z = a.z * b.z;
-
-			return this;
-
-		},
-
-		applyEuler: function () {
-
-			var quaternion = new Quaternion();
-
-			return function applyEuler( euler ) {
-
-				if ( ! ( euler && euler.isEuler ) ) {
-
-					console.error( 'THREE.Vector3: .applyEuler() now expects an Euler rotation rather than a Vector3 and order.' );
-
-				}
-
-				return this.applyQuaternion( quaternion.setFromEuler( euler ) );
-
-			};
-
-		}(),
-
-		applyAxisAngle: function () {
-
-			var quaternion = new Quaternion();
-
-			return function applyAxisAngle( axis, angle ) {
-
-				return this.applyQuaternion( quaternion.setFromAxisAngle( axis, angle ) );
-
-			};
-
-		}(),
-
-		applyMatrix3: function ( m ) {
-
-			var x = this.x, y = this.y, z = this.z;
-			var e = m.elements;
-
-			this.x = e[ 0 ] * x + e[ 3 ] * y + e[ 6 ] * z;
-			this.y = e[ 1 ] * x + e[ 4 ] * y + e[ 7 ] * z;
-			this.z = e[ 2 ] * x + e[ 5 ] * y + e[ 8 ] * z;
-
-			return this;
-
-		},
-
-		applyMatrix4: function ( m ) {
-
-			var x = this.x, y = this.y, z = this.z;
-			var e = m.elements;
-
-			var w = 1 / ( e[ 3 ] * x + e[ 7 ] * y + e[ 11 ] * z + e[ 15 ] );
-
-			this.x = ( e[ 0 ] * x + e[ 4 ] * y + e[ 8 ] * z + e[ 12 ] ) * w;
-			this.y = ( e[ 1 ] * x + e[ 5 ] * y + e[ 9 ] * z + e[ 13 ] ) * w;
-			this.z = ( e[ 2 ] * x + e[ 6 ] * y + e[ 10 ] * z + e[ 14 ] ) * w;
-
-			return this;
-
-		},
-
-		applyQuaternion: function ( q ) {
-
-			var x = this.x, y = this.y, z = this.z;
-			var qx = q.x, qy = q.y, qz = q.z, qw = q.w;
-
-			// calculate quat * vector
-
-			var ix = qw * x + qy * z - qz * y;
-			var iy = qw * y + qz * x - qx * z;
-			var iz = qw * z + qx * y - qy * x;
-			var iw = - qx * x - qy * y - qz * z;
-
-			// calculate result * inverse quat
-
-			this.x = ix * qw + iw * - qx + iy * - qz - iz * - qy;
-			this.y = iy * qw + iw * - qy + iz * - qx - ix * - qz;
-			this.z = iz * qw + iw * - qz + ix * - qy - iy * - qx;
-
-			return this;
-
-		},
-
-		project: function ( camera ) {
-
-			return this.applyMatrix4( camera.matrixWorldInverse ).applyMatrix4( camera.projectionMatrix );
-
-		},
-
-		unproject: function ( camera ) {
-
-			return this.applyMatrix4( camera.projectionMatrixInverse ).applyMatrix4( camera.matrixWorld );
-
-		},
-
-		transformDirection: function ( m ) {
-
-			// input: THREE.Matrix4 affine matrix
-			// vector interpreted as a direction
-
-			var x = this.x, y = this.y, z = this.z;
-			var e = m.elements;
-
-			this.x = e[ 0 ] * x + e[ 4 ] * y + e[ 8 ] * z;
-			this.y = e[ 1 ] * x + e[ 5 ] * y + e[ 9 ] * z;
-			this.z = e[ 2 ] * x + e[ 6 ] * y + e[ 10 ] * z;
-
-			return this.normalize();
-
-		},
-
-		divide: function ( v ) {
-
-			this.x /= v.x;
-			this.y /= v.y;
-			this.z /= v.z;
-
-			return this;
-
-		},
-
-		divideScalar: function ( scalar ) {
-
-			return this.multiplyScalar( 1 / scalar );
-
-		},
-
-		min: function ( v ) {
-
-			this.x = Math.min( this.x, v.x );
-			this.y = Math.min( this.y, v.y );
-			this.z = Math.min( this.z, v.z );
-
-			return this;
-
-		},
-
-		max: function ( v ) {
-
-			this.x = Math.max( this.x, v.x );
-			this.y = Math.max( this.y, v.y );
-			this.z = Math.max( this.z, v.z );
-
-			return this;
-
-		},
-
-		clamp: function ( min, max ) {
-
-			// assumes min < max, componentwise
-
-			this.x = Math.max( min.x, Math.min( max.x, this.x ) );
-			this.y = Math.max( min.y, Math.min( max.y, this.y ) );
-			this.z = Math.max( min.z, Math.min( max.z, this.z ) );
-
-			return this;
-
-		},
-
-		clampScalar: function ( minVal, maxVal ) {
-
-			this.x = Math.max( minVal, Math.min( maxVal, this.x ) );
-			this.y = Math.max( minVal, Math.min( maxVal, this.y ) );
-			this.z = Math.max( minVal, Math.min( maxVal, this.z ) );
-
-			return this;
-
-		},
-
-		clampLength: function ( min, max ) {
-
-			var length = this.length();
-
-			return this.divideScalar( length || 1 ).multiplyScalar( Math.max( min, Math.min( max, length ) ) );
-
-		},
-
-		floor: function () {
-
-			this.x = Math.floor( this.x );
-			this.y = Math.floor( this.y );
-			this.z = Math.floor( this.z );
-
-			return this;
-
-		},
-
-		ceil: function () {
-
-			this.x = Math.ceil( this.x );
-			this.y = Math.ceil( this.y );
-			this.z = Math.ceil( this.z );
-
-			return this;
-
-		},
-
-		round: function () {
-
-			this.x = Math.round( this.x );
-			this.y = Math.round( this.y );
-			this.z = Math.round( this.z );
-
-			return this;
-
-		},
-
-		roundToZero: function () {
-
-			this.x = ( this.x < 0 ) ? Math.ceil( this.x ) : Math.floor( this.x );
-			this.y = ( this.y < 0 ) ? Math.ceil( this.y ) : Math.floor( this.y );
-			this.z = ( this.z < 0 ) ? Math.ceil( this.z ) : Math.floor( this.z );
-
-			return this;
-
-		},
-
-		negate: function () {
-
-			this.x = - this.x;
-			this.y = - this.y;
-			this.z = - this.z;
-
-			return this;
-
-		},
-
-		dot: function ( v ) {
-
-			return this.x * v.x + this.y * v.y + this.z * v.z;
-
-		},
-
-		// TODO lengthSquared?
-
-		lengthSq: function () {
-
-			return this.x * this.x + this.y * this.y + this.z * this.z;
-
-		},
-
-		length: function () {
-
-			return Math.sqrt( this.x * this.x + this.y * this.y + this.z * this.z );
-
-		},
-
-		manhattanLength: function () {
-
-			return Math.abs( this.x ) + Math.abs( this.y ) + Math.abs( this.z );
-
-		},
-
-		normalize: function () {
-
-			return this.divideScalar( this.length() || 1 );
-
-		},
-
-		setLength: function ( length ) {
-
-			return this.normalize().multiplyScalar( length );
-
-		},
-
-		lerp: function ( v, alpha ) {
-
-			this.x += ( v.x - this.x ) * alpha;
-			this.y += ( v.y - this.y ) * alpha;
-			this.z += ( v.z - this.z ) * alpha;
-
-			return this;
-
-		},
-
-		lerpVectors: function ( v1, v2, alpha ) {
-
-			return this.subVectors( v2, v1 ).multiplyScalar( alpha ).add( v1 );
-
-		},
-
-		cross: function ( v, w ) {
-
-			if ( w !== undefined ) {
-
-				console.warn( 'THREE.Vector3: .cross() now only accepts one argument. Use .crossVectors( a, b ) instead.' );
-				return this.crossVectors( v, w );
-
-			}
-
-			return this.crossVectors( this, v );
-
-		},
-
-		crossVectors: function ( a, b ) {
-
-			var ax = a.x, ay = a.y, az = a.z;
-			var bx = b.x, by = b.y, bz = b.z;
-
-			this.x = ay * bz - az * by;
-			this.y = az * bx - ax * bz;
-			this.z = ax * by - ay * bx;
-
-			return this;
-
-		},
-
-		projectOnVector: function ( vector ) {
-
-			var scalar = vector.dot( this ) / vector.lengthSq();
-
-			return this.copy( vector ).multiplyScalar( scalar );
-
-		},
-
-		projectOnPlane: function () {
-
-			var v1 = new Vector3();
-
-			return function projectOnPlane( planeNormal ) {
-
-				v1.copy( this ).projectOnVector( planeNormal );
-
-				return this.sub( v1 );
-
-			};
-
-		}(),
-
-		reflect: function () {
-
-			// reflect incident vector off plane orthogonal to normal
-			// normal is assumed to have unit length
-
-			var v1 = new Vector3();
-
-			return function reflect( normal ) {
-
-				return this.sub( v1.copy( normal ).multiplyScalar( 2 * this.dot( normal ) ) );
-
-			};
-
-		}(),
-
-		angleTo: function ( v ) {
-
-			var theta = this.dot( v ) / ( Math.sqrt( this.lengthSq() * v.lengthSq() ) );
-
-			// clamp, to handle numerical problems
-
-			return Math.acos( _Math.clamp( theta, - 1, 1 ) );
-
-		},
-
-		distanceTo: function ( v ) {
-
-			return Math.sqrt( this.distanceToSquared( v ) );
-
-		},
-
-		distanceToSquared: function ( v ) {
-
-			var dx = this.x - v.x, dy = this.y - v.y, dz = this.z - v.z;
-
-			return dx * dx + dy * dy + dz * dz;
-
-		},
-
-		manhattanDistanceTo: function ( v ) {
-
-			return Math.abs( this.x - v.x ) + Math.abs( this.y - v.y ) + Math.abs( this.z - v.z );
-
-		},
-
-		setFromSpherical: function ( s ) {
-
-			return this.setFromSphericalCoords( s.radius, s.phi, s.theta );
-
-		},
-
-		setFromSphericalCoords: function ( radius, phi, theta ) {
-
-			var sinPhiRadius = Math.sin( phi ) * radius;
-
-			this.x = sinPhiRadius * Math.sin( theta );
-			this.y = Math.cos( phi ) * radius;
-			this.z = sinPhiRadius * Math.cos( theta );
-
-			return this;
-
-		},
-
-		setFromCylindrical: function ( c ) {
-
-			return this.setFromCylindricalCoords( c.radius, c.theta, c.y );
-
-		},
-
-		setFromCylindricalCoords: function ( radius, theta, y ) {
-
-			this.x = radius * Math.sin( theta );
-			this.y = y;
-			this.z = radius * Math.cos( theta );
-
-			return this;
-
-		},
-
-		setFromMatrixPosition: function ( m ) {
-
-			var e = m.elements;
-
-			this.x = e[ 12 ];
-			this.y = e[ 13 ];
-			this.z = e[ 14 ];
-
-			return this;
-
-		},
-
-		setFromMatrixScale: function ( m ) {
-
-			var sx = this.setFromMatrixColumn( m, 0 ).length();
-			var sy = this.setFromMatrixColumn( m, 1 ).length();
-			var sz = this.setFromMatrixColumn( m, 2 ).length();
-
-			this.x = sx;
-			this.y = sy;
-			this.z = sz;
-
-			return this;
-
-		},
-
-		setFromMatrixColumn: function ( m, index ) {
-
-			return this.fromArray( m.elements, index * 4 );
-
-		},
-
-		equals: function ( v ) {
-
-			return ( ( v.x === this.x ) && ( v.y === this.y ) && ( v.z === this.z ) );
-
-		},
-
-		fromArray: function ( array, offset ) {
-
-			if ( offset === undefined ) offset = 0;
-
-			this.x = array[ offset ];
-			this.y = array[ offset + 1 ];
-			this.z = array[ offset + 2 ];
-
-			return this;
-
 		},
-
-		toArray: function ( array, offset ) {
-
-			if ( array === undefined ) array = [];
-			if ( offset === undefined ) offset = 0;
-
-			array[ offset ] = this.x;
-			array[ offset + 1 ] = this.y;
-			array[ offset + 2 ] = this.z;
-
-			return array;
-
-		},
-
-		fromBufferAttribute: function ( attribute, index, offset ) {
-
-			if ( offset !== undefined ) {
-
-				console.warn( 'THREE.Vector3: offset has been removed from .fromBufferAttribute().' );
 
-			}
+		random: function () {
 
-			this.x = attribute.getX( index );
-			this.y = attribute.getY( index );
-			this.z = attribute.getZ( index );
+			this.x = Math.random();
+			this.y = Math.random();
 
 			return this;
 
@@ -2345,8 +1088,6 @@ var Spacekit = (function (exports) {
 	 * @author bhouston / http://clara.io
 	 * @author tschw
 	 */
-
-	var _vector;
 
 	function Matrix3() {
 
@@ -2415,6 +1156,16 @@ var Spacekit = (function (exports) {
 
 		},
 
+		extractBasis: function ( xAxis, yAxis, zAxis ) {
+
+			xAxis.setFromMatrix3Column( this, 0 );
+			yAxis.setFromMatrix3Column( this, 1 );
+			zAxis.setFromMatrix3Column( this, 2 );
+
+			return this;
+
+		},
+
 		setFromMatrix4: function ( m ) {
 
 			var me = m.elements;
@@ -2428,26 +1179,6 @@ var Spacekit = (function (exports) {
 			);
 
 			return this;
-
-		},
-
-		applyToBufferAttribute: function ( attribute ) {
-
-			if ( _vector === undefined ) _vector = new Vector3();
-
-			for ( var i = 0, l = attribute.count; i < l; i ++ ) {
-
-				_vector.x = attribute.getX( i );
-				_vector.y = attribute.getY( i );
-				_vector.z = attribute.getZ( i );
-
-				_vector.applyMatrix3( this );
-
-				attribute.setXYZ( i, _vector.x, _vector.y, _vector.z );
-
-			}
-
-			return attribute;
 
 		},
 
@@ -2519,9 +1250,9 @@ var Spacekit = (function (exports) {
 
 		getInverse: function ( matrix, throwOnDegenerate ) {
 
-			if ( matrix && matrix.isMatrix4 ) {
+			if ( throwOnDegenerate !== undefined ) {
 
-				console.error( "THREE.Matrix3: .getInverse() no longer takes a Matrix4 argument." );
+				console.warn( "THREE.Matrix3: .getInverse() can no longer be configured to throw on degenerate." );
 
 			}
 
@@ -2538,23 +1269,7 @@ var Spacekit = (function (exports) {
 
 				det = n11 * t11 + n21 * t12 + n31 * t13;
 
-			if ( det === 0 ) {
-
-				var msg = "THREE.Matrix3: .getInverse() can't invert matrix, determinant is 0";
-
-				if ( throwOnDegenerate === true ) {
-
-					throw new Error( msg );
-
-				} else {
-
-					console.warn( msg );
-
-				}
-
-				return this.identity();
-
-			}
+			if ( det === 0 ) return this.set( 0, 0, 0, 0, 0, 0, 0, 0, 0 );
 
 			var detInv = 1 / det;
 
@@ -2792,7 +1507,7 @@ var Spacekit = (function (exports) {
 
 		Object.defineProperty( this, 'id', { value: textureId ++ } );
 
-		this.uuid = _Math.generateUUID();
+		this.uuid = MathUtils.generateUUID();
 
 		this.name = '';
 
@@ -2810,6 +1525,7 @@ var Spacekit = (function (exports) {
 		this.anisotropy = anisotropy !== undefined ? anisotropy : 1;
 
 		this.format = format !== undefined ? format : RGBAFormat;
+		this.internalFormat = null;
 		this.type = type !== undefined ? type : UnsignedByteType;
 
 		this.offset = new Vector2( 0, 0 );
@@ -2875,6 +1591,7 @@ var Spacekit = (function (exports) {
 			this.anisotropy = source.anisotropy;
 
 			this.format = source.format;
+			this.internalFormat = source.internalFormat;
 			this.type = source.type;
 
 			this.offset.copy( source.offset );
@@ -2948,7 +1665,7 @@ var Spacekit = (function (exports) {
 
 				if ( image.uuid === undefined ) {
 
-					image.uuid = _Math.generateUUID(); // UGH
+					image.uuid = MathUtils.generateUUID(); // UGH
 
 				}
 
@@ -3034,6 +1751,7 @@ var Spacekit = (function (exports) {
 							uv.x = uv.x - Math.floor( uv.x );
 
 						}
+
 						break;
 
 				}
@@ -3065,6 +1783,7 @@ var Spacekit = (function (exports) {
 							uv.y = uv.y - Math.floor( uv.y );
 
 						}
+
 						break;
 
 				}
@@ -3741,6 +2460,17 @@ var Spacekit = (function (exports) {
 
 			return this;
 
+		},
+
+		random: function () {
+
+			this.x = Math.random();
+			this.y = Math.random();
+			this.z = Math.random();
+			this.w = Math.random();
+
+			return this;
+
 		}
 
 	} );
@@ -3768,7 +2498,7 @@ var Spacekit = (function (exports) {
 
 		options = options || {};
 
-		this.texture = new Texture( undefined, undefined, options.wrapS, options.wrapT, options.magFilter, options.minFilter, options.format, options.type, options.anisotropy, options.encoding );
+		this.texture = new Texture( undefined, options.mapping, options.wrapS, options.wrapT, options.magFilter, options.minFilter, options.format, options.type, options.anisotropy, options.encoding );
 
 		this.texture.image = {};
 		this.texture.image.width = width;
@@ -3869,6 +2599,1408 @@ var Spacekit = (function (exports) {
 		}
 
 	} );
+
+	/**
+	 * @author mikael emtinger / http://gomo.se/
+	 * @author alteredq / http://alteredqualia.com/
+	 * @author WestLangley / http://github.com/WestLangley
+	 * @author bhouston / http://clara.io
+	 */
+
+	function Quaternion( x, y, z, w ) {
+
+		this._x = x || 0;
+		this._y = y || 0;
+		this._z = z || 0;
+		this._w = ( w !== undefined ) ? w : 1;
+
+	}
+
+	Object.assign( Quaternion, {
+
+		slerp: function ( qa, qb, qm, t ) {
+
+			return qm.copy( qa ).slerp( qb, t );
+
+		},
+
+		slerpFlat: function ( dst, dstOffset, src0, srcOffset0, src1, srcOffset1, t ) {
+
+			// fuzz-free, array-based Quaternion SLERP operation
+
+			var x0 = src0[ srcOffset0 + 0 ],
+				y0 = src0[ srcOffset0 + 1 ],
+				z0 = src0[ srcOffset0 + 2 ],
+				w0 = src0[ srcOffset0 + 3 ],
+
+				x1 = src1[ srcOffset1 + 0 ],
+				y1 = src1[ srcOffset1 + 1 ],
+				z1 = src1[ srcOffset1 + 2 ],
+				w1 = src1[ srcOffset1 + 3 ];
+
+			if ( w0 !== w1 || x0 !== x1 || y0 !== y1 || z0 !== z1 ) {
+
+				var s = 1 - t,
+
+					cos = x0 * x1 + y0 * y1 + z0 * z1 + w0 * w1,
+
+					dir = ( cos >= 0 ? 1 : - 1 ),
+					sqrSin = 1 - cos * cos;
+
+				// Skip the Slerp for tiny steps to avoid numeric problems:
+				if ( sqrSin > Number.EPSILON ) {
+
+					var sin = Math.sqrt( sqrSin ),
+						len = Math.atan2( sin, cos * dir );
+
+					s = Math.sin( s * len ) / sin;
+					t = Math.sin( t * len ) / sin;
+
+				}
+
+				var tDir = t * dir;
+
+				x0 = x0 * s + x1 * tDir;
+				y0 = y0 * s + y1 * tDir;
+				z0 = z0 * s + z1 * tDir;
+				w0 = w0 * s + w1 * tDir;
+
+				// Normalize in case we just did a lerp:
+				if ( s === 1 - t ) {
+
+					var f = 1 / Math.sqrt( x0 * x0 + y0 * y0 + z0 * z0 + w0 * w0 );
+
+					x0 *= f;
+					y0 *= f;
+					z0 *= f;
+					w0 *= f;
+
+				}
+
+			}
+
+			dst[ dstOffset ] = x0;
+			dst[ dstOffset + 1 ] = y0;
+			dst[ dstOffset + 2 ] = z0;
+			dst[ dstOffset + 3 ] = w0;
+
+		},
+
+		multiplyQuaternionsFlat: function ( dst, dstOffset, src0, srcOffset0, src1, srcOffset1 ) {
+
+			var x0 = src0[ srcOffset0 ];
+			var y0 = src0[ srcOffset0 + 1 ];
+			var z0 = src0[ srcOffset0 + 2 ];
+			var w0 = src0[ srcOffset0 + 3 ];
+
+			var x1 = src1[ srcOffset1 ];
+			var y1 = src1[ srcOffset1 + 1 ];
+			var z1 = src1[ srcOffset1 + 2 ];
+			var w1 = src1[ srcOffset1 + 3 ];
+
+			dst[ dstOffset ] = x0 * w1 + w0 * x1 + y0 * z1 - z0 * y1;
+			dst[ dstOffset + 1 ] = y0 * w1 + w0 * y1 + z0 * x1 - x0 * z1;
+			dst[ dstOffset + 2 ] = z0 * w1 + w0 * z1 + x0 * y1 - y0 * x1;
+			dst[ dstOffset + 3 ] = w0 * w1 - x0 * x1 - y0 * y1 - z0 * z1;
+
+			return dst;
+
+		}
+
+	} );
+
+	Object.defineProperties( Quaternion.prototype, {
+
+		x: {
+
+			get: function () {
+
+				return this._x;
+
+			},
+
+			set: function ( value ) {
+
+				this._x = value;
+				this._onChangeCallback();
+
+			}
+
+		},
+
+		y: {
+
+			get: function () {
+
+				return this._y;
+
+			},
+
+			set: function ( value ) {
+
+				this._y = value;
+				this._onChangeCallback();
+
+			}
+
+		},
+
+		z: {
+
+			get: function () {
+
+				return this._z;
+
+			},
+
+			set: function ( value ) {
+
+				this._z = value;
+				this._onChangeCallback();
+
+			}
+
+		},
+
+		w: {
+
+			get: function () {
+
+				return this._w;
+
+			},
+
+			set: function ( value ) {
+
+				this._w = value;
+				this._onChangeCallback();
+
+			}
+
+		}
+
+	} );
+
+	Object.assign( Quaternion.prototype, {
+
+		isQuaternion: true,
+
+		set: function ( x, y, z, w ) {
+
+			this._x = x;
+			this._y = y;
+			this._z = z;
+			this._w = w;
+
+			this._onChangeCallback();
+
+			return this;
+
+		},
+
+		clone: function () {
+
+			return new this.constructor( this._x, this._y, this._z, this._w );
+
+		},
+
+		copy: function ( quaternion ) {
+
+			this._x = quaternion.x;
+			this._y = quaternion.y;
+			this._z = quaternion.z;
+			this._w = quaternion.w;
+
+			this._onChangeCallback();
+
+			return this;
+
+		},
+
+		setFromEuler: function ( euler, update ) {
+
+			if ( ! ( euler && euler.isEuler ) ) {
+
+				throw new Error( 'THREE.Quaternion: .setFromEuler() now expects an Euler rotation rather than a Vector3 and order.' );
+
+			}
+
+			var x = euler._x, y = euler._y, z = euler._z, order = euler.order;
+
+			// http://www.mathworks.com/matlabcentral/fileexchange/
+			// 	20696-function-to-convert-between-dcm-euler-angles-quaternions-and-euler-vectors/
+			//	content/SpinCalc.m
+
+			var cos = Math.cos;
+			var sin = Math.sin;
+
+			var c1 = cos( x / 2 );
+			var c2 = cos( y / 2 );
+			var c3 = cos( z / 2 );
+
+			var s1 = sin( x / 2 );
+			var s2 = sin( y / 2 );
+			var s3 = sin( z / 2 );
+
+			switch ( order ) {
+
+				case 'XYZ':
+					this._x = s1 * c2 * c3 + c1 * s2 * s3;
+					this._y = c1 * s2 * c3 - s1 * c2 * s3;
+					this._z = c1 * c2 * s3 + s1 * s2 * c3;
+					this._w = c1 * c2 * c3 - s1 * s2 * s3;
+					break;
+
+				case 'YXZ':
+					this._x = s1 * c2 * c3 + c1 * s2 * s3;
+					this._y = c1 * s2 * c3 - s1 * c2 * s3;
+					this._z = c1 * c2 * s3 - s1 * s2 * c3;
+					this._w = c1 * c2 * c3 + s1 * s2 * s3;
+					break;
+
+				case 'ZXY':
+					this._x = s1 * c2 * c3 - c1 * s2 * s3;
+					this._y = c1 * s2 * c3 + s1 * c2 * s3;
+					this._z = c1 * c2 * s3 + s1 * s2 * c3;
+					this._w = c1 * c2 * c3 - s1 * s2 * s3;
+					break;
+
+				case 'ZYX':
+					this._x = s1 * c2 * c3 - c1 * s2 * s3;
+					this._y = c1 * s2 * c3 + s1 * c2 * s3;
+					this._z = c1 * c2 * s3 - s1 * s2 * c3;
+					this._w = c1 * c2 * c3 + s1 * s2 * s3;
+					break;
+
+				case 'YZX':
+					this._x = s1 * c2 * c3 + c1 * s2 * s3;
+					this._y = c1 * s2 * c3 + s1 * c2 * s3;
+					this._z = c1 * c2 * s3 - s1 * s2 * c3;
+					this._w = c1 * c2 * c3 - s1 * s2 * s3;
+					break;
+
+				case 'XZY':
+					this._x = s1 * c2 * c3 - c1 * s2 * s3;
+					this._y = c1 * s2 * c3 - s1 * c2 * s3;
+					this._z = c1 * c2 * s3 + s1 * s2 * c3;
+					this._w = c1 * c2 * c3 + s1 * s2 * s3;
+					break;
+
+				default:
+					console.warn( 'THREE.Quaternion: .setFromEuler() encountered an unknown order: ' + order );
+
+			}
+
+			if ( update !== false ) this._onChangeCallback();
+
+			return this;
+
+		},
+
+		setFromAxisAngle: function ( axis, angle ) {
+
+			// http://www.euclideanspace.com/maths/geometry/rotations/conversions/angleToQuaternion/index.htm
+
+			// assumes axis is normalized
+
+			var halfAngle = angle / 2, s = Math.sin( halfAngle );
+
+			this._x = axis.x * s;
+			this._y = axis.y * s;
+			this._z = axis.z * s;
+			this._w = Math.cos( halfAngle );
+
+			this._onChangeCallback();
+
+			return this;
+
+		},
+
+		setFromRotationMatrix: function ( m ) {
+
+			// http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/index.htm
+
+			// assumes the upper 3x3 of m is a pure rotation matrix (i.e, unscaled)
+
+			var te = m.elements,
+
+				m11 = te[ 0 ], m12 = te[ 4 ], m13 = te[ 8 ],
+				m21 = te[ 1 ], m22 = te[ 5 ], m23 = te[ 9 ],
+				m31 = te[ 2 ], m32 = te[ 6 ], m33 = te[ 10 ],
+
+				trace = m11 + m22 + m33,
+				s;
+
+			if ( trace > 0 ) {
+
+				s = 0.5 / Math.sqrt( trace + 1.0 );
+
+				this._w = 0.25 / s;
+				this._x = ( m32 - m23 ) * s;
+				this._y = ( m13 - m31 ) * s;
+				this._z = ( m21 - m12 ) * s;
+
+			} else if ( m11 > m22 && m11 > m33 ) {
+
+				s = 2.0 * Math.sqrt( 1.0 + m11 - m22 - m33 );
+
+				this._w = ( m32 - m23 ) / s;
+				this._x = 0.25 * s;
+				this._y = ( m12 + m21 ) / s;
+				this._z = ( m13 + m31 ) / s;
+
+			} else if ( m22 > m33 ) {
+
+				s = 2.0 * Math.sqrt( 1.0 + m22 - m11 - m33 );
+
+				this._w = ( m13 - m31 ) / s;
+				this._x = ( m12 + m21 ) / s;
+				this._y = 0.25 * s;
+				this._z = ( m23 + m32 ) / s;
+
+			} else {
+
+				s = 2.0 * Math.sqrt( 1.0 + m33 - m11 - m22 );
+
+				this._w = ( m21 - m12 ) / s;
+				this._x = ( m13 + m31 ) / s;
+				this._y = ( m23 + m32 ) / s;
+				this._z = 0.25 * s;
+
+			}
+
+			this._onChangeCallback();
+
+			return this;
+
+		},
+
+		setFromUnitVectors: function ( vFrom, vTo ) {
+
+			// assumes direction vectors vFrom and vTo are normalized
+
+			var EPS = 0.000001;
+
+			var r = vFrom.dot( vTo ) + 1;
+
+			if ( r < EPS ) {
+
+				r = 0;
+
+				if ( Math.abs( vFrom.x ) > Math.abs( vFrom.z ) ) {
+
+					this._x = - vFrom.y;
+					this._y = vFrom.x;
+					this._z = 0;
+					this._w = r;
+
+				} else {
+
+					this._x = 0;
+					this._y = - vFrom.z;
+					this._z = vFrom.y;
+					this._w = r;
+
+				}
+
+			} else {
+
+				// crossVectors( vFrom, vTo ); // inlined to avoid cyclic dependency on Vector3
+
+				this._x = vFrom.y * vTo.z - vFrom.z * vTo.y;
+				this._y = vFrom.z * vTo.x - vFrom.x * vTo.z;
+				this._z = vFrom.x * vTo.y - vFrom.y * vTo.x;
+				this._w = r;
+
+			}
+
+			return this.normalize();
+
+		},
+
+		angleTo: function ( q ) {
+
+			return 2 * Math.acos( Math.abs( MathUtils.clamp( this.dot( q ), - 1, 1 ) ) );
+
+		},
+
+		rotateTowards: function ( q, step ) {
+
+			var angle = this.angleTo( q );
+
+			if ( angle === 0 ) return this;
+
+			var t = Math.min( 1, step / angle );
+
+			this.slerp( q, t );
+
+			return this;
+
+		},
+
+		inverse: function () {
+
+			// quaternion is assumed to have unit length
+
+			return this.conjugate();
+
+		},
+
+		conjugate: function () {
+
+			this._x *= - 1;
+			this._y *= - 1;
+			this._z *= - 1;
+
+			this._onChangeCallback();
+
+			return this;
+
+		},
+
+		dot: function ( v ) {
+
+			return this._x * v._x + this._y * v._y + this._z * v._z + this._w * v._w;
+
+		},
+
+		lengthSq: function () {
+
+			return this._x * this._x + this._y * this._y + this._z * this._z + this._w * this._w;
+
+		},
+
+		length: function () {
+
+			return Math.sqrt( this._x * this._x + this._y * this._y + this._z * this._z + this._w * this._w );
+
+		},
+
+		normalize: function () {
+
+			var l = this.length();
+
+			if ( l === 0 ) {
+
+				this._x = 0;
+				this._y = 0;
+				this._z = 0;
+				this._w = 1;
+
+			} else {
+
+				l = 1 / l;
+
+				this._x = this._x * l;
+				this._y = this._y * l;
+				this._z = this._z * l;
+				this._w = this._w * l;
+
+			}
+
+			this._onChangeCallback();
+
+			return this;
+
+		},
+
+		multiply: function ( q, p ) {
+
+			if ( p !== undefined ) {
+
+				console.warn( 'THREE.Quaternion: .multiply() now only accepts one argument. Use .multiplyQuaternions( a, b ) instead.' );
+				return this.multiplyQuaternions( q, p );
+
+			}
+
+			return this.multiplyQuaternions( this, q );
+
+		},
+
+		premultiply: function ( q ) {
+
+			return this.multiplyQuaternions( q, this );
+
+		},
+
+		multiplyQuaternions: function ( a, b ) {
+
+			// from http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/code/index.htm
+
+			var qax = a._x, qay = a._y, qaz = a._z, qaw = a._w;
+			var qbx = b._x, qby = b._y, qbz = b._z, qbw = b._w;
+
+			this._x = qax * qbw + qaw * qbx + qay * qbz - qaz * qby;
+			this._y = qay * qbw + qaw * qby + qaz * qbx - qax * qbz;
+			this._z = qaz * qbw + qaw * qbz + qax * qby - qay * qbx;
+			this._w = qaw * qbw - qax * qbx - qay * qby - qaz * qbz;
+
+			this._onChangeCallback();
+
+			return this;
+
+		},
+
+		slerp: function ( qb, t ) {
+
+			if ( t === 0 ) return this;
+			if ( t === 1 ) return this.copy( qb );
+
+			var x = this._x, y = this._y, z = this._z, w = this._w;
+
+			// http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/slerp/
+
+			var cosHalfTheta = w * qb._w + x * qb._x + y * qb._y + z * qb._z;
+
+			if ( cosHalfTheta < 0 ) {
+
+				this._w = - qb._w;
+				this._x = - qb._x;
+				this._y = - qb._y;
+				this._z = - qb._z;
+
+				cosHalfTheta = - cosHalfTheta;
+
+			} else {
+
+				this.copy( qb );
+
+			}
+
+			if ( cosHalfTheta >= 1.0 ) {
+
+				this._w = w;
+				this._x = x;
+				this._y = y;
+				this._z = z;
+
+				return this;
+
+			}
+
+			var sqrSinHalfTheta = 1.0 - cosHalfTheta * cosHalfTheta;
+
+			if ( sqrSinHalfTheta <= Number.EPSILON ) {
+
+				var s = 1 - t;
+				this._w = s * w + t * this._w;
+				this._x = s * x + t * this._x;
+				this._y = s * y + t * this._y;
+				this._z = s * z + t * this._z;
+
+				this.normalize();
+				this._onChangeCallback();
+
+				return this;
+
+			}
+
+			var sinHalfTheta = Math.sqrt( sqrSinHalfTheta );
+			var halfTheta = Math.atan2( sinHalfTheta, cosHalfTheta );
+			var ratioA = Math.sin( ( 1 - t ) * halfTheta ) / sinHalfTheta,
+				ratioB = Math.sin( t * halfTheta ) / sinHalfTheta;
+
+			this._w = ( w * ratioA + this._w * ratioB );
+			this._x = ( x * ratioA + this._x * ratioB );
+			this._y = ( y * ratioA + this._y * ratioB );
+			this._z = ( z * ratioA + this._z * ratioB );
+
+			this._onChangeCallback();
+
+			return this;
+
+		},
+
+		equals: function ( quaternion ) {
+
+			return ( quaternion._x === this._x ) && ( quaternion._y === this._y ) && ( quaternion._z === this._z ) && ( quaternion._w === this._w );
+
+		},
+
+		fromArray: function ( array, offset ) {
+
+			if ( offset === undefined ) offset = 0;
+
+			this._x = array[ offset ];
+			this._y = array[ offset + 1 ];
+			this._z = array[ offset + 2 ];
+			this._w = array[ offset + 3 ];
+
+			this._onChangeCallback();
+
+			return this;
+
+		},
+
+		toArray: function ( array, offset ) {
+
+			if ( array === undefined ) array = [];
+			if ( offset === undefined ) offset = 0;
+
+			array[ offset ] = this._x;
+			array[ offset + 1 ] = this._y;
+			array[ offset + 2 ] = this._z;
+			array[ offset + 3 ] = this._w;
+
+			return array;
+
+		},
+
+		fromBufferAttribute: function ( attribute, index ) {
+
+			this._x = attribute.getX( index );
+			this._y = attribute.getY( index );
+			this._z = attribute.getZ( index );
+			this._w = attribute.getW( index );
+
+			return this;
+
+		},
+
+		_onChange: function ( callback ) {
+
+			this._onChangeCallback = callback;
+
+			return this;
+
+		},
+
+		_onChangeCallback: function () {}
+
+	} );
+
+	/**
+	 * @author mrdoob / http://mrdoob.com/
+	 * @author kile / http://kile.stravaganza.org/
+	 * @author philogb / http://blog.thejit.org/
+	 * @author mikael emtinger / http://gomo.se/
+	 * @author egraether / http://egraether.com/
+	 * @author WestLangley / http://github.com/WestLangley
+	 */
+
+	var _vector = new Vector3();
+	var _quaternion = new Quaternion();
+
+	function Vector3( x, y, z ) {
+
+		this.x = x || 0;
+		this.y = y || 0;
+		this.z = z || 0;
+
+	}
+
+	Object.assign( Vector3.prototype, {
+
+		isVector3: true,
+
+		set: function ( x, y, z ) {
+
+			this.x = x;
+			this.y = y;
+			this.z = z;
+
+			return this;
+
+		},
+
+		setScalar: function ( scalar ) {
+
+			this.x = scalar;
+			this.y = scalar;
+			this.z = scalar;
+
+			return this;
+
+		},
+
+		setX: function ( x ) {
+
+			this.x = x;
+
+			return this;
+
+		},
+
+		setY: function ( y ) {
+
+			this.y = y;
+
+			return this;
+
+		},
+
+		setZ: function ( z ) {
+
+			this.z = z;
+
+			return this;
+
+		},
+
+		setComponent: function ( index, value ) {
+
+			switch ( index ) {
+
+				case 0: this.x = value; break;
+				case 1: this.y = value; break;
+				case 2: this.z = value; break;
+				default: throw new Error( 'index is out of range: ' + index );
+
+			}
+
+			return this;
+
+		},
+
+		getComponent: function ( index ) {
+
+			switch ( index ) {
+
+				case 0: return this.x;
+				case 1: return this.y;
+				case 2: return this.z;
+				default: throw new Error( 'index is out of range: ' + index );
+
+			}
+
+		},
+
+		clone: function () {
+
+			return new this.constructor( this.x, this.y, this.z );
+
+		},
+
+		copy: function ( v ) {
+
+			this.x = v.x;
+			this.y = v.y;
+			this.z = v.z;
+
+			return this;
+
+		},
+
+		add: function ( v, w ) {
+
+			if ( w !== undefined ) {
+
+				console.warn( 'THREE.Vector3: .add() now only accepts one argument. Use .addVectors( a, b ) instead.' );
+				return this.addVectors( v, w );
+
+			}
+
+			this.x += v.x;
+			this.y += v.y;
+			this.z += v.z;
+
+			return this;
+
+		},
+
+		addScalar: function ( s ) {
+
+			this.x += s;
+			this.y += s;
+			this.z += s;
+
+			return this;
+
+		},
+
+		addVectors: function ( a, b ) {
+
+			this.x = a.x + b.x;
+			this.y = a.y + b.y;
+			this.z = a.z + b.z;
+
+			return this;
+
+		},
+
+		addScaledVector: function ( v, s ) {
+
+			this.x += v.x * s;
+			this.y += v.y * s;
+			this.z += v.z * s;
+
+			return this;
+
+		},
+
+		sub: function ( v, w ) {
+
+			if ( w !== undefined ) {
+
+				console.warn( 'THREE.Vector3: .sub() now only accepts one argument. Use .subVectors( a, b ) instead.' );
+				return this.subVectors( v, w );
+
+			}
+
+			this.x -= v.x;
+			this.y -= v.y;
+			this.z -= v.z;
+
+			return this;
+
+		},
+
+		subScalar: function ( s ) {
+
+			this.x -= s;
+			this.y -= s;
+			this.z -= s;
+
+			return this;
+
+		},
+
+		subVectors: function ( a, b ) {
+
+			this.x = a.x - b.x;
+			this.y = a.y - b.y;
+			this.z = a.z - b.z;
+
+			return this;
+
+		},
+
+		multiply: function ( v, w ) {
+
+			if ( w !== undefined ) {
+
+				console.warn( 'THREE.Vector3: .multiply() now only accepts one argument. Use .multiplyVectors( a, b ) instead.' );
+				return this.multiplyVectors( v, w );
+
+			}
+
+			this.x *= v.x;
+			this.y *= v.y;
+			this.z *= v.z;
+
+			return this;
+
+		},
+
+		multiplyScalar: function ( scalar ) {
+
+			this.x *= scalar;
+			this.y *= scalar;
+			this.z *= scalar;
+
+			return this;
+
+		},
+
+		multiplyVectors: function ( a, b ) {
+
+			this.x = a.x * b.x;
+			this.y = a.y * b.y;
+			this.z = a.z * b.z;
+
+			return this;
+
+		},
+
+		applyEuler: function ( euler ) {
+
+			if ( ! ( euler && euler.isEuler ) ) {
+
+				console.error( 'THREE.Vector3: .applyEuler() now expects an Euler rotation rather than a Vector3 and order.' );
+
+			}
+
+			return this.applyQuaternion( _quaternion.setFromEuler( euler ) );
+
+		},
+
+		applyAxisAngle: function ( axis, angle ) {
+
+			return this.applyQuaternion( _quaternion.setFromAxisAngle( axis, angle ) );
+
+		},
+
+		applyMatrix3: function ( m ) {
+
+			var x = this.x, y = this.y, z = this.z;
+			var e = m.elements;
+
+			this.x = e[ 0 ] * x + e[ 3 ] * y + e[ 6 ] * z;
+			this.y = e[ 1 ] * x + e[ 4 ] * y + e[ 7 ] * z;
+			this.z = e[ 2 ] * x + e[ 5 ] * y + e[ 8 ] * z;
+
+			return this;
+
+		},
+
+		applyNormalMatrix: function ( m ) {
+
+			return this.applyMatrix3( m ).normalize();
+
+		},
+
+		applyMatrix4: function ( m ) {
+
+			var x = this.x, y = this.y, z = this.z;
+			var e = m.elements;
+
+			var w = 1 / ( e[ 3 ] * x + e[ 7 ] * y + e[ 11 ] * z + e[ 15 ] );
+
+			this.x = ( e[ 0 ] * x + e[ 4 ] * y + e[ 8 ] * z + e[ 12 ] ) * w;
+			this.y = ( e[ 1 ] * x + e[ 5 ] * y + e[ 9 ] * z + e[ 13 ] ) * w;
+			this.z = ( e[ 2 ] * x + e[ 6 ] * y + e[ 10 ] * z + e[ 14 ] ) * w;
+
+			return this;
+
+		},
+
+		applyQuaternion: function ( q ) {
+
+			var x = this.x, y = this.y, z = this.z;
+			var qx = q.x, qy = q.y, qz = q.z, qw = q.w;
+
+			// calculate quat * vector
+
+			var ix = qw * x + qy * z - qz * y;
+			var iy = qw * y + qz * x - qx * z;
+			var iz = qw * z + qx * y - qy * x;
+			var iw = - qx * x - qy * y - qz * z;
+
+			// calculate result * inverse quat
+
+			this.x = ix * qw + iw * - qx + iy * - qz - iz * - qy;
+			this.y = iy * qw + iw * - qy + iz * - qx - ix * - qz;
+			this.z = iz * qw + iw * - qz + ix * - qy - iy * - qx;
+
+			return this;
+
+		},
+
+		project: function ( camera ) {
+
+			return this.applyMatrix4( camera.matrixWorldInverse ).applyMatrix4( camera.projectionMatrix );
+
+		},
+
+		unproject: function ( camera ) {
+
+			return this.applyMatrix4( camera.projectionMatrixInverse ).applyMatrix4( camera.matrixWorld );
+
+		},
+
+		transformDirection: function ( m ) {
+
+			// input: THREE.Matrix4 affine matrix
+			// vector interpreted as a direction
+
+			var x = this.x, y = this.y, z = this.z;
+			var e = m.elements;
+
+			this.x = e[ 0 ] * x + e[ 4 ] * y + e[ 8 ] * z;
+			this.y = e[ 1 ] * x + e[ 5 ] * y + e[ 9 ] * z;
+			this.z = e[ 2 ] * x + e[ 6 ] * y + e[ 10 ] * z;
+
+			return this.normalize();
+
+		},
+
+		divide: function ( v ) {
+
+			this.x /= v.x;
+			this.y /= v.y;
+			this.z /= v.z;
+
+			return this;
+
+		},
+
+		divideScalar: function ( scalar ) {
+
+			return this.multiplyScalar( 1 / scalar );
+
+		},
+
+		min: function ( v ) {
+
+			this.x = Math.min( this.x, v.x );
+			this.y = Math.min( this.y, v.y );
+			this.z = Math.min( this.z, v.z );
+
+			return this;
+
+		},
+
+		max: function ( v ) {
+
+			this.x = Math.max( this.x, v.x );
+			this.y = Math.max( this.y, v.y );
+			this.z = Math.max( this.z, v.z );
+
+			return this;
+
+		},
+
+		clamp: function ( min, max ) {
+
+			// assumes min < max, componentwise
+
+			this.x = Math.max( min.x, Math.min( max.x, this.x ) );
+			this.y = Math.max( min.y, Math.min( max.y, this.y ) );
+			this.z = Math.max( min.z, Math.min( max.z, this.z ) );
+
+			return this;
+
+		},
+
+		clampScalar: function ( minVal, maxVal ) {
+
+			this.x = Math.max( minVal, Math.min( maxVal, this.x ) );
+			this.y = Math.max( minVal, Math.min( maxVal, this.y ) );
+			this.z = Math.max( minVal, Math.min( maxVal, this.z ) );
+
+			return this;
+
+		},
+
+		clampLength: function ( min, max ) {
+
+			var length = this.length();
+
+			return this.divideScalar( length || 1 ).multiplyScalar( Math.max( min, Math.min( max, length ) ) );
+
+		},
+
+		floor: function () {
+
+			this.x = Math.floor( this.x );
+			this.y = Math.floor( this.y );
+			this.z = Math.floor( this.z );
+
+			return this;
+
+		},
+
+		ceil: function () {
+
+			this.x = Math.ceil( this.x );
+			this.y = Math.ceil( this.y );
+			this.z = Math.ceil( this.z );
+
+			return this;
+
+		},
+
+		round: function () {
+
+			this.x = Math.round( this.x );
+			this.y = Math.round( this.y );
+			this.z = Math.round( this.z );
+
+			return this;
+
+		},
+
+		roundToZero: function () {
+
+			this.x = ( this.x < 0 ) ? Math.ceil( this.x ) : Math.floor( this.x );
+			this.y = ( this.y < 0 ) ? Math.ceil( this.y ) : Math.floor( this.y );
+			this.z = ( this.z < 0 ) ? Math.ceil( this.z ) : Math.floor( this.z );
+
+			return this;
+
+		},
+
+		negate: function () {
+
+			this.x = - this.x;
+			this.y = - this.y;
+			this.z = - this.z;
+
+			return this;
+
+		},
+
+		dot: function ( v ) {
+
+			return this.x * v.x + this.y * v.y + this.z * v.z;
+
+		},
+
+		// TODO lengthSquared?
+
+		lengthSq: function () {
+
+			return this.x * this.x + this.y * this.y + this.z * this.z;
+
+		},
+
+		length: function () {
+
+			return Math.sqrt( this.x * this.x + this.y * this.y + this.z * this.z );
+
+		},
+
+		manhattanLength: function () {
+
+			return Math.abs( this.x ) + Math.abs( this.y ) + Math.abs( this.z );
+
+		},
+
+		normalize: function () {
+
+			return this.divideScalar( this.length() || 1 );
+
+		},
+
+		setLength: function ( length ) {
+
+			return this.normalize().multiplyScalar( length );
+
+		},
+
+		lerp: function ( v, alpha ) {
+
+			this.x += ( v.x - this.x ) * alpha;
+			this.y += ( v.y - this.y ) * alpha;
+			this.z += ( v.z - this.z ) * alpha;
+
+			return this;
+
+		},
+
+		lerpVectors: function ( v1, v2, alpha ) {
+
+			return this.subVectors( v2, v1 ).multiplyScalar( alpha ).add( v1 );
+
+		},
+
+		cross: function ( v, w ) {
+
+			if ( w !== undefined ) {
+
+				console.warn( 'THREE.Vector3: .cross() now only accepts one argument. Use .crossVectors( a, b ) instead.' );
+				return this.crossVectors( v, w );
+
+			}
+
+			return this.crossVectors( this, v );
+
+		},
+
+		crossVectors: function ( a, b ) {
+
+			var ax = a.x, ay = a.y, az = a.z;
+			var bx = b.x, by = b.y, bz = b.z;
+
+			this.x = ay * bz - az * by;
+			this.y = az * bx - ax * bz;
+			this.z = ax * by - ay * bx;
+
+			return this;
+
+		},
+
+		projectOnVector: function ( v ) {
+
+			var denominator = v.lengthSq();
+
+			if ( denominator === 0 ) return this.set( 0, 0, 0 );
+
+			var scalar = v.dot( this ) / denominator;
+
+			return this.copy( v ).multiplyScalar( scalar );
+
+		},
+
+		projectOnPlane: function ( planeNormal ) {
+
+			_vector.copy( this ).projectOnVector( planeNormal );
+
+			return this.sub( _vector );
+
+		},
+
+		reflect: function ( normal ) {
+
+			// reflect incident vector off plane orthogonal to normal
+			// normal is assumed to have unit length
+
+			return this.sub( _vector.copy( normal ).multiplyScalar( 2 * this.dot( normal ) ) );
+
+		},
+
+		angleTo: function ( v ) {
+
+			var denominator = Math.sqrt( this.lengthSq() * v.lengthSq() );
+
+			if ( denominator === 0 ) return Math.PI / 2;
+
+			var theta = this.dot( v ) / denominator;
+
+			// clamp, to handle numerical problems
+
+			return Math.acos( MathUtils.clamp( theta, - 1, 1 ) );
+
+		},
+
+		distanceTo: function ( v ) {
+
+			return Math.sqrt( this.distanceToSquared( v ) );
+
+		},
+
+		distanceToSquared: function ( v ) {
+
+			var dx = this.x - v.x, dy = this.y - v.y, dz = this.z - v.z;
+
+			return dx * dx + dy * dy + dz * dz;
+
+		},
+
+		manhattanDistanceTo: function ( v ) {
+
+			return Math.abs( this.x - v.x ) + Math.abs( this.y - v.y ) + Math.abs( this.z - v.z );
+
+		},
+
+		setFromSpherical: function ( s ) {
+
+			return this.setFromSphericalCoords( s.radius, s.phi, s.theta );
+
+		},
+
+		setFromSphericalCoords: function ( radius, phi, theta ) {
+
+			var sinPhiRadius = Math.sin( phi ) * radius;
+
+			this.x = sinPhiRadius * Math.sin( theta );
+			this.y = Math.cos( phi ) * radius;
+			this.z = sinPhiRadius * Math.cos( theta );
+
+			return this;
+
+		},
+
+		setFromCylindrical: function ( c ) {
+
+			return this.setFromCylindricalCoords( c.radius, c.theta, c.y );
+
+		},
+
+		setFromCylindricalCoords: function ( radius, theta, y ) {
+
+			this.x = radius * Math.sin( theta );
+			this.y = y;
+			this.z = radius * Math.cos( theta );
+
+			return this;
+
+		},
+
+		setFromMatrixPosition: function ( m ) {
+
+			var e = m.elements;
+
+			this.x = e[ 12 ];
+			this.y = e[ 13 ];
+			this.z = e[ 14 ];
+
+			return this;
+
+		},
+
+		setFromMatrixScale: function ( m ) {
+
+			var sx = this.setFromMatrixColumn( m, 0 ).length();
+			var sy = this.setFromMatrixColumn( m, 1 ).length();
+			var sz = this.setFromMatrixColumn( m, 2 ).length();
+
+			this.x = sx;
+			this.y = sy;
+			this.z = sz;
+
+			return this;
+
+		},
+
+		setFromMatrixColumn: function ( m, index ) {
+
+			return this.fromArray( m.elements, index * 4 );
+
+		},
+
+		setFromMatrix3Column: function ( m, index ) {
+
+			return this.fromArray( m.elements, index * 3 );
+
+		},
+
+		equals: function ( v ) {
+
+			return ( ( v.x === this.x ) && ( v.y === this.y ) && ( v.z === this.z ) );
+
+		},
+
+		fromArray: function ( array, offset ) {
+
+			if ( offset === undefined ) offset = 0;
+
+			this.x = array[ offset ];
+			this.y = array[ offset + 1 ];
+			this.z = array[ offset + 2 ];
+
+			return this;
+
+		},
+
+		toArray: function ( array, offset ) {
+
+			if ( array === undefined ) array = [];
+			if ( offset === undefined ) offset = 0;
+
+			array[ offset ] = this.x;
+			array[ offset + 1 ] = this.y;
+			array[ offset + 2 ] = this.z;
+
+			return array;
+
+		},
+
+		fromBufferAttribute: function ( attribute, index, offset ) {
+
+			if ( offset !== undefined ) {
+
+				console.warn( 'THREE.Vector3: offset has been removed from .fromBufferAttribute().' );
+
+			}
+
+			this.x = attribute.getX( index );
+			this.y = attribute.getY( index );
+			this.z = attribute.getZ( index );
+
+			return this;
+
+		},
+
+		random: function () {
+
+			this.x = Math.random();
+			this.y = Math.random();
+			this.z = Math.random();
+
+			return this;
+
+		}
+
+	} );
+
+	var _v1 = new Vector3();
+	var _m1 = new Matrix4();
+	var _zero = new Vector3( 0, 0, 0 );
+	var _one = new Vector3( 1, 1, 1 );
+	var _x = new Vector3();
+	var _y = new Vector3();
+	var _z = new Vector3();
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -3989,46 +4121,40 @@ var Spacekit = (function (exports) {
 
 		},
 
-		extractRotation: function () {
+		extractRotation: function ( m ) {
 
-			var v1 = new Vector3();
+			// this method does not support reflection matrices
 
-			return function extractRotation( m ) {
+			var te = this.elements;
+			var me = m.elements;
 
-				// this method does not support reflection matrices
+			var scaleX = 1 / _v1.setFromMatrixColumn( m, 0 ).length();
+			var scaleY = 1 / _v1.setFromMatrixColumn( m, 1 ).length();
+			var scaleZ = 1 / _v1.setFromMatrixColumn( m, 2 ).length();
 
-				var te = this.elements;
-				var me = m.elements;
+			te[ 0 ] = me[ 0 ] * scaleX;
+			te[ 1 ] = me[ 1 ] * scaleX;
+			te[ 2 ] = me[ 2 ] * scaleX;
+			te[ 3 ] = 0;
 
-				var scaleX = 1 / v1.setFromMatrixColumn( m, 0 ).length();
-				var scaleY = 1 / v1.setFromMatrixColumn( m, 1 ).length();
-				var scaleZ = 1 / v1.setFromMatrixColumn( m, 2 ).length();
+			te[ 4 ] = me[ 4 ] * scaleY;
+			te[ 5 ] = me[ 5 ] * scaleY;
+			te[ 6 ] = me[ 6 ] * scaleY;
+			te[ 7 ] = 0;
 
-				te[ 0 ] = me[ 0 ] * scaleX;
-				te[ 1 ] = me[ 1 ] * scaleX;
-				te[ 2 ] = me[ 2 ] * scaleX;
-				te[ 3 ] = 0;
+			te[ 8 ] = me[ 8 ] * scaleZ;
+			te[ 9 ] = me[ 9 ] * scaleZ;
+			te[ 10 ] = me[ 10 ] * scaleZ;
+			te[ 11 ] = 0;
 
-				te[ 4 ] = me[ 4 ] * scaleY;
-				te[ 5 ] = me[ 5 ] * scaleY;
-				te[ 6 ] = me[ 6 ] * scaleY;
-				te[ 7 ] = 0;
+			te[ 12 ] = 0;
+			te[ 13 ] = 0;
+			te[ 14 ] = 0;
+			te[ 15 ] = 1;
 
-				te[ 8 ] = me[ 8 ] * scaleZ;
-				te[ 9 ] = me[ 9 ] * scaleZ;
-				te[ 10 ] = me[ 10 ] * scaleZ;
-				te[ 11 ] = 0;
+			return this;
 
-				te[ 12 ] = 0;
-				te[ 13 ] = 0;
-				te[ 14 ] = 0;
-				te[ 15 ] = 1;
-
-				return this;
-
-			};
-
-		}(),
+		},
 
 		makeRotationFromEuler: function ( euler ) {
 
@@ -4158,73 +4284,58 @@ var Spacekit = (function (exports) {
 
 		},
 
-		makeRotationFromQuaternion: function () {
+		makeRotationFromQuaternion: function ( q ) {
 
-			var zero = new Vector3( 0, 0, 0 );
-			var one = new Vector3( 1, 1, 1 );
+			return this.compose( _zero, q, _one );
 
-			return function makeRotationFromQuaternion( q ) {
+		},
 
-				return this.compose( zero, q, one );
+		lookAt: function ( eye, target, up ) {
 
-			};
+			var te = this.elements;
 
-		}(),
+			_z.subVectors( eye, target );
 
-		lookAt: function () {
+			if ( _z.lengthSq() === 0 ) {
 
-			var x = new Vector3();
-			var y = new Vector3();
-			var z = new Vector3();
+				// eye and target are in the same position
 
-			return function lookAt( eye, target, up ) {
+				_z.z = 1;
 
-				var te = this.elements;
+			}
 
-				z.subVectors( eye, target );
+			_z.normalize();
+			_x.crossVectors( up, _z );
 
-				if ( z.lengthSq() === 0 ) {
+			if ( _x.lengthSq() === 0 ) {
 
-					// eye and target are in the same position
+				// up and z are parallel
 
-					z.z = 1;
+				if ( Math.abs( up.z ) === 1 ) {
 
-				}
+					_z.x += 0.0001;
 
-				z.normalize();
-				x.crossVectors( up, z );
+				} else {
 
-				if ( x.lengthSq() === 0 ) {
-
-					// up and z are parallel
-
-					if ( Math.abs( up.z ) === 1 ) {
-
-						z.x += 0.0001;
-
-					} else {
-
-						z.z += 0.0001;
-
-					}
-
-					z.normalize();
-					x.crossVectors( up, z );
+					_z.z += 0.0001;
 
 				}
 
-				x.normalize();
-				y.crossVectors( z, x );
+				_z.normalize();
+				_x.crossVectors( up, _z );
 
-				te[ 0 ] = x.x; te[ 4 ] = y.x; te[ 8 ] = z.x;
-				te[ 1 ] = x.y; te[ 5 ] = y.y; te[ 9 ] = z.y;
-				te[ 2 ] = x.z; te[ 6 ] = y.z; te[ 10 ] = z.z;
+			}
 
-				return this;
+			_x.normalize();
+			_y.crossVectors( _z, _x );
 
-			};
+			te[ 0 ] = _x.x; te[ 4 ] = _y.x; te[ 8 ] = _z.x;
+			te[ 1 ] = _x.y; te[ 5 ] = _y.y; te[ 9 ] = _z.y;
+			te[ 2 ] = _x.z; te[ 6 ] = _y.z; te[ 10 ] = _z.z;
 
-		}(),
+			return this;
+
+		},
 
 		multiply: function ( m, n ) {
 
@@ -4297,30 +4408,6 @@ var Spacekit = (function (exports) {
 			return this;
 
 		},
-
-		applyToBufferAttribute: function () {
-
-			var v1 = new Vector3();
-
-			return function applyToBufferAttribute( attribute ) {
-
-				for ( var i = 0, l = attribute.count; i < l; i ++ ) {
-
-					v1.x = attribute.getX( i );
-					v1.y = attribute.getY( i );
-					v1.z = attribute.getZ( i );
-
-					v1.applyMatrix4( this );
-
-					attribute.setXYZ( i, v1.x, v1.y, v1.z );
-
-				}
-
-				return attribute;
-
-			};
-
-		}(),
 
 		determinant: function () {
 
@@ -4413,6 +4500,12 @@ var Spacekit = (function (exports) {
 
 		getInverse: function ( m, throwOnDegenerate ) {
 
+			if ( throwOnDegenerate !== undefined ) {
+
+				console.warn( "THREE.Matrix4: .getInverse() can no longer be configured to throw on degenerate." );
+
+			}
+
 			// based on http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/fourD/index.htm
 			var te = this.elements,
 				me = m.elements,
@@ -4429,23 +4522,7 @@ var Spacekit = (function (exports) {
 
 			var det = n11 * t11 + n21 * t12 + n31 * t13 + n41 * t14;
 
-			if ( det === 0 ) {
-
-				var msg = "THREE.Matrix4: .getInverse() can't invert matrix, determinant is 0";
-
-				if ( throwOnDegenerate === true ) {
-
-					throw new Error( msg );
-
-				} else {
-
-					console.warn( msg );
-
-				}
-
-				return this.identity();
-
-			}
+			if ( det === 0 ) return this.set( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 );
 
 			var detInv = 1 / det;
 
@@ -4654,57 +4731,50 @@ var Spacekit = (function (exports) {
 
 		},
 
-		decompose: function () {
+		decompose: function ( position, quaternion, scale ) {
 
-			var vector = new Vector3();
-			var matrix = new Matrix4();
+			var te = this.elements;
 
-			return function decompose( position, quaternion, scale ) {
+			var sx = _v1.set( te[ 0 ], te[ 1 ], te[ 2 ] ).length();
+			var sy = _v1.set( te[ 4 ], te[ 5 ], te[ 6 ] ).length();
+			var sz = _v1.set( te[ 8 ], te[ 9 ], te[ 10 ] ).length();
 
-				var te = this.elements;
+			// if determine is negative, we need to invert one scale
+			var det = this.determinant();
+			if ( det < 0 ) sx = - sx;
 
-				var sx = vector.set( te[ 0 ], te[ 1 ], te[ 2 ] ).length();
-				var sy = vector.set( te[ 4 ], te[ 5 ], te[ 6 ] ).length();
-				var sz = vector.set( te[ 8 ], te[ 9 ], te[ 10 ] ).length();
+			position.x = te[ 12 ];
+			position.y = te[ 13 ];
+			position.z = te[ 14 ];
 
-				// if determine is negative, we need to invert one scale
-				var det = this.determinant();
-				if ( det < 0 ) sx = - sx;
+			// scale the rotation part
+			_m1.copy( this );
 
-				position.x = te[ 12 ];
-				position.y = te[ 13 ];
-				position.z = te[ 14 ];
+			var invSX = 1 / sx;
+			var invSY = 1 / sy;
+			var invSZ = 1 / sz;
 
-				// scale the rotation part
-				matrix.copy( this );
+			_m1.elements[ 0 ] *= invSX;
+			_m1.elements[ 1 ] *= invSX;
+			_m1.elements[ 2 ] *= invSX;
 
-				var invSX = 1 / sx;
-				var invSY = 1 / sy;
-				var invSZ = 1 / sz;
+			_m1.elements[ 4 ] *= invSY;
+			_m1.elements[ 5 ] *= invSY;
+			_m1.elements[ 6 ] *= invSY;
 
-				matrix.elements[ 0 ] *= invSX;
-				matrix.elements[ 1 ] *= invSX;
-				matrix.elements[ 2 ] *= invSX;
+			_m1.elements[ 8 ] *= invSZ;
+			_m1.elements[ 9 ] *= invSZ;
+			_m1.elements[ 10 ] *= invSZ;
 
-				matrix.elements[ 4 ] *= invSY;
-				matrix.elements[ 5 ] *= invSY;
-				matrix.elements[ 6 ] *= invSY;
+			quaternion.setFromRotationMatrix( _m1 );
 
-				matrix.elements[ 8 ] *= invSZ;
-				matrix.elements[ 9 ] *= invSZ;
-				matrix.elements[ 10 ] *= invSZ;
+			scale.x = sx;
+			scale.y = sy;
+			scale.z = sz;
 
-				quaternion.setFromRotationMatrix( matrix );
+			return this;
 
-				scale.x = sx;
-				scale.y = sy;
-				scale.z = sz;
-
-				return this;
-
-			};
-
-		}(),
+		},
 
 		makePerspective: function ( left, right, top, bottom, near, far ) {
 
@@ -4820,7 +4890,8 @@ var Spacekit = (function (exports) {
 	 * @author bhouston / http://clara.io
 	 */
 
-	var _matrix, _quaternion;
+	var _matrix = new Matrix4();
+	var _quaternion$1 = new Quaternion();
 
 	function Euler( x, y, z, order ) {
 
@@ -4945,7 +5016,7 @@ var Spacekit = (function (exports) {
 
 		setFromRotationMatrix: function ( m, order, update ) {
 
-			var clamp = _Math.clamp;
+			var clamp = MathUtils.clamp;
 
 			// assumes the upper 3x3 of m is a pure rotation matrix (i.e, unscaled)
 
@@ -4956,105 +5027,119 @@ var Spacekit = (function (exports) {
 
 			order = order || this._order;
 
-			if ( order === 'XYZ' ) {
+			switch ( order ) {
 
-				this._y = Math.asin( clamp( m13, - 1, 1 ) );
+				case 'XYZ':
 
-				if ( Math.abs( m13 ) < 0.99999 ) {
+					this._y = Math.asin( clamp( m13, - 1, 1 ) );
 
-					this._x = Math.atan2( - m23, m33 );
-					this._z = Math.atan2( - m12, m11 );
+					if ( Math.abs( m13 ) < 0.9999999 ) {
 
-				} else {
+						this._x = Math.atan2( - m23, m33 );
+						this._z = Math.atan2( - m12, m11 );
 
-					this._x = Math.atan2( m32, m22 );
-					this._z = 0;
+					} else {
 
-				}
+						this._x = Math.atan2( m32, m22 );
+						this._z = 0;
 
-			} else if ( order === 'YXZ' ) {
+					}
 
-				this._x = Math.asin( - clamp( m23, - 1, 1 ) );
+					break;
 
-				if ( Math.abs( m23 ) < 0.99999 ) {
+				case 'YXZ':
 
-					this._y = Math.atan2( m13, m33 );
-					this._z = Math.atan2( m21, m22 );
+					this._x = Math.asin( - clamp( m23, - 1, 1 ) );
 
-				} else {
+					if ( Math.abs( m23 ) < 0.9999999 ) {
 
-					this._y = Math.atan2( - m31, m11 );
-					this._z = 0;
+						this._y = Math.atan2( m13, m33 );
+						this._z = Math.atan2( m21, m22 );
 
-				}
+					} else {
 
-			} else if ( order === 'ZXY' ) {
+						this._y = Math.atan2( - m31, m11 );
+						this._z = 0;
 
-				this._x = Math.asin( clamp( m32, - 1, 1 ) );
+					}
 
-				if ( Math.abs( m32 ) < 0.99999 ) {
+					break;
 
-					this._y = Math.atan2( - m31, m33 );
-					this._z = Math.atan2( - m12, m22 );
+				case 'ZXY':
 
-				} else {
+					this._x = Math.asin( clamp( m32, - 1, 1 ) );
 
-					this._y = 0;
-					this._z = Math.atan2( m21, m11 );
+					if ( Math.abs( m32 ) < 0.9999999 ) {
 
-				}
+						this._y = Math.atan2( - m31, m33 );
+						this._z = Math.atan2( - m12, m22 );
 
-			} else if ( order === 'ZYX' ) {
+					} else {
 
-				this._y = Math.asin( - clamp( m31, - 1, 1 ) );
+						this._y = 0;
+						this._z = Math.atan2( m21, m11 );
 
-				if ( Math.abs( m31 ) < 0.99999 ) {
+					}
 
-					this._x = Math.atan2( m32, m33 );
-					this._z = Math.atan2( m21, m11 );
+					break;
 
-				} else {
+				case 'ZYX':
 
-					this._x = 0;
-					this._z = Math.atan2( - m12, m22 );
+					this._y = Math.asin( - clamp( m31, - 1, 1 ) );
 
-				}
+					if ( Math.abs( m31 ) < 0.9999999 ) {
 
-			} else if ( order === 'YZX' ) {
+						this._x = Math.atan2( m32, m33 );
+						this._z = Math.atan2( m21, m11 );
 
-				this._z = Math.asin( clamp( m21, - 1, 1 ) );
+					} else {
 
-				if ( Math.abs( m21 ) < 0.99999 ) {
+						this._x = 0;
+						this._z = Math.atan2( - m12, m22 );
 
-					this._x = Math.atan2( - m23, m22 );
-					this._y = Math.atan2( - m31, m11 );
+					}
 
-				} else {
+					break;
 
-					this._x = 0;
-					this._y = Math.atan2( m13, m33 );
+				case 'YZX':
 
-				}
+					this._z = Math.asin( clamp( m21, - 1, 1 ) );
 
-			} else if ( order === 'XZY' ) {
+					if ( Math.abs( m21 ) < 0.9999999 ) {
 
-				this._z = Math.asin( - clamp( m12, - 1, 1 ) );
+						this._x = Math.atan2( - m23, m22 );
+						this._y = Math.atan2( - m31, m11 );
 
-				if ( Math.abs( m12 ) < 0.99999 ) {
+					} else {
 
-					this._x = Math.atan2( m32, m22 );
-					this._y = Math.atan2( m13, m11 );
+						this._x = 0;
+						this._y = Math.atan2( m13, m33 );
 
-				} else {
+					}
 
-					this._x = Math.atan2( - m23, m33 );
-					this._y = 0;
+					break;
 
-				}
+				case 'XZY':
 
-			} else {
+					this._z = Math.asin( - clamp( m12, - 1, 1 ) );
 
-				console.warn( 'THREE.Euler: .setFromRotationMatrix() given unsupported order: ' + order );
+					if ( Math.abs( m12 ) < 0.9999999 ) {
+
+						this._x = Math.atan2( m32, m22 );
+						this._y = Math.atan2( m13, m11 );
+
+					} else {
+
+						this._x = Math.atan2( - m23, m33 );
+						this._y = 0;
+
+					}
+
+					break;
+
+				default:
+
+					console.warn( 'THREE.Euler: .setFromRotationMatrix() encountered an unknown order: ' + order );
 
 			}
 
@@ -5067,8 +5152,6 @@ var Spacekit = (function (exports) {
 		},
 
 		setFromQuaternion: function ( q, order, update ) {
-
-			if ( _matrix === undefined ) _matrix = new Matrix4();
 
 			_matrix.makeRotationFromQuaternion( q );
 
@@ -5086,11 +5169,9 @@ var Spacekit = (function (exports) {
 
 			// WARNING: this discards revolution information -bhouston
 
-			if ( _quaternion === undefined ) _quaternion = new Quaternion();
+			_quaternion$1.setFromEuler( this );
 
-			_quaternion.setFromEuler( this );
-
-			return this.setFromQuaternion( _quaternion, newOrder );
+			return this.setFromQuaternion( _quaternion$1, newOrder );
 
 		},
 
@@ -5177,6 +5258,12 @@ var Spacekit = (function (exports) {
 
 		},
 
+		enableAll: function () {
+
+			this.mask = 0xffffffff | 0;
+
+		},
+
 		toggle: function ( channel ) {
 
 			this.mask ^= 1 << channel | 0;
@@ -5189,6 +5276,12 @@ var Spacekit = (function (exports) {
 
 		},
 
+		disableAll: function () {
+
+			this.mask = 0;
+
+		},
+
 		test: function ( layers ) {
 
 			return ( this.mask & layers.mask ) !== 0;
@@ -5196,6 +5289,24 @@ var Spacekit = (function (exports) {
 		}
 
 	} );
+
+	var _object3DId = 0;
+
+	var _v1$1 = new Vector3();
+	var _q1 = new Quaternion();
+	var _m1$1 = new Matrix4();
+	var _target = new Vector3();
+
+	var _position = new Vector3();
+	var _scale = new Vector3();
+	var _quaternion$2 = new Quaternion();
+
+	var _xAxis = new Vector3( 1, 0, 0 );
+	var _yAxis = new Vector3( 0, 1, 0 );
+	var _zAxis = new Vector3( 0, 0, 1 );
+
+	var _addedEvent = { type: 'added' };
+	var _removedEvent = { type: 'removed' };
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -5205,13 +5316,11 @@ var Spacekit = (function (exports) {
 	 * @author elephantatwork / www.elephantatwork.ch
 	 */
 
-	var object3DId = 0;
-
 	function Object3D() {
 
-		Object.defineProperty( this, 'id', { value: object3DId ++ } );
+		Object.defineProperty( this, 'id', { value: _object3DId ++ } );
 
-		this.uuid = _Math.generateUUID();
+		this.uuid = MathUtils.generateUUID();
 
 		this.name = '';
 		this.type = 'Object3D';
@@ -5301,7 +5410,7 @@ var Spacekit = (function (exports) {
 		onBeforeRender: function () {},
 		onAfterRender: function () {},
 
-		applyMatrix: function ( matrix ) {
+		applyMatrix4: function ( matrix ) {
 
 			if ( this.matrixAutoUpdate ) this.updateMatrix();
 
@@ -5349,135 +5458,81 @@ var Spacekit = (function (exports) {
 
 		},
 
-		rotateOnAxis: function () {
+		rotateOnAxis: function ( axis, angle ) {
 
 			// rotate object on axis in object space
 			// axis is assumed to be normalized
 
-			var q1 = new Quaternion();
+			_q1.setFromAxisAngle( axis, angle );
 
-			return function rotateOnAxis( axis, angle ) {
+			this.quaternion.multiply( _q1 );
 
-				q1.setFromAxisAngle( axis, angle );
+			return this;
 
-				this.quaternion.multiply( q1 );
+		},
 
-				return this;
-
-			};
-
-		}(),
-
-		rotateOnWorldAxis: function () {
+		rotateOnWorldAxis: function ( axis, angle ) {
 
 			// rotate object on axis in world space
 			// axis is assumed to be normalized
 			// method assumes no rotated parent
 
-			var q1 = new Quaternion();
+			_q1.setFromAxisAngle( axis, angle );
 
-			return function rotateOnWorldAxis( axis, angle ) {
+			this.quaternion.premultiply( _q1 );
 
-				q1.setFromAxisAngle( axis, angle );
+			return this;
 
-				this.quaternion.premultiply( q1 );
+		},
 
-				return this;
+		rotateX: function ( angle ) {
 
-			};
+			return this.rotateOnAxis( _xAxis, angle );
 
-		}(),
+		},
 
-		rotateX: function () {
+		rotateY: function ( angle ) {
 
-			var v1 = new Vector3( 1, 0, 0 );
+			return this.rotateOnAxis( _yAxis, angle );
 
-			return function rotateX( angle ) {
+		},
 
-				return this.rotateOnAxis( v1, angle );
+		rotateZ: function ( angle ) {
 
-			};
+			return this.rotateOnAxis( _zAxis, angle );
 
-		}(),
+		},
 
-		rotateY: function () {
-
-			var v1 = new Vector3( 0, 1, 0 );
-
-			return function rotateY( angle ) {
-
-				return this.rotateOnAxis( v1, angle );
-
-			};
-
-		}(),
-
-		rotateZ: function () {
-
-			var v1 = new Vector3( 0, 0, 1 );
-
-			return function rotateZ( angle ) {
-
-				return this.rotateOnAxis( v1, angle );
-
-			};
-
-		}(),
-
-		translateOnAxis: function () {
+		translateOnAxis: function ( axis, distance ) {
 
 			// translate object by distance along axis in object space
 			// axis is assumed to be normalized
 
-			var v1 = new Vector3();
+			_v1$1.copy( axis ).applyQuaternion( this.quaternion );
 
-			return function translateOnAxis( axis, distance ) {
+			this.position.add( _v1$1.multiplyScalar( distance ) );
 
-				v1.copy( axis ).applyQuaternion( this.quaternion );
+			return this;
 
-				this.position.add( v1.multiplyScalar( distance ) );
+		},
 
-				return this;
+		translateX: function ( distance ) {
 
-			};
+			return this.translateOnAxis( _xAxis, distance );
 
-		}(),
+		},
 
-		translateX: function () {
+		translateY: function ( distance ) {
 
-			var v1 = new Vector3( 1, 0, 0 );
+			return this.translateOnAxis( _yAxis, distance );
 
-			return function translateX( distance ) {
+		},
 
-				return this.translateOnAxis( v1, distance );
+		translateZ: function ( distance ) {
 
-			};
+			return this.translateOnAxis( _zAxis, distance );
 
-		}(),
-
-		translateY: function () {
-
-			var v1 = new Vector3( 0, 1, 0 );
-
-			return function translateY( distance ) {
-
-				return this.translateOnAxis( v1, distance );
-
-			};
-
-		}(),
-
-		translateZ: function () {
-
-			var v1 = new Vector3( 0, 0, 1 );
-
-			return function translateZ( distance ) {
-
-				return this.translateOnAxis( v1, distance );
-
-			};
-
-		}(),
+		},
 
 		localToWorld: function ( vector ) {
 
@@ -5485,68 +5540,53 @@ var Spacekit = (function (exports) {
 
 		},
 
-		worldToLocal: function () {
+		worldToLocal: function ( vector ) {
 
-			var m1 = new Matrix4();
+			return vector.applyMatrix4( _m1$1.getInverse( this.matrixWorld ) );
 
-			return function worldToLocal( vector ) {
+		},
 
-				return vector.applyMatrix4( m1.getInverse( this.matrixWorld ) );
-
-			};
-
-		}(),
-
-		lookAt: function () {
+		lookAt: function ( x, y, z ) {
 
 			// This method does not support objects having non-uniformly-scaled parent(s)
 
-			var q1 = new Quaternion();
-			var m1 = new Matrix4();
-			var target = new Vector3();
-			var position = new Vector3();
+			if ( x.isVector3 ) {
 
-			return function lookAt( x, y, z ) {
+				_target.copy( x );
 
-				if ( x.isVector3 ) {
+			} else {
 
-					target.copy( x );
+				_target.set( x, y, z );
 
-				} else {
+			}
 
-					target.set( x, y, z );
+			var parent = this.parent;
 
-				}
+			this.updateWorldMatrix( true, false );
 
-				var parent = this.parent;
+			_position.setFromMatrixPosition( this.matrixWorld );
 
-				this.updateWorldMatrix( true, false );
+			if ( this.isCamera || this.isLight ) {
 
-				position.setFromMatrixPosition( this.matrixWorld );
+				_m1$1.lookAt( _position, _target, this.up );
 
-				if ( this.isCamera || this.isLight ) {
+			} else {
 
-					m1.lookAt( position, target, this.up );
+				_m1$1.lookAt( _target, _position, this.up );
 
-				} else {
+			}
 
-					m1.lookAt( target, position, this.up );
+			this.quaternion.setFromRotationMatrix( _m1$1 );
 
-				}
+			if ( parent ) {
 
-				this.quaternion.setFromRotationMatrix( m1 );
+				_m1$1.extractRotation( parent.matrixWorld );
+				_q1.setFromRotationMatrix( _m1$1 );
+				this.quaternion.premultiply( _q1.inverse() );
 
-				if ( parent ) {
+			}
 
-					m1.extractRotation( parent.matrixWorld );
-					q1.setFromRotationMatrix( m1 );
-					this.quaternion.premultiply( q1.inverse() );
-
-				}
-
-			};
-
-		}(),
+		},
 
 		add: function ( object ) {
 
@@ -5580,7 +5620,7 @@ var Spacekit = (function (exports) {
 				object.parent = this;
 				this.children.push( object );
 
-				object.dispatchEvent( { type: 'added' } );
+				object.dispatchEvent( _addedEvent );
 
 			} else {
 
@@ -5613,7 +5653,7 @@ var Spacekit = (function (exports) {
 				object.parent = null;
 				this.children.splice( index, 1 );
 
-				object.dispatchEvent( { type: 'removed' } );
+				object.dispatchEvent( _removedEvent );
 
 			}
 
@@ -5621,37 +5661,31 @@ var Spacekit = (function (exports) {
 
 		},
 
-		attach: function () {
+		attach: function ( object ) {
 
 			// adds object as a child of this, while maintaining the object's world transform
 
-			var m = new Matrix4();
+			this.updateWorldMatrix( true, false );
 
-			return function attach( object ) {
+			_m1$1.getInverse( this.matrixWorld );
 
-				this.updateWorldMatrix( true, false );
+			if ( object.parent !== null ) {
 
-				m.getInverse( this.matrixWorld );
+				object.parent.updateWorldMatrix( true, false );
 
-				if ( object.parent !== null ) {
+				_m1$1.multiply( object.parent.matrixWorld );
 
-					object.parent.updateWorldMatrix( true, false );
+			}
 
-					m.multiply( object.parent.matrixWorld );
+			object.applyMatrix4( _m1$1 );
 
-				}
+			object.updateWorldMatrix( false, false );
 
-				object.applyMatrix( m );
+			this.add( object );
 
-				object.updateWorldMatrix( false, false );
+			return this;
 
-				this.add( object );
-
-				return this;
-
-			};
-
-		}(),
+		},
 
 		getObjectById: function ( id ) {
 
@@ -5701,53 +5735,39 @@ var Spacekit = (function (exports) {
 
 		},
 
-		getWorldQuaternion: function () {
+		getWorldQuaternion: function ( target ) {
 
-			var position = new Vector3();
-			var scale = new Vector3();
+			if ( target === undefined ) {
 
-			return function getWorldQuaternion( target ) {
+				console.warn( 'THREE.Object3D: .getWorldQuaternion() target is now required' );
+				target = new Quaternion();
 
-				if ( target === undefined ) {
+			}
 
-					console.warn( 'THREE.Object3D: .getWorldQuaternion() target is now required' );
-					target = new Quaternion();
+			this.updateMatrixWorld( true );
 
-				}
+			this.matrixWorld.decompose( _position, target, _scale );
 
-				this.updateMatrixWorld( true );
+			return target;
 
-				this.matrixWorld.decompose( position, target, scale );
+		},
 
-				return target;
+		getWorldScale: function ( target ) {
 
-			};
+			if ( target === undefined ) {
 
-		}(),
+				console.warn( 'THREE.Object3D: .getWorldScale() target is now required' );
+				target = new Vector3();
 
-		getWorldScale: function () {
+			}
 
-			var position = new Vector3();
-			var quaternion = new Quaternion();
+			this.updateMatrixWorld( true );
 
-			return function getWorldScale( target ) {
+			this.matrixWorld.decompose( _position, _quaternion$2, target );
 
-				if ( target === undefined ) {
+			return target;
 
-					console.warn( 'THREE.Object3D: .getWorldScale() target is now required' );
-					target = new Vector3();
-
-				}
-
-				this.updateMatrixWorld( true );
-
-				this.matrixWorld.decompose( position, quaternion, target );
-
-				return target;
-
-			};
-
-		}(),
+		},
 
 		getWorldDirection: function ( target ) {
 
@@ -5943,7 +5963,13 @@ var Spacekit = (function (exports) {
 
 			// object specific properties
 
-			if ( this.isMesh && this.drawMode !== TrianglesDrawMode ) object.drawMode = this.drawMode;
+			if ( this.isInstancedMesh ) {
+
+				object.type = 'InstancedMesh';
+				object.count = this.count;
+				object.instanceMatrix = this.instanceMatrix.toJSON();
+
+			}
 
 			//
 
@@ -6058,6 +6084,7 @@ var Spacekit = (function (exports) {
 					values.push( data );
 
 				}
+
 				return values;
 
 			}
@@ -6127,7 +6154,9 @@ var Spacekit = (function (exports) {
 		this.type = 'Scene';
 
 		this.background = null;
+		this.environment = null;
 		this.fog = null;
+
 		this.overrideMaterial = null;
 
 		this.autoUpdate = true; // checked by the renderer
@@ -6151,7 +6180,9 @@ var Spacekit = (function (exports) {
 			Object3D.prototype.copy.call( this, source, recursive );
 
 			if ( source.background !== null ) this.background = source.background.clone();
+			if ( source.environment !== null ) this.environment = source.environment.clone();
 			if ( source.fog !== null ) this.fog = source.fog.clone();
+
 			if ( source.overrideMaterial !== null ) this.overrideMaterial = source.overrideMaterial.clone();
 
 			this.autoUpdate = source.autoUpdate;
@@ -6166,6 +6197,7 @@ var Spacekit = (function (exports) {
 			var data = Object3D.prototype.toJSON.call( this, meta );
 
 			if ( this.background !== null ) data.object.background = this.background.toJSON( meta );
+			if ( this.environment !== null ) data.object.environment = this.environment.toJSON( meta );
 			if ( this.fog !== null ) data.object.fog = this.fog.toJSON();
 
 			return data;
@@ -6180,6 +6212,38 @@ var Spacekit = (function (exports) {
 
 	} );
 
+	var _points = [
+		new Vector3(),
+		new Vector3(),
+		new Vector3(),
+		new Vector3(),
+		new Vector3(),
+		new Vector3(),
+		new Vector3(),
+		new Vector3()
+	];
+
+	var _vector$1 = new Vector3();
+
+	var _box = new Box3();
+
+	// triangle centered vertices
+
+	var _v0 = new Vector3();
+	var _v1$2 = new Vector3();
+	var _v2 = new Vector3();
+
+	// triangle edge vectors
+
+	var _f0 = new Vector3();
+	var _f1 = new Vector3();
+	var _f2 = new Vector3();
+
+	var _center = new Vector3();
+	var _extents = new Vector3();
+	var _triangleNormal = new Vector3();
+	var _testAxis = new Vector3();
+
 	/**
 	 * @author bhouston / http://clara.io
 	 * @author WestLangley / http://github.com/WestLangley
@@ -6191,6 +6255,7 @@ var Spacekit = (function (exports) {
 		this.max = ( max !== undefined ) ? max : new Vector3( - Infinity, - Infinity, - Infinity );
 
 	}
+
 
 	Object.assign( Box3.prototype, {
 
@@ -6285,22 +6350,16 @@ var Spacekit = (function (exports) {
 
 		},
 
-		setFromCenterAndSize: function () {
+		setFromCenterAndSize: function ( center, size ) {
 
-			var v1 = new Vector3();
+			var halfSize = _vector$1.copy( size ).multiplyScalar( 0.5 );
 
-			return function setFromCenterAndSize( center, size ) {
+			this.min.copy( center ).sub( halfSize );
+			this.max.copy( center ).add( halfSize );
 
-				var halfSize = v1.copy( size ).multiplyScalar( 0.5 );
+			return this;
 
-				this.min.copy( center ).sub( halfSize );
-				this.max.copy( center ).add( halfSize );
-
-				return this;
-
-			};
-
-		}(),
+		},
 
 		setFromObject: function ( object ) {
 
@@ -6395,69 +6454,41 @@ var Spacekit = (function (exports) {
 
 		},
 
-		expandByObject: function () {
+		expandByObject: function ( object ) {
 
 			// Computes the world-axis-aligned bounding box of an object (including its children),
 			// accounting for both the object's, and children's, world transforms
 
-			var scope, i, l;
+			object.updateWorldMatrix( false, false );
 
-			var v1 = new Vector3();
+			var geometry = object.geometry;
 
-			function traverse( node ) {
+			if ( geometry !== undefined ) {
 
-				var geometry = node.geometry;
+				if ( geometry.boundingBox === null ) {
 
-				if ( geometry !== undefined ) {
-
-					if ( geometry.isGeometry ) {
-
-						var vertices = geometry.vertices;
-
-						for ( i = 0, l = vertices.length; i < l; i ++ ) {
-
-							v1.copy( vertices[ i ] );
-							v1.applyMatrix4( node.matrixWorld );
-
-							scope.expandByPoint( v1 );
-
-						}
-
-					} else if ( geometry.isBufferGeometry ) {
-
-						var attribute = geometry.attributes.position;
-
-						if ( attribute !== undefined ) {
-
-							for ( i = 0, l = attribute.count; i < l; i ++ ) {
-
-								v1.fromBufferAttribute( attribute, i ).applyMatrix4( node.matrixWorld );
-
-								scope.expandByPoint( v1 );
-
-							}
-
-						}
-
-					}
+					geometry.computeBoundingBox();
 
 				}
 
+				_box.copy( geometry.boundingBox );
+				_box.applyMatrix4( object.matrixWorld );
+
+				this.union( _box );
+
 			}
 
-			return function expandByObject( object ) {
+			var children = object.children;
 
-				scope = this;
+			for ( var i = 0, l = children.length; i < l; i ++ ) {
 
-				object.updateMatrixWorld( true );
+				this.expandByObject( children[ i ] );
 
-				object.traverse( traverse );
+			}
 
-				return this;
+			return this;
 
-			};
-
-		}(),
+		},
 
 		containsPoint: function ( point ) {
 
@@ -6504,21 +6535,15 @@ var Spacekit = (function (exports) {
 
 		},
 
-		intersectsSphere: ( function () {
+		intersectsSphere: function ( sphere ) {
 
-			var closestPoint = new Vector3();
+			// Find the point on the AABB closest to the sphere center.
+			this.clampPoint( sphere.center, _vector$1 );
 
-			return function intersectsSphere( sphere ) {
+			// If that point is inside the sphere, the AABB and sphere intersect.
+			return _vector$1.distanceToSquared( sphere.center ) <= ( sphere.radius * sphere.radius );
 
-				// Find the point on the AABB closest to the sphere center.
-				this.clampPoint( sphere.center, closestPoint );
-
-				// If that point is inside the sphere, the AABB and sphere intersect.
-				return closestPoint.distanceToSquared( sphere.center ) <= ( sphere.radius * sphere.radius );
-
-			};
-
-		} )(),
+		},
 
 		intersectsPlane: function ( plane ) {
 
@@ -6567,106 +6592,58 @@ var Spacekit = (function (exports) {
 
 		},
 
-		intersectsTriangle: ( function () {
+		intersectsTriangle: function ( triangle ) {
 
-			// triangle centered vertices
-			var v0 = new Vector3();
-			var v1 = new Vector3();
-			var v2 = new Vector3();
+			if ( this.isEmpty() ) {
 
-			// triangle edge vectors
-			var f0 = new Vector3();
-			var f1 = new Vector3();
-			var f2 = new Vector3();
-
-			var testAxis = new Vector3();
-
-			var center = new Vector3();
-			var extents = new Vector3();
-
-			var triangleNormal = new Vector3();
-
-			function satForAxes( axes ) {
-
-				var i, j;
-
-				for ( i = 0, j = axes.length - 3; i <= j; i += 3 ) {
-
-					testAxis.fromArray( axes, i );
-					// project the aabb onto the seperating axis
-					var r = extents.x * Math.abs( testAxis.x ) + extents.y * Math.abs( testAxis.y ) + extents.z * Math.abs( testAxis.z );
-					// project all 3 vertices of the triangle onto the seperating axis
-					var p0 = v0.dot( testAxis );
-					var p1 = v1.dot( testAxis );
-					var p2 = v2.dot( testAxis );
-					// actual test, basically see if either of the most extreme of the triangle points intersects r
-					if ( Math.max( - Math.max( p0, p1, p2 ), Math.min( p0, p1, p2 ) ) > r ) {
-
-						// points of the projected triangle are outside the projected half-length of the aabb
-						// the axis is seperating and we can exit
-						return false;
-
-					}
-
-				}
-
-				return true;
+				return false;
 
 			}
 
-			return function intersectsTriangle( triangle ) {
+			// compute box center and extents
+			this.getCenter( _center );
+			_extents.subVectors( this.max, _center );
 
-				if ( this.isEmpty() ) {
+			// translate triangle to aabb origin
+			_v0.subVectors( triangle.a, _center );
+			_v1$2.subVectors( triangle.b, _center );
+			_v2.subVectors( triangle.c, _center );
 
-					return false;
+			// compute edge vectors for triangle
+			_f0.subVectors( _v1$2, _v0 );
+			_f1.subVectors( _v2, _v1$2 );
+			_f2.subVectors( _v0, _v2 );
 
-				}
+			// test against axes that are given by cross product combinations of the edges of the triangle and the edges of the aabb
+			// make an axis testing of each of the 3 sides of the aabb against each of the 3 sides of the triangle = 9 axis of separation
+			// axis_ij = u_i x f_j (u0, u1, u2 = face normals of aabb = x,y,z axes vectors since aabb is axis aligned)
+			var axes = [
+				0, - _f0.z, _f0.y, 0, - _f1.z, _f1.y, 0, - _f2.z, _f2.y,
+				_f0.z, 0, - _f0.x, _f1.z, 0, - _f1.x, _f2.z, 0, - _f2.x,
+				- _f0.y, _f0.x, 0, - _f1.y, _f1.x, 0, - _f2.y, _f2.x, 0
+			];
+			if ( ! satForAxes( axes, _v0, _v1$2, _v2, _extents ) ) {
 
-				// compute box center and extents
-				this.getCenter( center );
-				extents.subVectors( this.max, center );
+				return false;
 
-				// translate triangle to aabb origin
-				v0.subVectors( triangle.a, center );
-				v1.subVectors( triangle.b, center );
-				v2.subVectors( triangle.c, center );
+			}
 
-				// compute edge vectors for triangle
-				f0.subVectors( v1, v0 );
-				f1.subVectors( v2, v1 );
-				f2.subVectors( v0, v2 );
+			// test 3 face normals from the aabb
+			axes = [ 1, 0, 0, 0, 1, 0, 0, 0, 1 ];
+			if ( ! satForAxes( axes, _v0, _v1$2, _v2, _extents ) ) {
 
-				// test against axes that are given by cross product combinations of the edges of the triangle and the edges of the aabb
-				// make an axis testing of each of the 3 sides of the aabb against each of the 3 sides of the triangle = 9 axis of separation
-				// axis_ij = u_i x f_j (u0, u1, u2 = face normals of aabb = x,y,z axes vectors since aabb is axis aligned)
-				var axes = [
-					0, - f0.z, f0.y, 0, - f1.z, f1.y, 0, - f2.z, f2.y,
-					f0.z, 0, - f0.x, f1.z, 0, - f1.x, f2.z, 0, - f2.x,
-					- f0.y, f0.x, 0, - f1.y, f1.x, 0, - f2.y, f2.x, 0
-				];
-				if ( ! satForAxes( axes ) ) {
+				return false;
 
-					return false;
+			}
 
-				}
+			// finally testing the face normal of the triangle
+			// use already existing triangle edge vectors here
+			_triangleNormal.crossVectors( _f0, _f1 );
+			axes = [ _triangleNormal.x, _triangleNormal.y, _triangleNormal.z ];
 
-				// test 3 face normals from the aabb
-				axes = [ 1, 0, 0, 0, 1, 0, 0, 0, 1 ];
-				if ( ! satForAxes( axes ) ) {
+			return satForAxes( axes, _v0, _v1$2, _v2, _extents );
 
-					return false;
-
-				}
-
-				// finally testing the face normal of the triangle
-				// use already existing triangle edge vectors here
-				triangleNormal.crossVectors( f0, f1 );
-				axes = [ triangleNormal.x, triangleNormal.y, triangleNormal.z ];
-				return satForAxes( axes );
-
-			};
-
-		} )(),
+		},
 
 		clampPoint: function ( point, target ) {
 
@@ -6681,41 +6658,30 @@ var Spacekit = (function (exports) {
 
 		},
 
-		distanceToPoint: function () {
+		distanceToPoint: function ( point ) {
 
-			var v1 = new Vector3();
+			var clampedPoint = _vector$1.copy( point ).clamp( this.min, this.max );
 
-			return function distanceToPoint( point ) {
+			return clampedPoint.sub( point ).length();
 
-				var clampedPoint = v1.copy( point ).clamp( this.min, this.max );
-				return clampedPoint.sub( point ).length();
+		},
 
-			};
+		getBoundingSphere: function ( target ) {
 
-		}(),
+			if ( target === undefined ) {
 
-		getBoundingSphere: function () {
+				console.error( 'THREE.Box3: .getBoundingSphere() target is now required' );
+				//target = new Sphere(); // removed to avoid cyclic dependency
 
-			var v1 = new Vector3();
+			}
 
-			return function getBoundingSphere( target ) {
+			this.getCenter( target.center );
 
-				if ( target === undefined ) {
+			target.radius = this.getSize( _vector$1 ).length() * 0.5;
 
-					console.error( 'THREE.Box3: .getBoundingSphere() target is now required' );
-					//target = new Sphere(); // removed to avoid cyclic dependency
+			return target;
 
-				}
-
-				this.getCenter( target.center );
-
-				target.radius = this.getSize( v1 ).length() * 0.5;
-
-				return target;
-
-			};
-
-		}(),
+		},
 
 		intersect: function ( box ) {
 
@@ -6738,41 +6704,26 @@ var Spacekit = (function (exports) {
 
 		},
 
-		applyMatrix4: function () {
+		applyMatrix4: function ( matrix ) {
 
-			var points = [
-				new Vector3(),
-				new Vector3(),
-				new Vector3(),
-				new Vector3(),
-				new Vector3(),
-				new Vector3(),
-				new Vector3(),
-				new Vector3()
-			];
+			// transform of empty box is an empty box.
+			if ( this.isEmpty() ) return this;
 
-			return function applyMatrix4( matrix ) {
+			// NOTE: I am using a binary pattern to specify all 2^3 combinations below
+			_points[ 0 ].set( this.min.x, this.min.y, this.min.z ).applyMatrix4( matrix ); // 000
+			_points[ 1 ].set( this.min.x, this.min.y, this.max.z ).applyMatrix4( matrix ); // 001
+			_points[ 2 ].set( this.min.x, this.max.y, this.min.z ).applyMatrix4( matrix ); // 010
+			_points[ 3 ].set( this.min.x, this.max.y, this.max.z ).applyMatrix4( matrix ); // 011
+			_points[ 4 ].set( this.max.x, this.min.y, this.min.z ).applyMatrix4( matrix ); // 100
+			_points[ 5 ].set( this.max.x, this.min.y, this.max.z ).applyMatrix4( matrix ); // 101
+			_points[ 6 ].set( this.max.x, this.max.y, this.min.z ).applyMatrix4( matrix ); // 110
+			_points[ 7 ].set( this.max.x, this.max.y, this.max.z ).applyMatrix4( matrix ); // 111
 
-				// transform of empty box is an empty box.
-				if ( this.isEmpty() ) return this;
+			this.setFromPoints( _points );
 
-				// NOTE: I am using a binary pattern to specify all 2^3 combinations below
-				points[ 0 ].set( this.min.x, this.min.y, this.min.z ).applyMatrix4( matrix ); // 000
-				points[ 1 ].set( this.min.x, this.min.y, this.max.z ).applyMatrix4( matrix ); // 001
-				points[ 2 ].set( this.min.x, this.max.y, this.min.z ).applyMatrix4( matrix ); // 010
-				points[ 3 ].set( this.min.x, this.max.y, this.max.z ).applyMatrix4( matrix ); // 011
-				points[ 4 ].set( this.max.x, this.min.y, this.min.z ).applyMatrix4( matrix ); // 100
-				points[ 5 ].set( this.max.x, this.min.y, this.max.z ).applyMatrix4( matrix ); // 101
-				points[ 6 ].set( this.max.x, this.max.y, this.min.z ).applyMatrix4( matrix ); // 110
-				points[ 7 ].set( this.max.x, this.max.y, this.max.z ).applyMatrix4( matrix ); // 111
+			return this;
 
-				this.setFromPoints( points );
-
-				return this;
-
-			};
-
-		}(),
+		},
 
 		translate: function ( offset ) {
 
@@ -6791,17 +6742,45 @@ var Spacekit = (function (exports) {
 
 	} );
 
+	function satForAxes( axes, v0, v1, v2, extents ) {
+
+		var i, j;
+
+		for ( i = 0, j = axes.length - 3; i <= j; i += 3 ) {
+
+			_testAxis.fromArray( axes, i );
+			// project the aabb onto the seperating axis
+			var r = extents.x * Math.abs( _testAxis.x ) + extents.y * Math.abs( _testAxis.y ) + extents.z * Math.abs( _testAxis.z );
+			// project all 3 vertices of the triangle onto the seperating axis
+			var p0 = v0.dot( _testAxis );
+			var p1 = v1.dot( _testAxis );
+			var p2 = v2.dot( _testAxis );
+			// actual test, basically see if either of the most extreme of the triangle points intersects r
+			if ( Math.max( - Math.max( p0, p1, p2 ), Math.min( p0, p1, p2 ) ) > r ) {
+
+				// points of the projected triangle are outside the projected half-length of the aabb
+				// the axis is seperating and we can exit
+				return false;
+
+			}
+
+		}
+
+		return true;
+
+	}
+
+	var _box$1 = new Box3();
+
 	/**
 	 * @author bhouston / http://clara.io
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-	var _box;
-
 	function Sphere( center, radius ) {
 
 		this.center = ( center !== undefined ) ? center : new Vector3();
-		this.radius = ( radius !== undefined ) ? radius : 0;
+		this.radius = ( radius !== undefined ) ? radius : - 1;
 
 	}
 
@@ -6818,8 +6797,6 @@ var Spacekit = (function (exports) {
 
 		setFromPoints: function ( points, optionalCenter ) {
 
-			if ( _box === undefined ) _box = new Box3();
-
 			var center = this.center;
 
 			if ( optionalCenter !== undefined ) {
@@ -6828,7 +6805,7 @@ var Spacekit = (function (exports) {
 
 			} else {
 
-				_box.setFromPoints( points ).getCenter( center );
+				_box$1.setFromPoints( points ).getCenter( center );
 
 			}
 
@@ -6861,9 +6838,18 @@ var Spacekit = (function (exports) {
 
 		},
 
-		empty: function () {
+		isEmpty: function () {
 
-			return ( this.radius <= 0 );
+			return ( this.radius < 0 );
+
+		},
+
+		makeEmpty: function () {
+
+			this.center.set( 0, 0, 0 );
+			this.radius = - 1;
+
+			return this;
 
 		},
 
@@ -6932,6 +6918,14 @@ var Spacekit = (function (exports) {
 
 			}
 
+			if ( this.isEmpty() ) {
+
+				// Empty sphere produces empty bounding box
+				target.makeEmpty();
+				return target;
+
+			}
+
 			target.set( this.center, this.center );
 			target.expandByScalar( this.radius );
 
@@ -6964,6 +6958,15 @@ var Spacekit = (function (exports) {
 
 	} );
 
+	var _vector$2 = new Vector3();
+	var _segCenter = new Vector3();
+	var _segDir = new Vector3();
+	var _diff = new Vector3();
+
+	var _edge1 = new Vector3();
+	var _edge2 = new Vector3();
+	var _normal = new Vector3();
+
 	/**
 	 * @author bhouston / http://clara.io
 	 */
@@ -6971,7 +6974,7 @@ var Spacekit = (function (exports) {
 	function Ray( origin, direction ) {
 
 		this.origin = ( origin !== undefined ) ? origin : new Vector3();
-		this.direction = ( direction !== undefined ) ? direction : new Vector3();
+		this.direction = ( direction !== undefined ) ? direction : new Vector3( 0, 0, - 1 );
 
 	}
 
@@ -7022,19 +7025,13 @@ var Spacekit = (function (exports) {
 
 		},
 
-		recast: function () {
+		recast: function ( t ) {
 
-			var v1 = new Vector3();
+			this.origin.copy( this.at( t, _vector$2 ) );
 
-			return function recast( t ) {
+			return this;
 
-				this.origin.copy( this.at( t, v1 ) );
-
-				return this;
-
-			};
-
-		}(),
+		},
 
 		closestPointToPoint: function ( point, target ) {
 
@@ -7065,94 +7062,72 @@ var Spacekit = (function (exports) {
 
 		},
 
-		distanceSqToPoint: function () {
+		distanceSqToPoint: function ( point ) {
 
-			var v1 = new Vector3();
+			var directionDistance = _vector$2.subVectors( point, this.origin ).dot( this.direction );
 
-			return function distanceSqToPoint( point ) {
+			// point behind the ray
 
-				var directionDistance = v1.subVectors( point, this.origin ).dot( this.direction );
+			if ( directionDistance < 0 ) {
 
-				// point behind the ray
+				return this.origin.distanceToSquared( point );
 
-				if ( directionDistance < 0 ) {
+			}
 
-					return this.origin.distanceToSquared( point );
+			_vector$2.copy( this.direction ).multiplyScalar( directionDistance ).add( this.origin );
 
-				}
+			return _vector$2.distanceToSquared( point );
 
-				v1.copy( this.direction ).multiplyScalar( directionDistance ).add( this.origin );
+		},
 
-				return v1.distanceToSquared( point );
+		distanceSqToSegment: function ( v0, v1, optionalPointOnRay, optionalPointOnSegment ) {
 
-			};
+			// from http://www.geometrictools.com/GTEngine/Include/Mathematics/GteDistRaySegment.h
+			// It returns the min distance between the ray and the segment
+			// defined by v0 and v1
+			// It can also set two optional targets :
+			// - The closest point on the ray
+			// - The closest point on the segment
 
-		}(),
+			_segCenter.copy( v0 ).add( v1 ).multiplyScalar( 0.5 );
+			_segDir.copy( v1 ).sub( v0 ).normalize();
+			_diff.copy( this.origin ).sub( _segCenter );
 
-		distanceSqToSegment: function () {
+			var segExtent = v0.distanceTo( v1 ) * 0.5;
+			var a01 = - this.direction.dot( _segDir );
+			var b0 = _diff.dot( this.direction );
+			var b1 = - _diff.dot( _segDir );
+			var c = _diff.lengthSq();
+			var det = Math.abs( 1 - a01 * a01 );
+			var s0, s1, sqrDist, extDet;
 
-			var segCenter = new Vector3();
-			var segDir = new Vector3();
-			var diff = new Vector3();
+			if ( det > 0 ) {
 
-			return function distanceSqToSegment( v0, v1, optionalPointOnRay, optionalPointOnSegment ) {
+				// The ray and segment are not parallel.
 
-				// from http://www.geometrictools.com/GTEngine/Include/Mathematics/GteDistRaySegment.h
-				// It returns the min distance between the ray and the segment
-				// defined by v0 and v1
-				// It can also set two optional targets :
-				// - The closest point on the ray
-				// - The closest point on the segment
+				s0 = a01 * b1 - b0;
+				s1 = a01 * b0 - b1;
+				extDet = segExtent * det;
 
-				segCenter.copy( v0 ).add( v1 ).multiplyScalar( 0.5 );
-				segDir.copy( v1 ).sub( v0 ).normalize();
-				diff.copy( this.origin ).sub( segCenter );
+				if ( s0 >= 0 ) {
 
-				var segExtent = v0.distanceTo( v1 ) * 0.5;
-				var a01 = - this.direction.dot( segDir );
-				var b0 = diff.dot( this.direction );
-				var b1 = - diff.dot( segDir );
-				var c = diff.lengthSq();
-				var det = Math.abs( 1 - a01 * a01 );
-				var s0, s1, sqrDist, extDet;
+					if ( s1 >= - extDet ) {
 
-				if ( det > 0 ) {
+						if ( s1 <= extDet ) {
 
-					// The ray and segment are not parallel.
+							// region 0
+							// Minimum at interior points of ray and segment.
 
-					s0 = a01 * b1 - b0;
-					s1 = a01 * b0 - b1;
-					extDet = segExtent * det;
-
-					if ( s0 >= 0 ) {
-
-						if ( s1 >= - extDet ) {
-
-							if ( s1 <= extDet ) {
-
-								// region 0
-								// Minimum at interior points of ray and segment.
-
-								var invDet = 1 / det;
-								s0 *= invDet;
-								s1 *= invDet;
-								sqrDist = s0 * ( s0 + a01 * s1 + 2 * b0 ) + s1 * ( a01 * s0 + s1 + 2 * b1 ) + c;
-
-							} else {
-
-								// region 1
-
-								s1 = segExtent;
-								s0 = Math.max( 0, - ( a01 * s1 + b0 ) );
-								sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
-
-							}
+							var invDet = 1 / det;
+							s0 *= invDet;
+							s1 *= invDet;
+							sqrDist = s0 * ( s0 + a01 * s1 + 2 * b0 ) + s1 * ( a01 * s0 + s1 + 2 * b1 ) + c;
 
 						} else {
 
-							// region 5
+							// region 1
 
-							s1 = - segExtent;
+							s1 = segExtent;
 							s0 = Math.max( 0, - ( a01 * s1 + b0 ) );
 							sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
 
@@ -7160,97 +7135,99 @@ var Spacekit = (function (exports) {
 
 					} else {
 
-						if ( s1 <= - extDet ) {
+						// region 5
 
-							// region 4
-
-							s0 = Math.max( 0, - ( - a01 * segExtent + b0 ) );
-							s1 = ( s0 > 0 ) ? - segExtent : Math.min( Math.max( - segExtent, - b1 ), segExtent );
-							sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
-
-						} else if ( s1 <= extDet ) {
-
-							// region 3
-
-							s0 = 0;
-							s1 = Math.min( Math.max( - segExtent, - b1 ), segExtent );
-							sqrDist = s1 * ( s1 + 2 * b1 ) + c;
-
-						} else {
-
-							// region 2
-
-							s0 = Math.max( 0, - ( a01 * segExtent + b0 ) );
-							s1 = ( s0 > 0 ) ? segExtent : Math.min( Math.max( - segExtent, - b1 ), segExtent );
-							sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
-
-						}
+						s1 = - segExtent;
+						s0 = Math.max( 0, - ( a01 * s1 + b0 ) );
+						sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
 
 					}
 
 				} else {
 
-					// Ray and segment are parallel.
+					if ( s1 <= - extDet ) {
 
-					s1 = ( a01 > 0 ) ? - segExtent : segExtent;
-					s0 = Math.max( 0, - ( a01 * s1 + b0 ) );
-					sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
+						// region 4
+
+						s0 = Math.max( 0, - ( - a01 * segExtent + b0 ) );
+						s1 = ( s0 > 0 ) ? - segExtent : Math.min( Math.max( - segExtent, - b1 ), segExtent );
+						sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
+
+					} else if ( s1 <= extDet ) {
+
+						// region 3
+
+						s0 = 0;
+						s1 = Math.min( Math.max( - segExtent, - b1 ), segExtent );
+						sqrDist = s1 * ( s1 + 2 * b1 ) + c;
+
+					} else {
+
+						// region 2
+
+						s0 = Math.max( 0, - ( a01 * segExtent + b0 ) );
+						s1 = ( s0 > 0 ) ? segExtent : Math.min( Math.max( - segExtent, - b1 ), segExtent );
+						sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
+
+					}
 
 				}
 
-				if ( optionalPointOnRay ) {
+			} else {
 
-					optionalPointOnRay.copy( this.direction ).multiplyScalar( s0 ).add( this.origin );
+				// Ray and segment are parallel.
 
-				}
+				s1 = ( a01 > 0 ) ? - segExtent : segExtent;
+				s0 = Math.max( 0, - ( a01 * s1 + b0 ) );
+				sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
 
-				if ( optionalPointOnSegment ) {
+			}
 
-					optionalPointOnSegment.copy( segDir ).multiplyScalar( s1 ).add( segCenter );
+			if ( optionalPointOnRay ) {
 
-				}
+				optionalPointOnRay.copy( this.direction ).multiplyScalar( s0 ).add( this.origin );
 
-				return sqrDist;
+			}
 
-			};
+			if ( optionalPointOnSegment ) {
 
-		}(),
+				optionalPointOnSegment.copy( _segDir ).multiplyScalar( s1 ).add( _segCenter );
 
-		intersectSphere: function () {
+			}
 
-			var v1 = new Vector3();
+			return sqrDist;
 
-			return function intersectSphere( sphere, target ) {
+		},
 
-				v1.subVectors( sphere.center, this.origin );
-				var tca = v1.dot( this.direction );
-				var d2 = v1.dot( v1 ) - tca * tca;
-				var radius2 = sphere.radius * sphere.radius;
+		intersectSphere: function ( sphere, target ) {
 
-				if ( d2 > radius2 ) return null;
+			_vector$2.subVectors( sphere.center, this.origin );
+			var tca = _vector$2.dot( this.direction );
+			var d2 = _vector$2.dot( _vector$2 ) - tca * tca;
+			var radius2 = sphere.radius * sphere.radius;
 
-				var thc = Math.sqrt( radius2 - d2 );
+			if ( d2 > radius2 ) return null;
 
-				// t0 = first intersect point - entrance on front of sphere
-				var t0 = tca - thc;
+			var thc = Math.sqrt( radius2 - d2 );
 
-				// t1 = second intersect point - exit point on back of sphere
-				var t1 = tca + thc;
+			// t0 = first intersect point - entrance on front of sphere
+			var t0 = tca - thc;
 
-				// test to see if both t0 and t1 are behind the ray - if so, return null
-				if ( t0 < 0 && t1 < 0 ) return null;
+			// t1 = second intersect point - exit point on back of sphere
+			var t1 = tca + thc;
 
-				// test to see if t0 is behind the ray:
-				// if it is, the ray is inside the sphere, so return the second exit point scaled by t1,
-				// in order to always return an intersect point that is in front of the ray.
-				if ( t0 < 0 ) return this.at( t1, target );
+			// test to see if both t0 and t1 are behind the ray - if so, return null
+			if ( t0 < 0 && t1 < 0 ) return null;
 
-				// else t0 is in front of the ray, so return the first collision point scaled by t0
-				return this.at( t0, target );
+			// test to see if t0 is behind the ray:
+			// if it is, the ray is inside the sphere, so return the second exit point scaled by t1,
+			// in order to always return an intersect point that is in front of the ray.
+			if ( t0 < 0 ) return this.at( t1, target );
 
-			};
+			// else t0 is in front of the ray, so return the first collision point scaled by t0
+			return this.at( t0, target );
 
-		}(),
+		},
 
 		intersectsSphere: function ( sphere ) {
 
@@ -7394,100 +7371,86 @@ var Spacekit = (function (exports) {
 
 		},
 
-		intersectsBox: ( function () {
+		intersectsBox: function ( box ) {
 
-			var v = new Vector3();
+			return this.intersectBox( box, _vector$2 ) !== null;
 
-			return function intersectsBox( box ) {
+		},
 
-				return this.intersectBox( box, v ) !== null;
-
-			};
-
-		} )(),
-
-		intersectTriangle: function () {
+		intersectTriangle: function ( a, b, c, backfaceCulling, target ) {
 
 			// Compute the offset origin, edges, and normal.
-			var diff = new Vector3();
-			var edge1 = new Vector3();
-			var edge2 = new Vector3();
-			var normal = new Vector3();
 
-			return function intersectTriangle( a, b, c, backfaceCulling, target ) {
+			// from http://www.geometrictools.com/GTEngine/Include/Mathematics/GteIntrRay3Triangle3.h
 
-				// from http://www.geometrictools.com/GTEngine/Include/Mathematics/GteIntrRay3Triangle3.h
+			_edge1.subVectors( b, a );
+			_edge2.subVectors( c, a );
+			_normal.crossVectors( _edge1, _edge2 );
 
-				edge1.subVectors( b, a );
-				edge2.subVectors( c, a );
-				normal.crossVectors( edge1, edge2 );
+			// Solve Q + t*D = b1*E1 + b2*E2 (Q = kDiff, D = ray direction,
+			// E1 = kEdge1, E2 = kEdge2, N = Cross(E1,E2)) by
+			//   |Dot(D,N)|*b1 = sign(Dot(D,N))*Dot(D,Cross(Q,E2))
+			//   |Dot(D,N)|*b2 = sign(Dot(D,N))*Dot(D,Cross(E1,Q))
+			//   |Dot(D,N)|*t = -sign(Dot(D,N))*Dot(Q,N)
+			var DdN = this.direction.dot( _normal );
+			var sign;
 
-				// Solve Q + t*D = b1*E1 + b2*E2 (Q = kDiff, D = ray direction,
-				// E1 = kEdge1, E2 = kEdge2, N = Cross(E1,E2)) by
-				//   |Dot(D,N)|*b1 = sign(Dot(D,N))*Dot(D,Cross(Q,E2))
-				//   |Dot(D,N)|*b2 = sign(Dot(D,N))*Dot(D,Cross(E1,Q))
-				//   |Dot(D,N)|*t = -sign(Dot(D,N))*Dot(Q,N)
-				var DdN = this.direction.dot( normal );
-				var sign;
+			if ( DdN > 0 ) {
 
-				if ( DdN > 0 ) {
+				if ( backfaceCulling ) return null;
+				sign = 1;
 
-					if ( backfaceCulling ) return null;
-					sign = 1;
+			} else if ( DdN < 0 ) {
 
-				} else if ( DdN < 0 ) {
+				sign = - 1;
+				DdN = - DdN;
 
-					sign = - 1;
-					DdN = - DdN;
+			} else {
 
-				} else {
+				return null;
 
-					return null;
+			}
 
-				}
+			_diff.subVectors( this.origin, a );
+			var DdQxE2 = sign * this.direction.dot( _edge2.crossVectors( _diff, _edge2 ) );
 
-				diff.subVectors( this.origin, a );
-				var DdQxE2 = sign * this.direction.dot( edge2.crossVectors( diff, edge2 ) );
+			// b1 < 0, no intersection
+			if ( DdQxE2 < 0 ) {
 
-				// b1 < 0, no intersection
-				if ( DdQxE2 < 0 ) {
+				return null;
 
-					return null;
+			}
 
-				}
+			var DdE1xQ = sign * this.direction.dot( _edge1.cross( _diff ) );
 
-				var DdE1xQ = sign * this.direction.dot( edge1.cross( diff ) );
+			// b2 < 0, no intersection
+			if ( DdE1xQ < 0 ) {
 
-				// b2 < 0, no intersection
-				if ( DdE1xQ < 0 ) {
+				return null;
 
-					return null;
+			}
 
-				}
+			// b1+b2 > 1, no intersection
+			if ( DdQxE2 + DdE1xQ > DdN ) {
 
-				// b1+b2 > 1, no intersection
-				if ( DdQxE2 + DdE1xQ > DdN ) {
+				return null;
 
-					return null;
+			}
 
-				}
+			// Line intersects triangle, check if ray does.
+			var QdN = - sign * _diff.dot( _normal );
 
-				// Line intersects triangle, check if ray does.
-				var QdN = - sign * diff.dot( normal );
+			// t < 0, no intersection
+			if ( QdN < 0 ) {
 
-				// t < 0, no intersection
-				if ( QdN < 0 ) {
+				return null;
 
-					return null;
+			}
 
-				}
+			// Ray intersects triangle.
+			return this.at( QdN / DdN, target );
 
-				// Ray intersects triangle.
-				return this.at( QdN / DdN, target );
-
-			};
-
-		}(),
+		},
 
 		applyMatrix4: function ( matrix4 ) {
 
@@ -7508,8 +7471,246 @@ var Spacekit = (function (exports) {
 
 	/**
 	 * @author bhouston / http://clara.io
+	 */
+
+	var _vector1 = new Vector3();
+	var _vector2 = new Vector3();
+	var _normalMatrix = new Matrix3();
+
+	function Plane( normal, constant ) {
+
+		// normal is assumed to be normalized
+
+		this.normal = ( normal !== undefined ) ? normal : new Vector3( 1, 0, 0 );
+		this.constant = ( constant !== undefined ) ? constant : 0;
+
+	}
+
+	Object.assign( Plane.prototype, {
+
+		isPlane: true,
+
+		set: function ( normal, constant ) {
+
+			this.normal.copy( normal );
+			this.constant = constant;
+
+			return this;
+
+		},
+
+		setComponents: function ( x, y, z, w ) {
+
+			this.normal.set( x, y, z );
+			this.constant = w;
+
+			return this;
+
+		},
+
+		setFromNormalAndCoplanarPoint: function ( normal, point ) {
+
+			this.normal.copy( normal );
+			this.constant = - point.dot( this.normal );
+
+			return this;
+
+		},
+
+		setFromCoplanarPoints: function ( a, b, c ) {
+
+			var normal = _vector1.subVectors( c, b ).cross( _vector2.subVectors( a, b ) ).normalize();
+
+			// Q: should an error be thrown if normal is zero (e.g. degenerate plane)?
+
+			this.setFromNormalAndCoplanarPoint( normal, a );
+
+			return this;
+
+		},
+
+		clone: function () {
+
+			return new this.constructor().copy( this );
+
+		},
+
+		copy: function ( plane ) {
+
+			this.normal.copy( plane.normal );
+			this.constant = plane.constant;
+
+			return this;
+
+		},
+
+		normalize: function () {
+
+			// Note: will lead to a divide by zero if the plane is invalid.
+
+			var inverseNormalLength = 1.0 / this.normal.length();
+			this.normal.multiplyScalar( inverseNormalLength );
+			this.constant *= inverseNormalLength;
+
+			return this;
+
+		},
+
+		negate: function () {
+
+			this.constant *= - 1;
+			this.normal.negate();
+
+			return this;
+
+		},
+
+		distanceToPoint: function ( point ) {
+
+			return this.normal.dot( point ) + this.constant;
+
+		},
+
+		distanceToSphere: function ( sphere ) {
+
+			return this.distanceToPoint( sphere.center ) - sphere.radius;
+
+		},
+
+		projectPoint: function ( point, target ) {
+
+			if ( target === undefined ) {
+
+				console.warn( 'THREE.Plane: .projectPoint() target is now required' );
+				target = new Vector3();
+
+			}
+
+			return target.copy( this.normal ).multiplyScalar( - this.distanceToPoint( point ) ).add( point );
+
+		},
+
+		intersectLine: function ( line, target ) {
+
+			if ( target === undefined ) {
+
+				console.warn( 'THREE.Plane: .intersectLine() target is now required' );
+				target = new Vector3();
+
+			}
+
+			var direction = line.delta( _vector1 );
+
+			var denominator = this.normal.dot( direction );
+
+			if ( denominator === 0 ) {
+
+				// line is coplanar, return origin
+				if ( this.distanceToPoint( line.start ) === 0 ) {
+
+					return target.copy( line.start );
+
+				}
+
+				// Unsure if this is the correct method to handle this case.
+				return undefined;
+
+			}
+
+			var t = - ( line.start.dot( this.normal ) + this.constant ) / denominator;
+
+			if ( t < 0 || t > 1 ) {
+
+				return undefined;
+
+			}
+
+			return target.copy( direction ).multiplyScalar( t ).add( line.start );
+
+		},
+
+		intersectsLine: function ( line ) {
+
+			// Note: this tests if a line intersects the plane, not whether it (or its end-points) are coplanar with it.
+
+			var startSign = this.distanceToPoint( line.start );
+			var endSign = this.distanceToPoint( line.end );
+
+			return ( startSign < 0 && endSign > 0 ) || ( endSign < 0 && startSign > 0 );
+
+		},
+
+		intersectsBox: function ( box ) {
+
+			return box.intersectsPlane( this );
+
+		},
+
+		intersectsSphere: function ( sphere ) {
+
+			return sphere.intersectsPlane( this );
+
+		},
+
+		coplanarPoint: function ( target ) {
+
+			if ( target === undefined ) {
+
+				console.warn( 'THREE.Plane: .coplanarPoint() target is now required' );
+				target = new Vector3();
+
+			}
+
+			return target.copy( this.normal ).multiplyScalar( - this.constant );
+
+		},
+
+		applyMatrix4: function ( matrix, optionalNormalMatrix ) {
+
+			var normalMatrix = optionalNormalMatrix || _normalMatrix.getNormalMatrix( matrix );
+
+			var referencePoint = this.coplanarPoint( _vector1 ).applyMatrix4( matrix );
+
+			var normal = this.normal.applyMatrix3( normalMatrix ).normalize();
+
+			this.constant = - referencePoint.dot( normal );
+
+			return this;
+
+		},
+
+		translate: function ( offset ) {
+
+			this.constant -= offset.dot( this.normal );
+
+			return this;
+
+		},
+
+		equals: function ( plane ) {
+
+			return plane.normal.equals( this.normal ) && ( plane.constant === this.constant );
+
+		}
+
+	} );
+
+	/**
+	 * @author bhouston / http://clara.io
 	 * @author mrdoob / http://mrdoob.com/
 	 */
+
+	var _v0$1 = new Vector3();
+	var _v1$3 = new Vector3();
+	var _v2$1 = new Vector3();
+	var _v3 = new Vector3();
+
+	var _vab = new Vector3();
+	var _vac = new Vector3();
+	var _vbc = new Vector3();
+	var _vap = new Vector3();
+	var _vbp = new Vector3();
+	var _vcp = new Vector3();
 
 	function Triangle( a, b, c ) {
 
@@ -7521,134 +7722,101 @@ var Spacekit = (function (exports) {
 
 	Object.assign( Triangle, {
 
-		getNormal: function () {
+		getNormal: function ( a, b, c, target ) {
 
-			var v0 = new Vector3();
+			if ( target === undefined ) {
 
-			return function getNormal( a, b, c, target ) {
+				console.warn( 'THREE.Triangle: .getNormal() target is now required' );
+				target = new Vector3();
 
-				if ( target === undefined ) {
+			}
 
-					console.warn( 'THREE.Triangle: .getNormal() target is now required' );
-					target = new Vector3();
+			target.subVectors( c, b );
+			_v0$1.subVectors( a, b );
+			target.cross( _v0$1 );
 
-				}
+			var targetLengthSq = target.lengthSq();
+			if ( targetLengthSq > 0 ) {
 
-				target.subVectors( c, b );
-				v0.subVectors( a, b );
-				target.cross( v0 );
+				return target.multiplyScalar( 1 / Math.sqrt( targetLengthSq ) );
 
-				var targetLengthSq = target.lengthSq();
-				if ( targetLengthSq > 0 ) {
+			}
 
-					return target.multiplyScalar( 1 / Math.sqrt( targetLengthSq ) );
+			return target.set( 0, 0, 0 );
 
-				}
-
-				return target.set( 0, 0, 0 );
-
-			};
-
-		}(),
+		},
 
 		// static/instance method to calculate barycentric coordinates
 		// based on: http://www.blackpawn.com/texts/pointinpoly/default.html
-		getBarycoord: function () {
+		getBarycoord: function ( point, a, b, c, target ) {
 
-			var v0 = new Vector3();
-			var v1 = new Vector3();
-			var v2 = new Vector3();
+			_v0$1.subVectors( c, a );
+			_v1$3.subVectors( b, a );
+			_v2$1.subVectors( point, a );
 
-			return function getBarycoord( point, a, b, c, target ) {
+			var dot00 = _v0$1.dot( _v0$1 );
+			var dot01 = _v0$1.dot( _v1$3 );
+			var dot02 = _v0$1.dot( _v2$1 );
+			var dot11 = _v1$3.dot( _v1$3 );
+			var dot12 = _v1$3.dot( _v2$1 );
 
-				v0.subVectors( c, a );
-				v1.subVectors( b, a );
-				v2.subVectors( point, a );
+			var denom = ( dot00 * dot11 - dot01 * dot01 );
 
-				var dot00 = v0.dot( v0 );
-				var dot01 = v0.dot( v1 );
-				var dot02 = v0.dot( v2 );
-				var dot11 = v1.dot( v1 );
-				var dot12 = v1.dot( v2 );
+			if ( target === undefined ) {
 
-				var denom = ( dot00 * dot11 - dot01 * dot01 );
+				console.warn( 'THREE.Triangle: .getBarycoord() target is now required' );
+				target = new Vector3();
 
-				if ( target === undefined ) {
+			}
 
-					console.warn( 'THREE.Triangle: .getBarycoord() target is now required' );
-					target = new Vector3();
+			// collinear or singular triangle
+			if ( denom === 0 ) {
 
-				}
+				// arbitrary location outside of triangle?
+				// not sure if this is the best idea, maybe should be returning undefined
+				return target.set( - 2, - 1, - 1 );
 
-				// collinear or singular triangle
-				if ( denom === 0 ) {
+			}
 
-					// arbitrary location outside of triangle?
-					// not sure if this is the best idea, maybe should be returning undefined
-					return target.set( - 2, - 1, - 1 );
+			var invDenom = 1 / denom;
+			var u = ( dot11 * dot02 - dot01 * dot12 ) * invDenom;
+			var v = ( dot00 * dot12 - dot01 * dot02 ) * invDenom;
 
-				}
+			// barycentric coordinates must always sum to 1
+			return target.set( 1 - u - v, v, u );
 
-				var invDenom = 1 / denom;
-				var u = ( dot11 * dot02 - dot01 * dot12 ) * invDenom;
-				var v = ( dot00 * dot12 - dot01 * dot02 ) * invDenom;
+		},
 
-				// barycentric coordinates must always sum to 1
-				return target.set( 1 - u - v, v, u );
+		containsPoint: function ( point, a, b, c ) {
 
-			};
+			Triangle.getBarycoord( point, a, b, c, _v3 );
 
-		}(),
+			return ( _v3.x >= 0 ) && ( _v3.y >= 0 ) && ( ( _v3.x + _v3.y ) <= 1 );
 
-		containsPoint: function () {
+		},
 
-			var v1 = new Vector3();
+		getUV: function ( point, p1, p2, p3, uv1, uv2, uv3, target ) {
 
-			return function containsPoint( point, a, b, c ) {
+			this.getBarycoord( point, p1, p2, p3, _v3 );
 
-				Triangle.getBarycoord( point, a, b, c, v1 );
+			target.set( 0, 0 );
+			target.addScaledVector( uv1, _v3.x );
+			target.addScaledVector( uv2, _v3.y );
+			target.addScaledVector( uv3, _v3.z );
 
-				return ( v1.x >= 0 ) && ( v1.y >= 0 ) && ( ( v1.x + v1.y ) <= 1 );
+			return target;
 
-			};
+		},
 
-		}(),
+		isFrontFacing: function ( a, b, c, direction ) {
 
-		getUV: function () {
+			_v0$1.subVectors( c, b );
+			_v1$3.subVectors( a, b );
 
-			var barycoord = new Vector3();
+			// strictly front facing
+			return ( _v0$1.cross( _v1$3 ).dot( direction ) < 0 ) ? true : false;
 
-			return function getUV( point, p1, p2, p3, uv1, uv2, uv3, target ) {
-
-				this.getBarycoord( point, p1, p2, p3, barycoord );
-
-				target.set( 0, 0 );
-				target.addScaledVector( uv1, barycoord.x );
-				target.addScaledVector( uv2, barycoord.y );
-				target.addScaledVector( uv3, barycoord.z );
-
-				return target;
-
-			};
-
-		}(),
-
-		isFrontFacing: function () {
-
-			var v0 = new Vector3();
-			var v1 = new Vector3();
-
-			return function isFrontFacing( a, b, c, direction ) {
-
-				v0.subVectors( c, b );
-				v1.subVectors( a, b );
-
-				// strictly front facing
-				return ( v0.cross( v1 ).dot( direction ) < 0 ) ? true : false;
-
-			};
-
-		}()
+		}
 
 	} );
 
@@ -7692,19 +7860,12 @@ var Spacekit = (function (exports) {
 
 		getArea: function () {
 
-			var v0 = new Vector3();
-			var v1 = new Vector3();
+			_v0$1.subVectors( this.c, this.b );
+			_v1$3.subVectors( this.a, this.b );
 
-			return function getArea() {
+			return _v0$1.cross( _v1$3 ).length() * 0.5;
 
-				v0.subVectors( this.c, this.b );
-				v1.subVectors( this.a, this.b );
-
-				return v0.cross( v1 ).length() * 0.5;
-
-			};
-
-		}(),
+		},
 
 		getMidpoint: function ( target ) {
 
@@ -7730,7 +7891,7 @@ var Spacekit = (function (exports) {
 			if ( target === undefined ) {
 
 				console.warn( 'THREE.Triangle: .getPlane() target is now required' );
-				target = new Vector3();
+				target = new Plane();
 
 			}
 
@@ -7768,103 +7929,93 @@ var Spacekit = (function (exports) {
 
 		},
 
-		closestPointToPoint: function () {
+		closestPointToPoint: function ( p, target ) {
 
-			var vab = new Vector3();
-			var vac = new Vector3();
-			var vbc = new Vector3();
-			var vap = new Vector3();
-			var vbp = new Vector3();
-			var vcp = new Vector3();
+			if ( target === undefined ) {
 
-			return function closestPointToPoint( p, target ) {
+				console.warn( 'THREE.Triangle: .closestPointToPoint() target is now required' );
+				target = new Vector3();
 
-				if ( target === undefined ) {
+			}
 
-					console.warn( 'THREE.Triangle: .closestPointToPoint() target is now required' );
-					target = new Vector3();
+			var a = this.a, b = this.b, c = this.c;
+			var v, w;
 
-				}
+			// algorithm thanks to Real-Time Collision Detection by Christer Ericson,
+			// published by Morgan Kaufmann Publishers, (c) 2005 Elsevier Inc.,
+			// under the accompanying license; see chapter 5.1.5 for detailed explanation.
+			// basically, we're distinguishing which of the voronoi regions of the triangle
+			// the point lies in with the minimum amount of redundant computation.
 
-				var a = this.a, b = this.b, c = this.c;
-				var v, w;
+			_vab.subVectors( b, a );
+			_vac.subVectors( c, a );
+			_vap.subVectors( p, a );
+			var d1 = _vab.dot( _vap );
+			var d2 = _vac.dot( _vap );
+			if ( d1 <= 0 && d2 <= 0 ) {
 
-				// algorithm thanks to Real-Time Collision Detection by Christer Ericson,
-				// published by Morgan Kaufmann Publishers, (c) 2005 Elsevier Inc.,
-				// under the accompanying license; see chapter 5.1.5 for detailed explanation.
-				// basically, we're distinguishing which of the voronoi regions of the triangle
-				// the point lies in with the minimum amount of redundant computation.
+				// vertex region of A; barycentric coords (1, 0, 0)
+				return target.copy( a );
 
-				vab.subVectors( b, a );
-				vac.subVectors( c, a );
-				vap.subVectors( p, a );
-				var d1 = vab.dot( vap );
-				var d2 = vac.dot( vap );
-				if ( d1 <= 0 && d2 <= 0 ) {
+			}
 
-					// vertex region of A; barycentric coords (1, 0, 0)
-					return target.copy( a );
+			_vbp.subVectors( p, b );
+			var d3 = _vab.dot( _vbp );
+			var d4 = _vac.dot( _vbp );
+			if ( d3 >= 0 && d4 <= d3 ) {
 
-				}
+				// vertex region of B; barycentric coords (0, 1, 0)
+				return target.copy( b );
 
-				vbp.subVectors( p, b );
-				var d3 = vab.dot( vbp );
-				var d4 = vac.dot( vbp );
-				if ( d3 >= 0 && d4 <= d3 ) {
+			}
 
-					// vertex region of B; barycentric coords (0, 1, 0)
-					return target.copy( b );
+			var vc = d1 * d4 - d3 * d2;
+			if ( vc <= 0 && d1 >= 0 && d3 <= 0 ) {
 
-				}
+				v = d1 / ( d1 - d3 );
+				// edge region of AB; barycentric coords (1-v, v, 0)
+				return target.copy( a ).addScaledVector( _vab, v );
 
-				var vc = d1 * d4 - d3 * d2;
-				if ( vc <= 0 && d1 >= 0 && d3 <= 0 ) {
+			}
 
-					v = d1 / ( d1 - d3 );
-					// edge region of AB; barycentric coords (1-v, v, 0)
-					return target.copy( a ).addScaledVector( vab, v );
+			_vcp.subVectors( p, c );
+			var d5 = _vab.dot( _vcp );
+			var d6 = _vac.dot( _vcp );
+			if ( d6 >= 0 && d5 <= d6 ) {
 
-				}
+				// vertex region of C; barycentric coords (0, 0, 1)
+				return target.copy( c );
 
-				vcp.subVectors( p, c );
-				var d5 = vab.dot( vcp );
-				var d6 = vac.dot( vcp );
-				if ( d6 >= 0 && d5 <= d6 ) {
+			}
 
-					// vertex region of C; barycentric coords (0, 0, 1)
-					return target.copy( c );
+			var vb = d5 * d2 - d1 * d6;
+			if ( vb <= 0 && d2 >= 0 && d6 <= 0 ) {
 
-				}
+				w = d2 / ( d2 - d6 );
+				// edge region of AC; barycentric coords (1-w, 0, w)
+				return target.copy( a ).addScaledVector( _vac, w );
 
-				var vb = d5 * d2 - d1 * d6;
-				if ( vb <= 0 && d2 >= 0 && d6 <= 0 ) {
+			}
 
-					w = d2 / ( d2 - d6 );
-					// edge region of AC; barycentric coords (1-w, 0, w)
-					return target.copy( a ).addScaledVector( vac, w );
+			var va = d3 * d6 - d5 * d4;
+			if ( va <= 0 && ( d4 - d3 ) >= 0 && ( d5 - d6 ) >= 0 ) {
 
-				}
+				_vbc.subVectors( c, b );
+				w = ( d4 - d3 ) / ( ( d4 - d3 ) + ( d5 - d6 ) );
+				// edge region of BC; barycentric coords (0, 1-w, w)
+				return target.copy( b ).addScaledVector( _vbc, w ); // edge region of BC
 
-				var va = d3 * d6 - d5 * d4;
-				if ( va <= 0 && ( d4 - d3 ) >= 0 && ( d5 - d6 ) >= 0 ) {
+			}
 
-					vbc.subVectors( c, b );
-					w = ( d4 - d3 ) / ( ( d4 - d3 ) + ( d5 - d6 ) );
-					// edge region of BC; barycentric coords (0, 1-w, w)
-					return target.copy( b ).addScaledVector( vbc, w ); // edge region of BC
+			// face region
+			var denom = 1 / ( va + vb + vc );
+			// u = va * denom
+			v = vb * denom;
+			w = vc * denom;
 
-				}
+			return target.copy( a ).addScaledVector( _vab, v ).addScaledVector( _vac, w );
 
-				// face region
-				var denom = 1 / ( va + vb + vc );
-				// u = va * denom
-				v = vb * denom;
-				w = vc * denom;
-				return target.copy( a ).addScaledVector( vab, v ).addScaledVector( vac, w );
-
-			};
-
-		}(),
+		},
 
 		equals: function ( triangle ) {
 
@@ -7878,7 +8029,7 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-	var ColorKeywords = { 'aliceblue': 0xF0F8FF, 'antiquewhite': 0xFAEBD7, 'aqua': 0x00FFFF, 'aquamarine': 0x7FFFD4, 'azure': 0xF0FFFF,
+	var _colorKeywords = { 'aliceblue': 0xF0F8FF, 'antiquewhite': 0xFAEBD7, 'aqua': 0x00FFFF, 'aquamarine': 0x7FFFD4, 'azure': 0xF0FFFF,
 		'beige': 0xF5F5DC, 'bisque': 0xFFE4C4, 'black': 0x000000, 'blanchedalmond': 0xFFEBCD, 'blue': 0x0000FF, 'blueviolet': 0x8A2BE2,
 		'brown': 0xA52A2A, 'burlywood': 0xDEB887, 'cadetblue': 0x5F9EA0, 'chartreuse': 0x7FFF00, 'chocolate': 0xD2691E, 'coral': 0xFF7F50,
 		'cornflowerblue': 0x6495ED, 'cornsilk': 0xFFF8DC, 'crimson': 0xDC143C, 'cyan': 0x00FFFF, 'darkblue': 0x00008B, 'darkcyan': 0x008B8B,
@@ -7902,6 +8053,9 @@ var Spacekit = (function (exports) {
 		'sienna': 0xA0522D, 'silver': 0xC0C0C0, 'skyblue': 0x87CEEB, 'slateblue': 0x6A5ACD, 'slategray': 0x708090, 'slategrey': 0x708090, 'snow': 0xFFFAFA,
 		'springgreen': 0x00FF7F, 'steelblue': 0x4682B4, 'tan': 0xD2B48C, 'teal': 0x008080, 'thistle': 0xD8BFD8, 'tomato': 0xFF6347, 'turquoise': 0x40E0D0,
 		'violet': 0xEE82EE, 'wheat': 0xF5DEB3, 'white': 0xFFFFFF, 'whitesmoke': 0xF5F5F5, 'yellow': 0xFFFF00, 'yellowgreen': 0x9ACD32 };
+
+	var _hslA = { h: 0, s: 0, l: 0 };
+	var _hslB = { h: 0, s: 0, l: 0 };
 
 	function Color( r, g, b ) {
 
@@ -8000,9 +8154,9 @@ var Spacekit = (function (exports) {
 		setHSL: function ( h, s, l ) {
 
 			// h,s,l ranges are in 0.0 - 1.0
-			h = _Math.euclideanModulo( h, 1 );
-			s = _Math.clamp( s, 0, 1 );
-			l = _Math.clamp( l, 0, 1 );
+			h = MathUtils.euclideanModulo( h, 1 );
+			s = MathUtils.clamp( s, 0, 1 );
+			l = MathUtils.clamp( l, 0, 1 );
 
 			if ( s === 0 ) {
 
@@ -8132,20 +8286,28 @@ var Spacekit = (function (exports) {
 
 			if ( style && style.length > 0 ) {
 
-				// color keywords
-				var hex = ColorKeywords[ style ];
+				return this.setColorName( style );
 
-				if ( hex !== undefined ) {
+			}
 
-					// red
-					this.setHex( hex );
+			return this;
 
-				} else {
+		},
 
-					// unknown color
-					console.warn( 'THREE.Color: Unknown color ' + style );
+		setColorName: function ( style ) {
 
-				}
+			// color keywords
+			var hex = _colorKeywords[ style ];
+
+			if ( hex !== undefined ) {
+
+				// red
+				this.setHex( hex );
+
+			} else {
+
+				// unknown color
+				console.warn( 'THREE.Color: Unknown color ' + style );
 
 			}
 
@@ -8315,23 +8477,17 @@ var Spacekit = (function (exports) {
 
 		},
 
-		offsetHSL: function () {
+		offsetHSL: function ( h, s, l ) {
 
-			var hsl = {};
+			this.getHSL( _hslA );
 
-			return function ( h, s, l ) {
+			_hslA.h += h; _hslA.s += s; _hslA.l += l;
 
-				this.getHSL( hsl );
+			this.setHSL( _hslA.h, _hslA.s, _hslA.l );
 
-				hsl.h += h; hsl.s += s; hsl.l += l;
+			return this;
 
-				this.setHSL( hsl.h, hsl.s, hsl.l );
-
-				return this;
-
-			};
-
-		}(),
+		},
 
 		add: function ( color ) {
 
@@ -8403,27 +8559,20 @@ var Spacekit = (function (exports) {
 
 		},
 
-		lerpHSL: function () {
+		lerpHSL: function ( color, alpha ) {
 
-			var hslA = { h: 0, s: 0, l: 0 };
-			var hslB = { h: 0, s: 0, l: 0 };
+			this.getHSL( _hslA );
+			color.getHSL( _hslB );
 
-			return function lerpHSL( color, alpha ) {
+			var h = MathUtils.lerp( _hslA.h, _hslB.h, alpha );
+			var s = MathUtils.lerp( _hslA.s, _hslB.s, alpha );
+			var l = MathUtils.lerp( _hslA.l, _hslB.l, alpha );
 
-				this.getHSL( hslA );
-				color.getHSL( hslB );
+			this.setHSL( h, s, l );
 
-				var h = _Math.lerp( hslA.h, hslB.h, alpha );
-				var s = _Math.lerp( hslA.s, hslB.s, alpha );
-				var l = _Math.lerp( hslA.l, hslB.l, alpha );
+			return this;
 
-				this.setHSL( h, s, l );
-
-				return this;
-
-			};
-
-		}(),
+		},
 
 		equals: function ( c ) {
 
@@ -8463,6 +8612,8 @@ var Spacekit = (function (exports) {
 		}
 
 	} );
+
+	Color.NAMES = _colorKeywords;
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -8533,19 +8684,17 @@ var Spacekit = (function (exports) {
 
 		Object.defineProperty( this, 'id', { value: materialId ++ } );
 
-		this.uuid = _Math.generateUUID();
+		this.uuid = MathUtils.generateUUID();
 
 		this.name = '';
 		this.type = 'Material';
 
 		this.fog = true;
-		this.lights = true;
 
 		this.blending = NormalBlending;
 		this.side = FrontSide;
 		this.flatShading = false;
-		this.vertexTangents = false;
-		this.vertexColors = NoColors; // THREE.NoColors, THREE.VertexColors, THREE.FaceColors
+		this.vertexColors = false;
 
 		this.opacity = 1;
 		this.transparent = false;
@@ -8561,9 +8710,10 @@ var Spacekit = (function (exports) {
 		this.depthTest = true;
 		this.depthWrite = true;
 
+		this.stencilWriteMask = 0xff;
 		this.stencilFunc = AlwaysStencilFunc;
 		this.stencilRef = 0;
-		this.stencilMask = 0xff;
+		this.stencilFuncMask = 0xff;
 		this.stencilFail = KeepStencilOp;
 		this.stencilZFail = KeepStencilOp;
 		this.stencilZPass = KeepStencilOp;
@@ -8590,9 +8740,11 @@ var Spacekit = (function (exports) {
 
 		this.visible = true;
 
+		this.toneMapped = true;
+
 		this.userData = {};
 
-		this.needsUpdate = true;
+		this.version = 0;
 
 	}
 
@@ -8687,13 +8839,33 @@ var Spacekit = (function (exports) {
 			if ( this.roughness !== undefined ) data.roughness = this.roughness;
 			if ( this.metalness !== undefined ) data.metalness = this.metalness;
 
+			if ( this.sheen && this.sheen.isColor ) data.sheen = this.sheen.getHex();
 			if ( this.emissive && this.emissive.isColor ) data.emissive = this.emissive.getHex();
 			if ( this.emissiveIntensity && this.emissiveIntensity !== 1 ) data.emissiveIntensity = this.emissiveIntensity;
 
 			if ( this.specular && this.specular.isColor ) data.specular = this.specular.getHex();
 			if ( this.shininess !== undefined ) data.shininess = this.shininess;
-			if ( this.clearCoat !== undefined ) data.clearCoat = this.clearCoat;
-			if ( this.clearCoatRoughness !== undefined ) data.clearCoatRoughness = this.clearCoatRoughness;
+			if ( this.clearcoat !== undefined ) data.clearcoat = this.clearcoat;
+			if ( this.clearcoatRoughness !== undefined ) data.clearcoatRoughness = this.clearcoatRoughness;
+
+			if ( this.clearcoatMap && this.clearcoatMap.isTexture ) {
+
+				data.clearcoatMap = this.clearcoatMap.toJSON( meta ).uuid;
+
+			}
+
+			if ( this.clearcoatRoughnessMap && this.clearcoatRoughnessMap.isTexture ) {
+
+				data.clearcoatRoughnessMap = this.clearcoatRoughnessMap.toJSON( meta ).uuid;
+
+			}
+
+			if ( this.clearcoatNormalMap && this.clearcoatNormalMap.isTexture ) {
+
+				data.clearcoatNormalMap = this.clearcoatNormalMap.toJSON( meta ).uuid;
+				data.clearcoatNormalScale = this.clearcoatNormalScale.toArray();
+
+			}
 
 			if ( this.map && this.map.isTexture ) data.map = this.map.toJSON( meta ).uuid;
 			if ( this.matcap && this.matcap.isTexture ) data.matcap = this.matcap.toJSON( meta ).uuid;
@@ -8759,7 +8931,7 @@ var Spacekit = (function (exports) {
 			if ( this.blending !== NormalBlending ) data.blending = this.blending;
 			if ( this.flatShading === true ) data.flatShading = this.flatShading;
 			if ( this.side !== FrontSide ) data.side = this.side;
-			if ( this.vertexColors !== NoColors ) data.vertexColors = this.vertexColors;
+			if ( this.vertexColors ) data.vertexColors = true;
 
 			if ( this.opacity < 1 ) data.opacity = this.opacity;
 			if ( this.transparent === true ) data.transparent = this.transparent;
@@ -8769,9 +8941,10 @@ var Spacekit = (function (exports) {
 			data.depthWrite = this.depthWrite;
 
 			data.stencilWrite = this.stencilWrite;
+			data.stencilWriteMask = this.stencilWriteMask;
 			data.stencilFunc = this.stencilFunc;
 			data.stencilRef = this.stencilRef;
-			data.stencilMask = this.stencilMask;
+			data.stencilFuncMask = this.stencilFuncMask;
 			data.stencilFail = this.stencilFail;
 			data.stencilZFail = this.stencilZFail;
 			data.stencilZPass = this.stencilZPass;
@@ -8803,6 +8976,9 @@ var Spacekit = (function (exports) {
 			if ( this.skinning === true ) data.skinning = true;
 
 			if ( this.visible === false ) data.visible = false;
+
+			if ( this.toneMapped === false ) data.toneMapped = false;
+
 			if ( JSON.stringify( this.userData ) !== '{}' ) data.userData = this.userData;
 
 			// TODO: Copied from Object3D.toJSON
@@ -8848,7 +9024,6 @@ var Spacekit = (function (exports) {
 			this.name = source.name;
 
 			this.fog = source.fog;
-			this.lights = source.lights;
 
 			this.blending = source.blending;
 			this.side = source.side;
@@ -8869,32 +9044,14 @@ var Spacekit = (function (exports) {
 			this.depthTest = source.depthTest;
 			this.depthWrite = source.depthWrite;
 
-			this.stencilWrite = source.stencilWrite;
+			this.stencilWriteMask = source.stencilWriteMask;
 			this.stencilFunc = source.stencilFunc;
 			this.stencilRef = source.stencilRef;
-			this.stencilMask = source.stencilMask;
+			this.stencilFuncMask = source.stencilFuncMask;
 			this.stencilFail = source.stencilFail;
 			this.stencilZFail = source.stencilZFail;
 			this.stencilZPass = source.stencilZPass;
-
-			this.colorWrite = source.colorWrite;
-
-			this.precision = source.precision;
-
-			this.polygonOffset = source.polygonOffset;
-			this.polygonOffsetFactor = source.polygonOffsetFactor;
-			this.polygonOffsetUnits = source.polygonOffsetUnits;
-
-			this.dithering = source.dithering;
-
-			this.alphaTest = source.alphaTest;
-			this.premultipliedAlpha = source.premultipliedAlpha;
-
-			this.visible = source.visible;
-			this.userData = JSON.parse( JSON.stringify( source.userData ) );
-
-			this.clipShadows = source.clipShadows;
-			this.clipIntersection = source.clipIntersection;
+			this.stencilWrite = source.stencilWrite;
 
 			var srcPlanes = source.clippingPlanes,
 				dstPlanes = null;
@@ -8910,8 +9067,29 @@ var Spacekit = (function (exports) {
 			}
 
 			this.clippingPlanes = dstPlanes;
+			this.clipIntersection = source.clipIntersection;
+			this.clipShadows = source.clipShadows;
 
 			this.shadowSide = source.shadowSide;
+
+			this.colorWrite = source.colorWrite;
+
+			this.precision = source.precision;
+
+			this.polygonOffset = source.polygonOffset;
+			this.polygonOffsetFactor = source.polygonOffsetFactor;
+			this.polygonOffsetUnits = source.polygonOffsetUnits;
+
+			this.dithering = source.dithering;
+
+			this.alphaTest = source.alphaTest;
+			this.premultipliedAlpha = source.premultipliedAlpha;
+
+			this.visible = source.visible;
+
+			this.toneMapped = source.toneMapped;
+
+			this.userData = JSON.parse( JSON.stringify( source.userData ) );
 
 			return this;
 
@@ -8920,6 +9098,16 @@ var Spacekit = (function (exports) {
 		dispose: function () {
 
 			this.dispatchEvent( { type: 'dispose' } );
+
+		}
+
+	} );
+
+	Object.defineProperty( Material.prototype, 'needsUpdate', {
+
+		set: function ( value ) {
+
+			if ( value === true ) this.version ++;
 
 		}
 
@@ -8993,8 +9181,6 @@ var Spacekit = (function (exports) {
 		this.skinning = false;
 		this.morphTargets = false;
 
-		this.lights = false;
-
 		this.setValues( parameters );
 
 	}
@@ -9043,6 +9229,8 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
+	var _vector$3 = new Vector3();
+
 	function BufferAttribute( array, itemSize, normalized ) {
 
 		if ( Array.isArray( array ) ) {
@@ -9058,7 +9246,7 @@ var Spacekit = (function (exports) {
 		this.count = array !== undefined ? array.length / itemSize : 0;
 		this.normalized = normalized === true;
 
-		this.dynamic = false;
+		this.usage = StaticDrawUsage;
 		this.updateRange = { offset: 0, count: - 1 };
 
 		this.version = 0;
@@ -9081,24 +9269,9 @@ var Spacekit = (function (exports) {
 
 		onUploadCallback: function () {},
 
-		setArray: function ( array ) {
+		setUsage: function ( value ) {
 
-			if ( Array.isArray( array ) ) {
-
-				throw new TypeError( 'THREE.BufferAttribute: array should be a Typed Array.' );
-
-			}
-
-			this.count = array !== undefined ? array.length / this.itemSize : 0;
-			this.array = array;
-
-			return this;
-
-		},
-
-		setDynamic: function ( value ) {
-
-			this.dynamic = value;
+			this.usage = value;
 
 			return this;
 
@@ -9112,7 +9285,7 @@ var Spacekit = (function (exports) {
 			this.count = source.count;
 			this.normalized = source.normalized;
 
-			this.dynamic = source.dynamic;
+			this.usage = source.usage;
 
 			return this;
 
@@ -9234,6 +9407,78 @@ var Spacekit = (function (exports) {
 				array[ offset ++ ] = vector.y;
 				array[ offset ++ ] = vector.z;
 				array[ offset ++ ] = vector.w;
+
+			}
+
+			return this;
+
+		},
+
+		applyMatrix3: function ( m ) {
+
+			for ( var i = 0, l = this.count; i < l; i ++ ) {
+
+				_vector$3.x = this.getX( i );
+				_vector$3.y = this.getY( i );
+				_vector$3.z = this.getZ( i );
+
+				_vector$3.applyMatrix3( m );
+
+				this.setXYZ( i, _vector$3.x, _vector$3.y, _vector$3.z );
+
+			}
+
+			return this;
+
+		},
+
+		applyMatrix4: function ( m ) {
+
+			for ( var i = 0, l = this.count; i < l; i ++ ) {
+
+				_vector$3.x = this.getX( i );
+				_vector$3.y = this.getY( i );
+				_vector$3.z = this.getZ( i );
+
+				_vector$3.applyMatrix4( m );
+
+				this.setXYZ( i, _vector$3.x, _vector$3.y, _vector$3.z );
+
+			}
+
+			return this;
+
+		},
+
+		applyNormalMatrix: function ( m ) {
+
+			for ( var i = 0, l = this.count; i < l; i ++ ) {
+
+				_vector$3.x = this.getX( i );
+				_vector$3.y = this.getY( i );
+				_vector$3.z = this.getZ( i );
+
+				_vector$3.applyNormalMatrix( m );
+
+				this.setXYZ( i, _vector$3.x, _vector$3.y, _vector$3.z );
+
+			}
+
+			return this;
+
+		},
+
+		transformDirection: function ( m ) {
+
+			for ( var i = 0, l = this.count; i < l; i ++ ) {
+
+				_vector$3.x = this.getX( i );
+				_vector$3.y = this.getY( i );
+				_vector$3.z = this.getZ( i );
+
+				_vector$3.transformDirection( m );
+
+				this.setXYZ( i, _vector$3.x, _vector$3.y, _vector$3.z );
 
 			}
 
@@ -9768,13 +10013,20 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-	var bufferGeometryId = 1; // BufferGeometry uses odd numbers as Id
+	var _bufferGeometryId = 1; // BufferGeometry uses odd numbers as Id
+
+	var _m1$2 = new Matrix4();
+	var _obj = new Object3D();
+	var _offset = new Vector3();
+	var _box$2 = new Box3();
+	var _boxMorphTargets = new Box3();
+	var _vector$4 = new Vector3();
 
 	function BufferGeometry() {
 
-		Object.defineProperty( this, 'id', { value: bufferGeometryId += 2 } );
+		Object.defineProperty( this, 'id', { value: _bufferGeometryId += 2 } );
 
-		this.uuid = _Math.generateUUID();
+		this.uuid = MathUtils.generateUUID();
 
 		this.name = '';
 		this.type = 'BufferGeometry';
@@ -9783,6 +10035,7 @@ var Spacekit = (function (exports) {
 		this.attributes = {};
 
 		this.morphAttributes = {};
+		this.morphTargetsRelative = false;
 
 		this.groups = [];
 
@@ -9821,24 +10074,13 @@ var Spacekit = (function (exports) {
 
 		},
 
-		addAttribute: function ( name, attribute ) {
+		getAttribute: function ( name ) {
 
-			if ( ! ( attribute && attribute.isBufferAttribute ) && ! ( attribute && attribute.isInterleavedBufferAttribute ) ) {
+			return this.attributes[ name ];
 
-				console.warn( 'THREE.BufferGeometry: .addAttribute() now expects ( name, attribute ).' );
+		},
 
-				return this.addAttribute( name, new BufferAttribute( arguments[ 1 ], arguments[ 2 ] ) );
-
-			}
-
-			if ( name === 'index' ) {
-
-				console.warn( 'THREE.BufferGeometry.addAttribute: Use .setIndex() for index attribute.' );
-				this.setIndex( attribute );
-
-				return this;
-
-			}
+		setAttribute: function ( name, attribute ) {
 
 			this.attributes[ name ] = attribute;
 
@@ -9846,13 +10088,7 @@ var Spacekit = (function (exports) {
 
 		},
 
-		getAttribute: function ( name ) {
-
-			return this.attributes[ name ];
-
-		},
-
-		removeAttribute: function ( name ) {
+		deleteAttribute: function ( name ) {
 
 			delete this.attributes[ name ];
 
@@ -9885,13 +10121,14 @@ var Spacekit = (function (exports) {
 
 		},
 
-		applyMatrix: function ( matrix ) {
+		applyMatrix4: function ( matrix ) {
 
 			var position = this.attributes.position;
 
 			if ( position !== undefined ) {
 
-				matrix.applyToBufferAttribute( position );
+				position.applyMatrix4( matrix );
+
 				position.needsUpdate = true;
 
 			}
@@ -9902,7 +10139,8 @@ var Spacekit = (function (exports) {
 
 				var normalMatrix = new Matrix3().getNormalMatrix( matrix );
 
-				normalMatrix.applyToBufferAttribute( normal );
+				normal.applyNormalMatrix( normalMatrix );
+
 				normal.needsUpdate = true;
 
 			}
@@ -9911,10 +10149,8 @@ var Spacekit = (function (exports) {
 
 			if ( tangent !== undefined ) {
 
-				var normalMatrix = new Matrix3().getNormalMatrix( matrix );
+				tangent.transformDirection( matrix );
 
-				// Tangent is vec4, but the '.w' component is a sign value (+1/-1).
-				normalMatrix.applyToBufferAttribute( tangent );
 				tangent.needsUpdate = true;
 
 			}
@@ -9935,129 +10171,89 @@ var Spacekit = (function (exports) {
 
 		},
 
-		rotateX: function () {
+		rotateX: function ( angle ) {
 
 			// rotate geometry around world x-axis
 
-			var m1 = new Matrix4();
+			_m1$2.makeRotationX( angle );
 
-			return function rotateX( angle ) {
+			this.applyMatrix4( _m1$2 );
 
-				m1.makeRotationX( angle );
+			return this;
 
-				this.applyMatrix( m1 );
+		},
 
-				return this;
-
-			};
-
-		}(),
-
-		rotateY: function () {
+		rotateY: function ( angle ) {
 
 			// rotate geometry around world y-axis
 
-			var m1 = new Matrix4();
+			_m1$2.makeRotationY( angle );
 
-			return function rotateY( angle ) {
+			this.applyMatrix4( _m1$2 );
 
-				m1.makeRotationY( angle );
+			return this;
 
-				this.applyMatrix( m1 );
+		},
 
-				return this;
-
-			};
-
-		}(),
-
-		rotateZ: function () {
+		rotateZ: function ( angle ) {
 
 			// rotate geometry around world z-axis
 
-			var m1 = new Matrix4();
+			_m1$2.makeRotationZ( angle );
 
-			return function rotateZ( angle ) {
+			this.applyMatrix4( _m1$2 );
 
-				m1.makeRotationZ( angle );
+			return this;
 
-				this.applyMatrix( m1 );
+		},
 
-				return this;
-
-			};
-
-		}(),
-
-		translate: function () {
+		translate: function ( x, y, z ) {
 
 			// translate geometry
 
-			var m1 = new Matrix4();
+			_m1$2.makeTranslation( x, y, z );
 
-			return function translate( x, y, z ) {
+			this.applyMatrix4( _m1$2 );
 
-				m1.makeTranslation( x, y, z );
+			return this;
 
-				this.applyMatrix( m1 );
+		},
 
-				return this;
-
-			};
-
-		}(),
-
-		scale: function () {
+		scale: function ( x, y, z ) {
 
 			// scale geometry
 
-			var m1 = new Matrix4();
+			_m1$2.makeScale( x, y, z );
 
-			return function scale( x, y, z ) {
+			this.applyMatrix4( _m1$2 );
 
-				m1.makeScale( x, y, z );
+			return this;
 
-				this.applyMatrix( m1 );
+		},
 
-				return this;
+		lookAt: function ( vector ) {
 
-			};
+			_obj.lookAt( vector );
 
-		}(),
+			_obj.updateMatrix();
 
-		lookAt: function () {
+			this.applyMatrix4( _obj.matrix );
 
-			var obj = new Object3D();
+			return this;
 
-			return function lookAt( vector ) {
-
-				obj.lookAt( vector );
-
-				obj.updateMatrix();
-
-				this.applyMatrix( obj.matrix );
-
-			};
-
-		}(),
+		},
 
 		center: function () {
 
-			var offset = new Vector3();
+			this.computeBoundingBox();
 
-			return function center() {
+			this.boundingBox.getCenter( _offset ).negate();
 
-				this.computeBoundingBox();
+			this.translate( _offset.x, _offset.y, _offset.z );
 
-				this.boundingBox.getCenter( offset ).negate();
+			return this;
 
-				this.translate( offset.x, offset.y, offset.z );
-
-				return this;
-
-			};
-
-		}(),
+		},
 
 		setFromObject: function ( object ) {
 
@@ -10070,14 +10266,14 @@ var Spacekit = (function (exports) {
 				var positions = new Float32BufferAttribute( geometry.vertices.length * 3, 3 );
 				var colors = new Float32BufferAttribute( geometry.colors.length * 3, 3 );
 
-				this.addAttribute( 'position', positions.copyVector3sArray( geometry.vertices ) );
-				this.addAttribute( 'color', colors.copyColorsArray( geometry.colors ) );
+				this.setAttribute( 'position', positions.copyVector3sArray( geometry.vertices ) );
+				this.setAttribute( 'color', colors.copyColorsArray( geometry.colors ) );
 
 				if ( geometry.lineDistances && geometry.lineDistances.length === geometry.vertices.length ) {
 
 					var lineDistances = new Float32BufferAttribute( geometry.lineDistances.length, 1 );
 
-					this.addAttribute( 'lineDistance', lineDistances.copyArray( geometry.lineDistances ) );
+					this.setAttribute( 'lineDistance', lineDistances.copyArray( geometry.lineDistances ) );
 
 				}
 
@@ -10118,7 +10314,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			this.addAttribute( 'position', new Float32BufferAttribute( position, 3 ) );
+			this.setAttribute( 'position', new Float32BufferAttribute( position, 3 ) );
 
 			return this;
 
@@ -10262,33 +10458,33 @@ var Spacekit = (function (exports) {
 		fromDirectGeometry: function ( geometry ) {
 
 			var positions = new Float32Array( geometry.vertices.length * 3 );
-			this.addAttribute( 'position', new BufferAttribute( positions, 3 ).copyVector3sArray( geometry.vertices ) );
+			this.setAttribute( 'position', new BufferAttribute( positions, 3 ).copyVector3sArray( geometry.vertices ) );
 
 			if ( geometry.normals.length > 0 ) {
 
 				var normals = new Float32Array( geometry.normals.length * 3 );
-				this.addAttribute( 'normal', new BufferAttribute( normals, 3 ).copyVector3sArray( geometry.normals ) );
+				this.setAttribute( 'normal', new BufferAttribute( normals, 3 ).copyVector3sArray( geometry.normals ) );
 
 			}
 
 			if ( geometry.colors.length > 0 ) {
 
 				var colors = new Float32Array( geometry.colors.length * 3 );
-				this.addAttribute( 'color', new BufferAttribute( colors, 3 ).copyColorsArray( geometry.colors ) );
+				this.setAttribute( 'color', new BufferAttribute( colors, 3 ).copyColorsArray( geometry.colors ) );
 
 			}
 
 			if ( geometry.uvs.length > 0 ) {
 
 				var uvs = new Float32Array( geometry.uvs.length * 2 );
-				this.addAttribute( 'uv', new BufferAttribute( uvs, 2 ).copyVector2sArray( geometry.uvs ) );
+				this.setAttribute( 'uv', new BufferAttribute( uvs, 2 ).copyVector2sArray( geometry.uvs ) );
 
 			}
 
 			if ( geometry.uvs2.length > 0 ) {
 
 				var uvs2 = new Float32Array( geometry.uvs2.length * 2 );
-				this.addAttribute( 'uv2', new BufferAttribute( uvs2, 2 ).copyVector2sArray( geometry.uvs2 ) );
+				this.setAttribute( 'uv2', new BufferAttribute( uvs2, 2 ).copyVector2sArray( geometry.uvs2 ) );
 
 			}
 
@@ -10323,14 +10519,14 @@ var Spacekit = (function (exports) {
 			if ( geometry.skinIndices.length > 0 ) {
 
 				var skinIndices = new Float32BufferAttribute( geometry.skinIndices.length * 4, 4 );
-				this.addAttribute( 'skinIndex', skinIndices.copyVector4sArray( geometry.skinIndices ) );
+				this.setAttribute( 'skinIndex', skinIndices.copyVector4sArray( geometry.skinIndices ) );
 
 			}
 
 			if ( geometry.skinWeights.length > 0 ) {
 
 				var skinWeights = new Float32BufferAttribute( geometry.skinWeights.length * 4, 4 );
-				this.addAttribute( 'skinWeight', skinWeights.copyVector4sArray( geometry.skinWeights ) );
+				this.setAttribute( 'skinWeight', skinWeights.copyVector4sArray( geometry.skinWeights ) );
 
 			}
 
@@ -10354,144 +10550,162 @@ var Spacekit = (function (exports) {
 
 		computeBoundingBox: function () {
 
-			var box = new Box3();
+			if ( this.boundingBox === null ) {
 
-			return function computeBoundingBox() {
+				this.boundingBox = new Box3();
 
-				if ( this.boundingBox === null ) {
+			}
 
-					this.boundingBox = new Box3();
+			var position = this.attributes.position;
+			var morphAttributesPosition = this.morphAttributes.position;
 
-				}
+			if ( position !== undefined ) {
 
-				var position = this.attributes.position;
-				var morphAttributesPosition = this.morphAttributes.position;
+				this.boundingBox.setFromBufferAttribute( position );
 
-				if ( position !== undefined ) {
+				// process morph attributes if present
 
-					this.boundingBox.setFromBufferAttribute( position );
+				if ( morphAttributesPosition ) {
 
-					// process morph attributes if present
+					for ( var i = 0, il = morphAttributesPosition.length; i < il; i ++ ) {
 
-					if ( morphAttributesPosition ) {
+						var morphAttribute = morphAttributesPosition[ i ];
+						_box$2.setFromBufferAttribute( morphAttribute );
 
-						for ( var i = 0, il = morphAttributesPosition.length; i < il; i ++ ) {
+						if ( this.morphTargetsRelative ) {
 
-							var morphAttribute = morphAttributesPosition[ i ];
-							box.setFromBufferAttribute( morphAttribute );
+							_vector$4.addVectors( this.boundingBox.min, _box$2.min );
+							this.boundingBox.expandByPoint( _vector$4 );
 
-							this.boundingBox.expandByPoint( box.min );
-							this.boundingBox.expandByPoint( box.max );
+							_vector$4.addVectors( this.boundingBox.max, _box$2.max );
+							this.boundingBox.expandByPoint( _vector$4 );
+
+						} else {
+
+							this.boundingBox.expandByPoint( _box$2.min );
+							this.boundingBox.expandByPoint( _box$2.max );
 
 						}
 
 					}
 
-				} else {
-
-					this.boundingBox.makeEmpty();
-
 				}
 
-				if ( isNaN( this.boundingBox.min.x ) || isNaN( this.boundingBox.min.y ) || isNaN( this.boundingBox.min.z ) ) {
+			} else {
 
-					console.error( 'THREE.BufferGeometry.computeBoundingBox: Computed min/max have NaN values. The "position" attribute is likely to have NaN values.', this );
+				this.boundingBox.makeEmpty();
 
-				}
+			}
 
-			};
+			if ( isNaN( this.boundingBox.min.x ) || isNaN( this.boundingBox.min.y ) || isNaN( this.boundingBox.min.z ) ) {
 
-		}(),
+				console.error( 'THREE.BufferGeometry.computeBoundingBox: Computed min/max have NaN values. The "position" attribute is likely to have NaN values.', this );
+
+			}
+
+		},
 
 		computeBoundingSphere: function () {
 
-			var box = new Box3();
-			var boxMorphTargets = new Box3();
-			var vector = new Vector3();
+			if ( this.boundingSphere === null ) {
 
-			return function computeBoundingSphere() {
+				this.boundingSphere = new Sphere();
 
-				if ( this.boundingSphere === null ) {
+			}
 
-					this.boundingSphere = new Sphere();
+			var position = this.attributes.position;
+			var morphAttributesPosition = this.morphAttributes.position;
 
-				}
+			if ( position ) {
 
-				var position = this.attributes.position;
-				var morphAttributesPosition = this.morphAttributes.position;
+				// first, find the center of the bounding sphere
 
-				if ( position ) {
+				var center = this.boundingSphere.center;
 
-					// first, find the center of the bounding sphere
+				_box$2.setFromBufferAttribute( position );
 
-					var center = this.boundingSphere.center;
+				// process morph attributes if present
 
-					box.setFromBufferAttribute( position );
+				if ( morphAttributesPosition ) {
 
-					// process morph attributes if present
+					for ( var i = 0, il = morphAttributesPosition.length; i < il; i ++ ) {
 
-					if ( morphAttributesPosition ) {
+						var morphAttribute = morphAttributesPosition[ i ];
+						_boxMorphTargets.setFromBufferAttribute( morphAttribute );
 
-						for ( var i = 0, il = morphAttributesPosition.length; i < il; i ++ ) {
+						if ( this.morphTargetsRelative ) {
 
-							var morphAttribute = morphAttributesPosition[ i ];
-							boxMorphTargets.setFromBufferAttribute( morphAttribute );
+							_vector$4.addVectors( _box$2.min, _boxMorphTargets.min );
+							_box$2.expandByPoint( _vector$4 );
 
-							box.expandByPoint( boxMorphTargets.min );
-							box.expandByPoint( boxMorphTargets.max );
+							_vector$4.addVectors( _box$2.max, _boxMorphTargets.max );
+							_box$2.expandByPoint( _vector$4 );
+
+						} else {
+
+							_box$2.expandByPoint( _boxMorphTargets.min );
+							_box$2.expandByPoint( _boxMorphTargets.max );
 
 						}
 
 					}
 
-					box.getCenter( center );
+				}
 
-					// second, try to find a boundingSphere with a radius smaller than the
-					// boundingSphere of the boundingBox: sqrt(3) smaller in the best case
+				_box$2.getCenter( center );
 
-					var maxRadiusSq = 0;
+				// second, try to find a boundingSphere with a radius smaller than the
+				// boundingSphere of the boundingBox: sqrt(3) smaller in the best case
 
-					for ( var i = 0, il = position.count; i < il; i ++ ) {
+				var maxRadiusSq = 0;
 
-						vector.fromBufferAttribute( position, i );
+				for ( var i = 0, il = position.count; i < il; i ++ ) {
 
-						maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( vector ) );
+					_vector$4.fromBufferAttribute( position, i );
 
-					}
+					maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( _vector$4 ) );
 
-					// process morph attributes if present
+				}
 
-					if ( morphAttributesPosition ) {
+				// process morph attributes if present
 
-						for ( var i = 0, il = morphAttributesPosition.length; i < il; i ++ ) {
+				if ( morphAttributesPosition ) {
 
-							var morphAttribute = morphAttributesPosition[ i ];
+					for ( var i = 0, il = morphAttributesPosition.length; i < il; i ++ ) {
 
-							for ( var j = 0, jl = morphAttribute.count; j < jl; j ++ ) {
+						var morphAttribute = morphAttributesPosition[ i ];
+						var morphTargetsRelative = this.morphTargetsRelative;
 
-								vector.fromBufferAttribute( morphAttribute, j );
+						for ( var j = 0, jl = morphAttribute.count; j < jl; j ++ ) {
 
-								maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( vector ) );
+							_vector$4.fromBufferAttribute( morphAttribute, j );
+
+							if ( morphTargetsRelative ) {
+
+								_offset.fromBufferAttribute( position, j );
+								_vector$4.add( _offset );
 
 							}
 
+							maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( _vector$4 ) );
+
 						}
-
-					}
-
-					this.boundingSphere.radius = Math.sqrt( maxRadiusSq );
-
-					if ( isNaN( this.boundingSphere.radius ) ) {
-
-						console.error( 'THREE.BufferGeometry.computeBoundingSphere(): Computed radius is NaN. The "position" attribute is likely to have NaN values.', this );
 
 					}
 
 				}
 
-			};
+				this.boundingSphere.radius = Math.sqrt( maxRadiusSq );
 
-		}(),
+				if ( isNaN( this.boundingSphere.radius ) ) {
+
+					console.error( 'THREE.BufferGeometry.computeBoundingSphere(): Computed radius is NaN. The "position" attribute is likely to have NaN values.', this );
+
+				}
+
+			}
+
+		},
 
 		computeFaceNormals: function () {
 
@@ -10510,7 +10724,7 @@ var Spacekit = (function (exports) {
 
 				if ( attributes.normal === undefined ) {
 
-					this.addAttribute( 'normal', new BufferAttribute( new Float32Array( positions.length ), 3 ) );
+					this.setAttribute( 'normal', new BufferAttribute( new Float32Array( positions.length ), 3 ) );
 
 				} else {
 
@@ -10653,27 +10867,21 @@ var Spacekit = (function (exports) {
 
 		normalizeNormals: function () {
 
-			var vector = new Vector3();
+			var normals = this.attributes.normal;
 
-			return function normalizeNormals() {
+			for ( var i = 0, il = normals.count; i < il; i ++ ) {
 
-				var normals = this.attributes.normal;
+				_vector$4.x = normals.getX( i );
+				_vector$4.y = normals.getY( i );
+				_vector$4.z = normals.getZ( i );
 
-				for ( var i = 0, il = normals.count; i < il; i ++ ) {
+				_vector$4.normalize();
 
-					vector.x = normals.getX( i );
-					vector.y = normals.getY( i );
-					vector.z = normals.getZ( i );
+				normals.setXYZ( i, _vector$4.x, _vector$4.y, _vector$4.z );
 
-					vector.normalize();
+			}
 
-					normals.setXYZ( i, vector.x, vector.y, vector.z );
-
-				}
-
-			};
-
-		}(),
+		},
 
 		toNonIndexed: function () {
 
@@ -10724,7 +10932,7 @@ var Spacekit = (function (exports) {
 
 				var newAttribute = convertBufferAttribute( attribute, indices );
 
-				geometry2.addAttribute( name, newAttribute );
+				geometry2.setAttribute( name, newAttribute );
 
 			}
 
@@ -10750,6 +10958,8 @@ var Spacekit = (function (exports) {
 				geometry2.morphAttributes[ name ] = morphArray;
 
 			}
+
+			geometry2.morphTargetsRelative = this.morphTargetsRelative;
 
 			// groups
 
@@ -10855,7 +11065,12 @@ var Spacekit = (function (exports) {
 
 			}
 
-			if ( hasMorphAttributes ) data.data.morphAttributes = morphAttributes;
+			if ( hasMorphAttributes ) {
+
+				data.data.morphAttributes = morphAttributes;
+				data.data.morphTargetsRelative = this.morphTargetsRelative;
+
+			}
 
 			var groups = this.groups;
 
@@ -10944,7 +11159,7 @@ var Spacekit = (function (exports) {
 			for ( name in attributes ) {
 
 				var attribute = attributes[ name ];
-				this.addAttribute( name, attribute.clone() );
+				this.setAttribute( name, attribute.clone() );
 
 			}
 
@@ -10966,6 +11181,8 @@ var Spacekit = (function (exports) {
 				this.morphAttributes[ name ] = array;
 
 			}
+
+			this.morphTargetsRelative = source.morphTargetsRelative;
 
 			// groups
 
@@ -11026,6 +11243,29 @@ var Spacekit = (function (exports) {
 	 * @author jonobr1 / http://jonobr1.com/
 	 */
 
+	var _inverseMatrix = new Matrix4();
+	var _ray = new Ray();
+	var _sphere = new Sphere();
+
+	var _vA = new Vector3();
+	var _vB = new Vector3();
+	var _vC = new Vector3();
+
+	var _tempA = new Vector3();
+	var _tempB = new Vector3();
+	var _tempC = new Vector3();
+
+	var _morphA = new Vector3();
+	var _morphB = new Vector3();
+	var _morphC = new Vector3();
+
+	var _uvA = new Vector2();
+	var _uvB = new Vector2();
+	var _uvC = new Vector2();
+
+	var _intersectionPoint = new Vector3();
+	var _intersectionPointWorld = new Vector3();
+
 	function Mesh( geometry, material ) {
 
 		Object3D.call( this );
@@ -11033,9 +11273,7 @@ var Spacekit = (function (exports) {
 		this.type = 'Mesh';
 
 		this.geometry = geometry !== undefined ? geometry : new BufferGeometry();
-		this.material = material !== undefined ? material : new MeshBasicMaterial( { color: Math.random() * 0xffffff } );
-
-		this.drawMode = TrianglesDrawMode;
+		this.material = material !== undefined ? material : new MeshBasicMaterial();
 
 		this.updateMorphTargets();
 
@@ -11047,17 +11285,9 @@ var Spacekit = (function (exports) {
 
 		isMesh: true,
 
-		setDrawMode: function ( value ) {
-
-			this.drawMode = value;
-
-		},
-
 		copy: function ( source ) {
 
 			Object3D.prototype.copy.call( this, source );
-
-			this.drawMode = source.drawMode;
 
 			if ( source.morphTargetInfluences !== undefined ) {
 
@@ -11121,230 +11351,79 @@ var Spacekit = (function (exports) {
 
 		},
 
-		raycast: ( function () {
+		raycast: function ( raycaster, intersects ) {
 
-			var inverseMatrix = new Matrix4();
-			var ray = new Ray();
-			var sphere = new Sphere();
+			var geometry = this.geometry;
+			var material = this.material;
+			var matrixWorld = this.matrixWorld;
 
-			var vA = new Vector3();
-			var vB = new Vector3();
-			var vC = new Vector3();
+			if ( material === undefined ) return;
 
-			var tempA = new Vector3();
-			var tempB = new Vector3();
-			var tempC = new Vector3();
+			// Checking boundingSphere distance to ray
 
-			var morphA = new Vector3();
-			var morphB = new Vector3();
-			var morphC = new Vector3();
+			if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
 
-			var uvA = new Vector2();
-			var uvB = new Vector2();
-			var uvC = new Vector2();
+			_sphere.copy( geometry.boundingSphere );
+			_sphere.applyMatrix4( matrixWorld );
 
-			var intersectionPoint = new Vector3();
-			var intersectionPointWorld = new Vector3();
+			if ( raycaster.ray.intersectsSphere( _sphere ) === false ) return;
 
-			function checkIntersection( object, material, raycaster, ray, pA, pB, pC, point ) {
+			//
 
-				var intersect;
+			_inverseMatrix.getInverse( matrixWorld );
+			_ray.copy( raycaster.ray ).applyMatrix4( _inverseMatrix );
 
-				if ( material.side === BackSide ) {
+			// Check boundingBox before continuing
 
-					intersect = ray.intersectTriangle( pC, pB, pA, true, point );
+			if ( geometry.boundingBox !== null ) {
 
-				} else {
-
-					intersect = ray.intersectTriangle( pA, pB, pC, material.side !== DoubleSide, point );
-
-				}
-
-				if ( intersect === null ) return null;
-
-				intersectionPointWorld.copy( point );
-				intersectionPointWorld.applyMatrix4( object.matrixWorld );
-
-				var distance = raycaster.ray.origin.distanceTo( intersectionPointWorld );
-
-				if ( distance < raycaster.near || distance > raycaster.far ) return null;
-
-				return {
-					distance: distance,
-					point: intersectionPointWorld.clone(),
-					object: object
-				};
+				if ( _ray.intersectsBox( geometry.boundingBox ) === false ) return;
 
 			}
 
-			function checkBufferGeometryIntersection( object, material, raycaster, ray, position, morphPosition, uv, uv2, a, b, c ) {
+			var intersection;
 
-				vA.fromBufferAttribute( position, a );
-				vB.fromBufferAttribute( position, b );
-				vC.fromBufferAttribute( position, c );
+			if ( geometry.isBufferGeometry ) {
 
-				var morphInfluences = object.morphTargetInfluences;
+				var a, b, c;
+				var index = geometry.index;
+				var position = geometry.attributes.position;
+				var morphPosition = geometry.morphAttributes.position;
+				var morphTargetsRelative = geometry.morphTargetsRelative;
+				var uv = geometry.attributes.uv;
+				var uv2 = geometry.attributes.uv2;
+				var groups = geometry.groups;
+				var drawRange = geometry.drawRange;
+				var i, j, il, jl;
+				var group, groupMaterial;
+				var start, end;
 
-				if ( material.morphTargets && morphPosition && morphInfluences ) {
+				if ( index !== null ) {
 
-					morphA.set( 0, 0, 0 );
-					morphB.set( 0, 0, 0 );
-					morphC.set( 0, 0, 0 );
+					// indexed buffer geometry
 
-					for ( var i = 0, il = morphPosition.length; i < il; i ++ ) {
+					if ( Array.isArray( material ) ) {
 
-						var influence = morphInfluences[ i ];
-						var morphAttribute = morphPosition[ i ];
+						for ( i = 0, il = groups.length; i < il; i ++ ) {
 
-						if ( influence === 0 ) continue;
+							group = groups[ i ];
+							groupMaterial = material[ group.materialIndex ];
 
-						tempA.fromBufferAttribute( morphAttribute, a );
-						tempB.fromBufferAttribute( morphAttribute, b );
-						tempC.fromBufferAttribute( morphAttribute, c );
+							start = Math.max( group.start, drawRange.start );
+							end = Math.min( ( group.start + group.count ), ( drawRange.start + drawRange.count ) );
 
-						morphA.addScaledVector( tempA.sub( vA ), influence );
-						morphB.addScaledVector( tempB.sub( vB ), influence );
-						morphC.addScaledVector( tempC.sub( vC ), influence );
+							for ( j = start, jl = end; j < jl; j += 3 ) {
 
-					}
+								a = index.getX( j );
+								b = index.getX( j + 1 );
+								c = index.getX( j + 2 );
 
-					vA.add( morphA );
-					vB.add( morphB );
-					vC.add( morphC );
-
-				}
-
-				var intersection = checkIntersection( object, material, raycaster, ray, vA, vB, vC, intersectionPoint );
-
-				if ( intersection ) {
-
-					if ( uv ) {
-
-						uvA.fromBufferAttribute( uv, a );
-						uvB.fromBufferAttribute( uv, b );
-						uvC.fromBufferAttribute( uv, c );
-
-						intersection.uv = Triangle.getUV( intersectionPoint, vA, vB, vC, uvA, uvB, uvC, new Vector2() );
-
-					}
-
-					if ( uv2 ) {
-
-						uvA.fromBufferAttribute( uv2, a );
-						uvB.fromBufferAttribute( uv2, b );
-						uvC.fromBufferAttribute( uv2, c );
-
-						intersection.uv2 = Triangle.getUV( intersectionPoint, vA, vB, vC, uvA, uvB, uvC, new Vector2() );
-
-					}
-
-					var face = new Face3( a, b, c );
-					Triangle.getNormal( vA, vB, vC, face.normal );
-
-					intersection.face = face;
-
-				}
-
-				return intersection;
-
-			}
-
-			return function raycast( raycaster, intersects ) {
-
-				var geometry = this.geometry;
-				var material = this.material;
-				var matrixWorld = this.matrixWorld;
-
-				if ( material === undefined ) return;
-
-				// Checking boundingSphere distance to ray
-
-				if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
-
-				sphere.copy( geometry.boundingSphere );
-				sphere.applyMatrix4( matrixWorld );
-
-				if ( raycaster.ray.intersectsSphere( sphere ) === false ) return;
-
-				//
-
-				inverseMatrix.getInverse( matrixWorld );
-				ray.copy( raycaster.ray ).applyMatrix4( inverseMatrix );
-
-				// Check boundingBox before continuing
-
-				if ( geometry.boundingBox !== null ) {
-
-					if ( ray.intersectsBox( geometry.boundingBox ) === false ) return;
-
-				}
-
-				var intersection;
-
-				if ( geometry.isBufferGeometry ) {
-
-					var a, b, c;
-					var index = geometry.index;
-					var position = geometry.attributes.position;
-					var morphPosition = geometry.morphAttributes.position;
-					var uv = geometry.attributes.uv;
-					var uv2 = geometry.attributes.uv2;
-					var groups = geometry.groups;
-					var drawRange = geometry.drawRange;
-					var i, j, il, jl;
-					var group, groupMaterial;
-					var start, end;
-
-					if ( index !== null ) {
-
-						// indexed buffer geometry
-
-						if ( Array.isArray( material ) ) {
-
-							for ( i = 0, il = groups.length; i < il; i ++ ) {
-
-								group = groups[ i ];
-								groupMaterial = material[ group.materialIndex ];
-
-								start = Math.max( group.start, drawRange.start );
-								end = Math.min( ( group.start + group.count ), ( drawRange.start + drawRange.count ) );
-
-								for ( j = start, jl = end; j < jl; j += 3 ) {
-
-									a = index.getX( j );
-									b = index.getX( j + 1 );
-									c = index.getX( j + 2 );
-
-									intersection = checkBufferGeometryIntersection( this, groupMaterial, raycaster, ray, position, morphPosition, uv, uv2, a, b, c );
-
-									if ( intersection ) {
-
-										intersection.faceIndex = Math.floor( j / 3 ); // triangle number in indexed buffer semantics
-										intersection.face.materialIndex = group.materialIndex;
-										intersects.push( intersection );
-
-									}
-
-								}
-
-							}
-
-						} else {
-
-							start = Math.max( 0, drawRange.start );
-							end = Math.min( index.count, ( drawRange.start + drawRange.count ) );
-
-							for ( i = start, il = end; i < il; i += 3 ) {
-
-								a = index.getX( i );
-								b = index.getX( i + 1 );
-								c = index.getX( i + 2 );
-
-								intersection = checkBufferGeometryIntersection( this, material, raycaster, ray, position, morphPosition, uv, uv2, a, b, c );
+								intersection = checkBufferGeometryIntersection( this, groupMaterial, raycaster, _ray, position, morphPosition, morphTargetsRelative, uv, uv2, a, b, c );
 
 								if ( intersection ) {
 
-									intersection.faceIndex = Math.floor( i / 3 ); // triangle number in indexed buffer semantics
+									intersection.faceIndex = Math.floor( j / 3 ); // triangle number in indexed buffer semantics
+									intersection.face.materialIndex = group.materialIndex;
 									intersects.push( intersection );
 
 								}
@@ -11353,56 +11432,56 @@ var Spacekit = (function (exports) {
 
 						}
 
-					} else if ( position !== undefined ) {
+					} else {
 
-						// non-indexed buffer geometry
+						start = Math.max( 0, drawRange.start );
+						end = Math.min( index.count, ( drawRange.start + drawRange.count ) );
 
-						if ( Array.isArray( material ) ) {
+						for ( i = start, il = end; i < il; i += 3 ) {
 
-							for ( i = 0, il = groups.length; i < il; i ++ ) {
+							a = index.getX( i );
+							b = index.getX( i + 1 );
+							c = index.getX( i + 2 );
 
-								group = groups[ i ];
-								groupMaterial = material[ group.materialIndex ];
+							intersection = checkBufferGeometryIntersection( this, material, raycaster, _ray, position, morphPosition, morphTargetsRelative, uv, uv2, a, b, c );
 
-								start = Math.max( group.start, drawRange.start );
-								end = Math.min( ( group.start + group.count ), ( drawRange.start + drawRange.count ) );
+							if ( intersection ) {
 
-								for ( j = start, jl = end; j < jl; j += 3 ) {
-
-									a = j;
-									b = j + 1;
-									c = j + 2;
-
-									intersection = checkBufferGeometryIntersection( this, groupMaterial, raycaster, ray, position, morphPosition, uv, uv2, a, b, c );
-
-									if ( intersection ) {
-
-										intersection.faceIndex = Math.floor( j / 3 ); // triangle number in non-indexed buffer semantics
-										intersection.face.materialIndex = group.materialIndex;
-										intersects.push( intersection );
-
-									}
-
-								}
+								intersection.faceIndex = Math.floor( i / 3 ); // triangle number in indexed buffer semantics
+								intersects.push( intersection );
 
 							}
 
-						} else {
+						}
 
-							start = Math.max( 0, drawRange.start );
-							end = Math.min( position.count, ( drawRange.start + drawRange.count ) );
+					}
 
-							for ( i = start, il = end; i < il; i += 3 ) {
+				} else if ( position !== undefined ) {
 
-								a = i;
-								b = i + 1;
-								c = i + 2;
+					// non-indexed buffer geometry
 
-								intersection = checkBufferGeometryIntersection( this, material, raycaster, ray, position, morphPosition, uv, uv2, a, b, c );
+					if ( Array.isArray( material ) ) {
+
+						for ( i = 0, il = groups.length; i < il; i ++ ) {
+
+							group = groups[ i ];
+							groupMaterial = material[ group.materialIndex ];
+
+							start = Math.max( group.start, drawRange.start );
+							end = Math.min( ( group.start + group.count ), ( drawRange.start + drawRange.count ) );
+
+							for ( j = start, jl = end; j < jl; j += 3 ) {
+
+								a = j;
+								b = j + 1;
+								c = j + 2;
+
+								intersection = checkBufferGeometryIntersection( this, groupMaterial, raycaster, _ray, position, morphPosition, morphTargetsRelative, uv, uv2, a, b, c );
 
 								if ( intersection ) {
 
-									intersection.faceIndex = Math.floor( i / 3 ); // triangle number in non-indexed buffer semantics
+									intersection.faceIndex = Math.floor( j / 3 ); // triangle number in non-indexed buffer semantics
+									intersection.face.materialIndex = group.materialIndex;
 									intersects.push( intersection );
 
 								}
@@ -11411,49 +11490,25 @@ var Spacekit = (function (exports) {
 
 						}
 
-					}
+					} else {
 
-				} else if ( geometry.isGeometry ) {
+						start = Math.max( 0, drawRange.start );
+						end = Math.min( position.count, ( drawRange.start + drawRange.count ) );
 
-					var fvA, fvB, fvC;
-					var isMultiMaterial = Array.isArray( material );
+						for ( i = start, il = end; i < il; i += 3 ) {
 
-					var vertices = geometry.vertices;
-					var faces = geometry.faces;
-					var uvs;
+							a = i;
+							b = i + 1;
+							c = i + 2;
 
-					var faceVertexUvs = geometry.faceVertexUvs[ 0 ];
-					if ( faceVertexUvs.length > 0 ) uvs = faceVertexUvs;
+							intersection = checkBufferGeometryIntersection( this, material, raycaster, _ray, position, morphPosition, morphTargetsRelative, uv, uv2, a, b, c );
 
-					for ( var f = 0, fl = faces.length; f < fl; f ++ ) {
+							if ( intersection ) {
 
-						var face = faces[ f ];
-						var faceMaterial = isMultiMaterial ? material[ face.materialIndex ] : material;
-
-						if ( faceMaterial === undefined ) continue;
-
-						fvA = vertices[ face.a ];
-						fvB = vertices[ face.b ];
-						fvC = vertices[ face.c ];
-
-						intersection = checkIntersection( this, faceMaterial, raycaster, ray, fvA, fvB, fvC, intersectionPoint );
-
-						if ( intersection ) {
-
-							if ( uvs && uvs[ f ] ) {
-
-								var uvs_f = uvs[ f ];
-								uvA.copy( uvs_f[ 0 ] );
-								uvB.copy( uvs_f[ 1 ] );
-								uvC.copy( uvs_f[ 2 ] );
-
-								intersection.uv = Triangle.getUV( intersectionPoint, fvA, fvB, fvC, uvA, uvB, uvC, new Vector2() );
+								intersection.faceIndex = Math.floor( i / 3 ); // triangle number in non-indexed buffer semantics
+								intersects.push( intersection );
 
 							}
-
-							intersection.face = face;
-							intersection.faceIndex = f;
-							intersects.push( intersection );
 
 						}
 
@@ -11461,9 +11516,55 @@ var Spacekit = (function (exports) {
 
 				}
 
-			};
+			} else if ( geometry.isGeometry ) {
 
-		}() ),
+				var fvA, fvB, fvC;
+				var isMultiMaterial = Array.isArray( material );
+
+				var vertices = geometry.vertices;
+				var faces = geometry.faces;
+				var uvs;
+
+				var faceVertexUvs = geometry.faceVertexUvs[ 0 ];
+				if ( faceVertexUvs.length > 0 ) uvs = faceVertexUvs;
+
+				for ( var f = 0, fl = faces.length; f < fl; f ++ ) {
+
+					var face = faces[ f ];
+					var faceMaterial = isMultiMaterial ? material[ face.materialIndex ] : material;
+
+					if ( faceMaterial === undefined ) continue;
+
+					fvA = vertices[ face.a ];
+					fvB = vertices[ face.b ];
+					fvC = vertices[ face.c ];
+
+					intersection = checkIntersection( this, faceMaterial, raycaster, _ray, fvA, fvB, fvC, _intersectionPoint );
+
+					if ( intersection ) {
+
+						if ( uvs && uvs[ f ] ) {
+
+							var uvs_f = uvs[ f ];
+							_uvA.copy( uvs_f[ 0 ] );
+							_uvB.copy( uvs_f[ 1 ] );
+							_uvC.copy( uvs_f[ 2 ] );
+
+							intersection.uv = Triangle.getUV( _intersectionPoint, fvA, fvB, fvC, _uvA, _uvB, _uvC, new Vector2() );
+
+						}
+
+						intersection.face = face;
+						intersection.faceIndex = f;
+						intersects.push( intersection );
+
+					}
+
+				}
+
+			}
+
+		},
 
 		clone: function () {
 
@@ -11472,6 +11573,127 @@ var Spacekit = (function (exports) {
 		}
 
 	} );
+
+	function checkIntersection( object, material, raycaster, ray, pA, pB, pC, point ) {
+
+		var intersect;
+
+		if ( material.side === BackSide ) {
+
+			intersect = ray.intersectTriangle( pC, pB, pA, true, point );
+
+		} else {
+
+			intersect = ray.intersectTriangle( pA, pB, pC, material.side !== DoubleSide, point );
+
+		}
+
+		if ( intersect === null ) return null;
+
+		_intersectionPointWorld.copy( point );
+		_intersectionPointWorld.applyMatrix4( object.matrixWorld );
+
+		var distance = raycaster.ray.origin.distanceTo( _intersectionPointWorld );
+
+		if ( distance < raycaster.near || distance > raycaster.far ) return null;
+
+		return {
+			distance: distance,
+			point: _intersectionPointWorld.clone(),
+			object: object
+		};
+
+	}
+
+	function checkBufferGeometryIntersection( object, material, raycaster, ray, position, morphPosition, morphTargetsRelative, uv, uv2, a, b, c ) {
+
+		_vA.fromBufferAttribute( position, a );
+		_vB.fromBufferAttribute( position, b );
+		_vC.fromBufferAttribute( position, c );
+
+		var morphInfluences = object.morphTargetInfluences;
+
+		if ( material.morphTargets && morphPosition && morphInfluences ) {
+
+			_morphA.set( 0, 0, 0 );
+			_morphB.set( 0, 0, 0 );
+			_morphC.set( 0, 0, 0 );
+
+			for ( var i = 0, il = morphPosition.length; i < il; i ++ ) {
+
+				var influence = morphInfluences[ i ];
+				var morphAttribute = morphPosition[ i ];
+
+				if ( influence === 0 ) continue;
+
+				_tempA.fromBufferAttribute( morphAttribute, a );
+				_tempB.fromBufferAttribute( morphAttribute, b );
+				_tempC.fromBufferAttribute( morphAttribute, c );
+
+				if ( morphTargetsRelative ) {
+
+					_morphA.addScaledVector( _tempA, influence );
+					_morphB.addScaledVector( _tempB, influence );
+					_morphC.addScaledVector( _tempC, influence );
+
+				} else {
+
+					_morphA.addScaledVector( _tempA.sub( _vA ), influence );
+					_morphB.addScaledVector( _tempB.sub( _vB ), influence );
+					_morphC.addScaledVector( _tempC.sub( _vC ), influence );
+
+				}
+
+			}
+
+			_vA.add( _morphA );
+			_vB.add( _morphB );
+			_vC.add( _morphC );
+
+		}
+
+		if ( object.isSkinnedMesh ) {
+
+			object.boneTransform( a, _vA );
+			object.boneTransform( b, _vB );
+			object.boneTransform( c, _vC );
+
+		}
+
+		var intersection = checkIntersection( object, material, raycaster, ray, _vA, _vB, _vC, _intersectionPoint );
+
+		if ( intersection ) {
+
+			if ( uv ) {
+
+				_uvA.fromBufferAttribute( uv, a );
+				_uvB.fromBufferAttribute( uv, b );
+				_uvC.fromBufferAttribute( uv, c );
+
+				intersection.uv = Triangle.getUV( _intersectionPoint, _vA, _vB, _vC, _uvA, _uvB, _uvC, new Vector2() );
+
+			}
+
+			if ( uv2 ) {
+
+				_uvA.fromBufferAttribute( uv2, a );
+				_uvB.fromBufferAttribute( uv2, b );
+				_uvC.fromBufferAttribute( uv2, c );
+
+				intersection.uv2 = Triangle.getUV( _intersectionPoint, _vA, _vB, _vC, _uvA, _uvB, _uvC, new Vector2() );
+
+			}
+
+			var face = new Face3( a, b, c );
+			Triangle.getNormal( _vA, _vB, _vC, face.normal );
+
+			intersection.face = face;
+
+		}
+
+		return intersection;
+
+	}
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -11482,13 +11704,16 @@ var Spacekit = (function (exports) {
 	 * @author bhouston / http://clara.io
 	 */
 
-	var geometryId = 0; // Geometry uses even numbers as Id
+	var _geometryId = 0; // Geometry uses even numbers as Id
+	var _m1$3 = new Matrix4();
+	var _obj$1 = new Object3D();
+	var _offset$1 = new Vector3();
 
 	function Geometry() {
 
-		Object.defineProperty( this, 'id', { value: geometryId += 2 } );
+		Object.defineProperty( this, 'id', { value: _geometryId += 2 } );
 
-		this.uuid = _Math.generateUUID();
+		this.uuid = MathUtils.generateUUID();
 
 		this.name = '';
 		this.type = 'Geometry';
@@ -11527,7 +11752,7 @@ var Spacekit = (function (exports) {
 
 		isGeometry: true,
 
-		applyMatrix: function ( matrix ) {
+		applyMatrix4: function ( matrix ) {
 
 			var normalMatrix = new Matrix3().getNormalMatrix( matrix );
 
@@ -11570,111 +11795,77 @@ var Spacekit = (function (exports) {
 
 		},
 
-		rotateX: function () {
+		rotateX: function ( angle ) {
 
 			// rotate geometry around world x-axis
 
-			var m1 = new Matrix4();
+			_m1$3.makeRotationX( angle );
 
-			return function rotateX( angle ) {
+			this.applyMatrix4( _m1$3 );
 
-				m1.makeRotationX( angle );
+			return this;
 
-				this.applyMatrix( m1 );
+		},
 
-				return this;
-
-			};
-
-		}(),
-
-		rotateY: function () {
+		rotateY: function ( angle ) {
 
 			// rotate geometry around world y-axis
 
-			var m1 = new Matrix4();
+			_m1$3.makeRotationY( angle );
 
-			return function rotateY( angle ) {
+			this.applyMatrix4( _m1$3 );
 
-				m1.makeRotationY( angle );
+			return this;
 
-				this.applyMatrix( m1 );
+		},
 
-				return this;
-
-			};
-
-		}(),
-
-		rotateZ: function () {
+		rotateZ: function ( angle ) {
 
 			// rotate geometry around world z-axis
 
-			var m1 = new Matrix4();
+			_m1$3.makeRotationZ( angle );
 
-			return function rotateZ( angle ) {
+			this.applyMatrix4( _m1$3 );
 
-				m1.makeRotationZ( angle );
+			return this;
 
-				this.applyMatrix( m1 );
+		},
 
-				return this;
-
-			};
-
-		}(),
-
-		translate: function () {
+		translate: function ( x, y, z ) {
 
 			// translate geometry
 
-			var m1 = new Matrix4();
+			_m1$3.makeTranslation( x, y, z );
 
-			return function translate( x, y, z ) {
+			this.applyMatrix4( _m1$3 );
 
-				m1.makeTranslation( x, y, z );
+			return this;
 
-				this.applyMatrix( m1 );
+		},
 
-				return this;
-
-			};
-
-		}(),
-
-		scale: function () {
+		scale: function ( x, y, z ) {
 
 			// scale geometry
 
-			var m1 = new Matrix4();
+			_m1$3.makeScale( x, y, z );
 
-			return function scale( x, y, z ) {
+			this.applyMatrix4( _m1$3 );
 
-				m1.makeScale( x, y, z );
+			return this;
 
-				this.applyMatrix( m1 );
+		},
 
-				return this;
+		lookAt: function ( vector ) {
 
-			};
+			_obj$1.lookAt( vector );
 
-		}(),
+			_obj$1.updateMatrix();
 
-		lookAt: function () {
+			this.applyMatrix4( _obj$1.matrix );
 
-			var obj = new Object3D();
+			return this;
 
-			return function lookAt( vector ) {
-
-				obj.lookAt( vector );
-
-				obj.updateMatrix();
-
-				this.applyMatrix( obj.matrix );
-
-			};
-
-		}(),
+		},
 
 		fromBufferGeometry: function ( geometry ) {
 
@@ -11682,6 +11873,13 @@ var Spacekit = (function (exports) {
 
 			var indices = geometry.index !== null ? geometry.index.array : undefined;
 			var attributes = geometry.attributes;
+
+			if ( attributes.position === undefined ) {
+
+				console.error( 'THREE.Geometry.fromBufferGeometry(): Position attribute required for conversion.' );
+				return this;
+
+			}
 
 			var positions = attributes.position.array;
 			var normals = attributes.normal !== undefined ? attributes.normal.array : undefined;
@@ -11811,21 +12009,15 @@ var Spacekit = (function (exports) {
 
 		center: function () {
 
-			var offset = new Vector3();
+			this.computeBoundingBox();
 
-			return function center() {
+			this.boundingBox.getCenter( _offset$1 ).negate();
 
-				this.computeBoundingBox();
+			this.translate( _offset$1.x, _offset$1.y, _offset$1.z );
 
-				this.boundingBox.getCenter( offset ).negate();
+			return this;
 
-				this.translate( offset.x, offset.y, offset.z );
-
-				return this;
-
-			};
-
-		}(),
+		},
 
 		normalize: function () {
 
@@ -11844,7 +12036,7 @@ var Spacekit = (function (exports) {
 				0, 0, 0, 1
 			);
 
-			this.applyMatrix( matrix );
+			this.applyMatrix4( matrix );
 
 			return this;
 
@@ -12901,194 +13093,196 @@ var Spacekit = (function (exports) {
 
 	// BoxGeometry
 
-	function BoxGeometry( width, height, depth, widthSegments, heightSegments, depthSegments ) {
+	class BoxGeometry extends Geometry {
 
-		Geometry.call( this );
+		constructor( width, height, depth, widthSegments, heightSegments, depthSegments ) {
 
-		this.type = 'BoxGeometry';
+			super();
 
-		this.parameters = {
-			width: width,
-			height: height,
-			depth: depth,
-			widthSegments: widthSegments,
-			heightSegments: heightSegments,
-			depthSegments: depthSegments
-		};
+			this.type = 'BoxGeometry';
 
-		this.fromBufferGeometry( new BoxBufferGeometry( width, height, depth, widthSegments, heightSegments, depthSegments ) );
-		this.mergeVertices();
+			this.parameters = {
+				width: width,
+				height: height,
+				depth: depth,
+				widthSegments: widthSegments,
+				heightSegments: heightSegments,
+				depthSegments: depthSegments
+			};
 
-	}
-
-	BoxGeometry.prototype = Object.create( Geometry.prototype );
-	BoxGeometry.prototype.constructor = BoxGeometry;
-
-	// BoxBufferGeometry
-
-	function BoxBufferGeometry( width, height, depth, widthSegments, heightSegments, depthSegments ) {
-
-		BufferGeometry.call( this );
-
-		this.type = 'BoxBufferGeometry';
-
-		this.parameters = {
-			width: width,
-			height: height,
-			depth: depth,
-			widthSegments: widthSegments,
-			heightSegments: heightSegments,
-			depthSegments: depthSegments
-		};
-
-		var scope = this;
-
-		width = width || 1;
-		height = height || 1;
-		depth = depth || 1;
-
-		// segments
-
-		widthSegments = Math.floor( widthSegments ) || 1;
-		heightSegments = Math.floor( heightSegments ) || 1;
-		depthSegments = Math.floor( depthSegments ) || 1;
-
-		// buffers
-
-		var indices = [];
-		var vertices = [];
-		var normals = [];
-		var uvs = [];
-
-		// helper variables
-
-		var numberOfVertices = 0;
-		var groupStart = 0;
-
-		// build each side of the box geometry
-
-		buildPlane( 'z', 'y', 'x', - 1, - 1, depth, height, width, depthSegments, heightSegments, 0 ); // px
-		buildPlane( 'z', 'y', 'x', 1, - 1, depth, height, - width, depthSegments, heightSegments, 1 ); // nx
-		buildPlane( 'x', 'z', 'y', 1, 1, width, depth, height, widthSegments, depthSegments, 2 ); // py
-		buildPlane( 'x', 'z', 'y', 1, - 1, width, depth, - height, widthSegments, depthSegments, 3 ); // ny
-		buildPlane( 'x', 'y', 'z', 1, - 1, width, height, depth, widthSegments, heightSegments, 4 ); // pz
-		buildPlane( 'x', 'y', 'z', - 1, - 1, width, height, - depth, widthSegments, heightSegments, 5 ); // nz
-
-		// build geometry
-
-		this.setIndex( indices );
-		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
-
-		function buildPlane( u, v, w, udir, vdir, width, height, depth, gridX, gridY, materialIndex ) {
-
-			var segmentWidth = width / gridX;
-			var segmentHeight = height / gridY;
-
-			var widthHalf = width / 2;
-			var heightHalf = height / 2;
-			var depthHalf = depth / 2;
-
-			var gridX1 = gridX + 1;
-			var gridY1 = gridY + 1;
-
-			var vertexCounter = 0;
-			var groupCount = 0;
-
-			var ix, iy;
-
-			var vector = new Vector3();
-
-			// generate vertices, normals and uvs
-
-			for ( iy = 0; iy < gridY1; iy ++ ) {
-
-				var y = iy * segmentHeight - heightHalf;
-
-				for ( ix = 0; ix < gridX1; ix ++ ) {
-
-					var x = ix * segmentWidth - widthHalf;
-
-					// set values to correct vector component
-
-					vector[ u ] = x * udir;
-					vector[ v ] = y * vdir;
-					vector[ w ] = depthHalf;
-
-					// now apply vector to vertex buffer
-
-					vertices.push( vector.x, vector.y, vector.z );
-
-					// set values to correct vector component
-
-					vector[ u ] = 0;
-					vector[ v ] = 0;
-					vector[ w ] = depth > 0 ? 1 : - 1;
-
-					// now apply vector to normal buffer
-
-					normals.push( vector.x, vector.y, vector.z );
-
-					// uvs
-
-					uvs.push( ix / gridX );
-					uvs.push( 1 - ( iy / gridY ) );
-
-					// counters
-
-					vertexCounter += 1;
-
-				}
-
-			}
-
-			// indices
-
-			// 1. you need three indices to draw a single face
-			// 2. a single segment consists of two faces
-			// 3. so we need to generate six (2*3) indices per segment
-
-			for ( iy = 0; iy < gridY; iy ++ ) {
-
-				for ( ix = 0; ix < gridX; ix ++ ) {
-
-					var a = numberOfVertices + ix + gridX1 * iy;
-					var b = numberOfVertices + ix + gridX1 * ( iy + 1 );
-					var c = numberOfVertices + ( ix + 1 ) + gridX1 * ( iy + 1 );
-					var d = numberOfVertices + ( ix + 1 ) + gridX1 * iy;
-
-					// faces
-
-					indices.push( a, b, d );
-					indices.push( b, c, d );
-
-					// increase counter
-
-					groupCount += 6;
-
-				}
-
-			}
-
-			// add a group to the geometry. this will ensure multi material support
-
-			scope.addGroup( groupStart, groupCount, materialIndex );
-
-			// calculate new start value for groups
-
-			groupStart += groupCount;
-
-			// update total number of vertices
-
-			numberOfVertices += vertexCounter;
+			this.fromBufferGeometry( new BoxBufferGeometry( width, height, depth, widthSegments, heightSegments, depthSegments ) );
+			this.mergeVertices();
 
 		}
 
 	}
 
-	BoxBufferGeometry.prototype = Object.create( BufferGeometry.prototype );
-	BoxBufferGeometry.prototype.constructor = BoxBufferGeometry;
+	// BoxBufferGeometry
+
+	class BoxBufferGeometry extends BufferGeometry {
+
+		constructor( width, height, depth, widthSegments, heightSegments, depthSegments ) {
+
+			super();
+
+			this.type = 'BoxBufferGeometry';
+
+			this.parameters = {
+				width: width,
+				height: height,
+				depth: depth,
+				widthSegments: widthSegments,
+				heightSegments: heightSegments,
+				depthSegments: depthSegments
+			};
+
+			var scope = this;
+
+			width = width || 1;
+			height = height || 1;
+			depth = depth || 1;
+
+			// segments
+
+			widthSegments = Math.floor( widthSegments ) || 1;
+			heightSegments = Math.floor( heightSegments ) || 1;
+			depthSegments = Math.floor( depthSegments ) || 1;
+
+			// buffers
+
+			var indices = [];
+			var vertices = [];
+			var normals = [];
+			var uvs = [];
+
+			// helper variables
+
+			var numberOfVertices = 0;
+			var groupStart = 0;
+
+			// build each side of the box geometry
+
+			buildPlane( 'z', 'y', 'x', - 1, - 1, depth, height, width, depthSegments, heightSegments, 0 ); // px
+			buildPlane( 'z', 'y', 'x', 1, - 1, depth, height, - width, depthSegments, heightSegments, 1 ); // nx
+			buildPlane( 'x', 'z', 'y', 1, 1, width, depth, height, widthSegments, depthSegments, 2 ); // py
+			buildPlane( 'x', 'z', 'y', 1, - 1, width, depth, - height, widthSegments, depthSegments, 3 ); // ny
+			buildPlane( 'x', 'y', 'z', 1, - 1, width, height, depth, widthSegments, heightSegments, 4 ); // pz
+			buildPlane( 'x', 'y', 'z', - 1, - 1, width, height, - depth, widthSegments, heightSegments, 5 ); // nz
+
+			// build geometry
+
+			this.setIndex( indices );
+			this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+			this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+			this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+
+			function buildPlane( u, v, w, udir, vdir, width, height, depth, gridX, gridY, materialIndex ) {
+
+				var segmentWidth = width / gridX;
+				var segmentHeight = height / gridY;
+
+				var widthHalf = width / 2;
+				var heightHalf = height / 2;
+				var depthHalf = depth / 2;
+
+				var gridX1 = gridX + 1;
+				var gridY1 = gridY + 1;
+
+				var vertexCounter = 0;
+				var groupCount = 0;
+
+				var ix, iy;
+
+				var vector = new Vector3();
+
+				// generate vertices, normals and uvs
+
+				for ( iy = 0; iy < gridY1; iy ++ ) {
+
+					var y = iy * segmentHeight - heightHalf;
+
+					for ( ix = 0; ix < gridX1; ix ++ ) {
+
+						var x = ix * segmentWidth - widthHalf;
+
+						// set values to correct vector component
+
+						vector[ u ] = x * udir;
+						vector[ v ] = y * vdir;
+						vector[ w ] = depthHalf;
+
+						// now apply vector to vertex buffer
+
+						vertices.push( vector.x, vector.y, vector.z );
+
+						// set values to correct vector component
+
+						vector[ u ] = 0;
+						vector[ v ] = 0;
+						vector[ w ] = depth > 0 ? 1 : - 1;
+
+						// now apply vector to normal buffer
+
+						normals.push( vector.x, vector.y, vector.z );
+
+						// uvs
+
+						uvs.push( ix / gridX );
+						uvs.push( 1 - ( iy / gridY ) );
+
+						// counters
+
+						vertexCounter += 1;
+
+					}
+
+				}
+
+				// indices
+
+				// 1. you need three indices to draw a single face
+				// 2. a single segment consists of two faces
+				// 3. so we need to generate six (2*3) indices per segment
+
+				for ( iy = 0; iy < gridY; iy ++ ) {
+
+					for ( ix = 0; ix < gridX; ix ++ ) {
+
+						var a = numberOfVertices + ix + gridX1 * iy;
+						var b = numberOfVertices + ix + gridX1 * ( iy + 1 );
+						var c = numberOfVertices + ( ix + 1 ) + gridX1 * ( iy + 1 );
+						var d = numberOfVertices + ( ix + 1 ) + gridX1 * iy;
+
+						// faces
+
+						indices.push( a, b, d );
+						indices.push( b, c, d );
+
+						// increase counter
+
+						groupCount += 6;
+
+					}
+
+				}
+
+				// add a group to the geometry. this will ensure multi material support
+
+				scope.addGroup( groupStart, groupCount, materialIndex );
+
+				// calculate new start value for groups
+
+				groupStart += groupCount;
+
+				// update total number of vertices
+
+				numberOfVertices += vertexCounter;
+
+			}
+
+		}
+
+	}
 
 	/**
 	 * Uniform Utilities
@@ -13424,6 +13618,14 @@ var Spacekit = (function (exports) {
 
 		},
 
+		updateWorldMatrix: function ( updateParents, updateChildren ) {
+
+			Object3D.prototype.updateWorldMatrix.call( this, updateParents, updateChildren );
+
+			this.matrixWorldInverse.getInverse( this.matrixWorld );
+
+		},
+
 		clone: function () {
 
 			return new this.constructor().copy( this );
@@ -13502,7 +13704,7 @@ var Spacekit = (function (exports) {
 			// see http://www.bobatkins.com/photography/technical/field_of_view.html
 			var vExtentSlope = 0.5 * this.getFilmHeight() / focalLength;
 
-			this.fov = _Math.RAD2DEG * 2 * Math.atan( vExtentSlope );
+			this.fov = MathUtils.RAD2DEG * 2 * Math.atan( vExtentSlope );
 			this.updateProjectionMatrix();
 
 		},
@@ -13512,7 +13714,7 @@ var Spacekit = (function (exports) {
 		 */
 		getFocalLength: function () {
 
-			var vExtentSlope = Math.tan( _Math.DEG2RAD * 0.5 * this.fov );
+			var vExtentSlope = Math.tan( MathUtils.DEG2RAD * 0.5 * this.fov );
 
 			return 0.5 * this.getFilmHeight() / vExtentSlope;
 
@@ -13520,8 +13722,8 @@ var Spacekit = (function (exports) {
 
 		getEffectiveFOV: function () {
 
-			return _Math.RAD2DEG * 2 * Math.atan(
-				Math.tan( _Math.DEG2RAD * 0.5 * this.fov ) / this.zoom );
+			return MathUtils.RAD2DEG * 2 * Math.atan(
+				Math.tan( MathUtils.DEG2RAD * 0.5 * this.fov ) / this.zoom );
 
 		},
 
@@ -13619,7 +13821,7 @@ var Spacekit = (function (exports) {
 		updateProjectionMatrix: function () {
 
 			var near = this.near,
-				top = near * Math.tan( _Math.DEG2RAD * 0.5 * this.fov ) / this.zoom,
+				top = near * Math.tan( MathUtils.DEG2RAD * 0.5 * this.fov ) / this.zoom,
 				height = 2 * top,
 				width = this.aspect * height,
 				left = - 0.5 * width,
@@ -13717,7 +13919,7 @@ var Spacekit = (function (exports) {
 
 		options = options || { format: RGBFormat, magFilter: LinearFilter, minFilter: LinearFilter };
 
-		this.renderTarget = new WebGLRenderTargetCube( cubeResolution, cubeResolution, options );
+		this.renderTarget = new WebGLCubeRenderTarget( cubeResolution, options );
 		this.renderTarget.texture.name = "CubeCamera";
 
 		this.update = function ( renderer, scene ) {
@@ -13783,18 +13985,26 @@ var Spacekit = (function (exports) {
 	 * @author WestLangley / http://github.com/WestLangley
 	 */
 
-	function WebGLRenderTargetCube( width, height, options ) {
+	function WebGLCubeRenderTarget( size, options, dummy ) {
 
-		WebGLRenderTarget.call( this, width, height, options );
+		if ( Number.isInteger( options ) ) {
+
+			console.warn( 'THREE.WebGLCubeRenderTarget: constructor signature is now WebGLCubeRenderTarget( size, options )' );
+
+			options = dummy;
+
+		}
+
+		WebGLRenderTarget.call( this, size, size, options );
 
 	}
 
-	WebGLRenderTargetCube.prototype = Object.create( WebGLRenderTarget.prototype );
-	WebGLRenderTargetCube.prototype.constructor = WebGLRenderTargetCube;
+	WebGLCubeRenderTarget.prototype = Object.create( WebGLRenderTarget.prototype );
+	WebGLCubeRenderTarget.prototype.constructor = WebGLCubeRenderTarget;
 
-	WebGLRenderTargetCube.prototype.isWebGLRenderTargetCube = true;
+	WebGLCubeRenderTarget.prototype.isWebGLCubeRenderTarget = true;
 
-	WebGLRenderTargetCube.prototype.fromEquirectangularTexture = function ( renderer, texture ) {
+	WebGLCubeRenderTarget.prototype.fromEquirectangularTexture = function ( renderer, texture ) {
 
 		this.texture.type = texture.type;
 		this.texture.format = texture.format;
@@ -13895,7 +14105,7 @@ var Spacekit = (function (exports) {
 
 		Texture.call( this, null, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy, encoding );
 
-		this.image = { data: data, width: width, height: height };
+		this.image = { data: data || null, width: width || 1, height: height || 1 };
 
 		this.magFilter = magFilter !== undefined ? magFilter : NearestFilter;
 		this.minFilter = minFilter !== undefined ? minFilter : NearestFilter;
@@ -13903,6 +14113,8 @@ var Spacekit = (function (exports) {
 		this.generateMipmaps = false;
 		this.flipY = false;
 		this.unpackAlignment = 1;
+
+		this.needsUpdate = true;
 
 	}
 
@@ -13912,252 +14124,13 @@ var Spacekit = (function (exports) {
 	DataTexture.prototype.isDataTexture = true;
 
 	/**
-	 * @author bhouston / http://clara.io
-	 */
-
-	function Plane( normal, constant ) {
-
-		// normal is assumed to be normalized
-
-		this.normal = ( normal !== undefined ) ? normal : new Vector3( 1, 0, 0 );
-		this.constant = ( constant !== undefined ) ? constant : 0;
-
-	}
-
-	Object.assign( Plane.prototype, {
-
-		isPlane: true,
-
-		set: function ( normal, constant ) {
-
-			this.normal.copy( normal );
-			this.constant = constant;
-
-			return this;
-
-		},
-
-		setComponents: function ( x, y, z, w ) {
-
-			this.normal.set( x, y, z );
-			this.constant = w;
-
-			return this;
-
-		},
-
-		setFromNormalAndCoplanarPoint: function ( normal, point ) {
-
-			this.normal.copy( normal );
-			this.constant = - point.dot( this.normal );
-
-			return this;
-
-		},
-
-		setFromCoplanarPoints: function () {
-
-			var v1 = new Vector3();
-			var v2 = new Vector3();
-
-			return function setFromCoplanarPoints( a, b, c ) {
-
-				var normal = v1.subVectors( c, b ).cross( v2.subVectors( a, b ) ).normalize();
-
-				// Q: should an error be thrown if normal is zero (e.g. degenerate plane)?
-
-				this.setFromNormalAndCoplanarPoint( normal, a );
-
-				return this;
-
-			};
-
-		}(),
-
-		clone: function () {
-
-			return new this.constructor().copy( this );
-
-		},
-
-		copy: function ( plane ) {
-
-			this.normal.copy( plane.normal );
-			this.constant = plane.constant;
-
-			return this;
-
-		},
-
-		normalize: function () {
-
-			// Note: will lead to a divide by zero if the plane is invalid.
-
-			var inverseNormalLength = 1.0 / this.normal.length();
-			this.normal.multiplyScalar( inverseNormalLength );
-			this.constant *= inverseNormalLength;
-
-			return this;
-
-		},
-
-		negate: function () {
-
-			this.constant *= - 1;
-			this.normal.negate();
-
-			return this;
-
-		},
-
-		distanceToPoint: function ( point ) {
-
-			return this.normal.dot( point ) + this.constant;
-
-		},
-
-		distanceToSphere: function ( sphere ) {
-
-			return this.distanceToPoint( sphere.center ) - sphere.radius;
-
-		},
-
-		projectPoint: function ( point, target ) {
-
-			if ( target === undefined ) {
-
-				console.warn( 'THREE.Plane: .projectPoint() target is now required' );
-				target = new Vector3();
-
-			}
-
-			return target.copy( this.normal ).multiplyScalar( - this.distanceToPoint( point ) ).add( point );
-
-		},
-
-		intersectLine: function () {
-
-			var v1 = new Vector3();
-
-			return function intersectLine( line, target ) {
-
-				if ( target === undefined ) {
-
-					console.warn( 'THREE.Plane: .intersectLine() target is now required' );
-					target = new Vector3();
-
-				}
-
-				var direction = line.delta( v1 );
-
-				var denominator = this.normal.dot( direction );
-
-				if ( denominator === 0 ) {
-
-					// line is coplanar, return origin
-					if ( this.distanceToPoint( line.start ) === 0 ) {
-
-						return target.copy( line.start );
-
-					}
-
-					// Unsure if this is the correct method to handle this case.
-					return undefined;
-
-				}
-
-				var t = - ( line.start.dot( this.normal ) + this.constant ) / denominator;
-
-				if ( t < 0 || t > 1 ) {
-
-					return undefined;
-
-				}
-
-				return target.copy( direction ).multiplyScalar( t ).add( line.start );
-
-			};
-
-		}(),
-
-		intersectsLine: function ( line ) {
-
-			// Note: this tests if a line intersects the plane, not whether it (or its end-points) are coplanar with it.
-
-			var startSign = this.distanceToPoint( line.start );
-			var endSign = this.distanceToPoint( line.end );
-
-			return ( startSign < 0 && endSign > 0 ) || ( endSign < 0 && startSign > 0 );
-
-		},
-
-		intersectsBox: function ( box ) {
-
-			return box.intersectsPlane( this );
-
-		},
-
-		intersectsSphere: function ( sphere ) {
-
-			return sphere.intersectsPlane( this );
-
-		},
-
-		coplanarPoint: function ( target ) {
-
-			if ( target === undefined ) {
-
-				console.warn( 'THREE.Plane: .coplanarPoint() target is now required' );
-				target = new Vector3();
-
-			}
-
-			return target.copy( this.normal ).multiplyScalar( - this.constant );
-
-		},
-
-		applyMatrix4: function () {
-
-			var v1 = new Vector3();
-			var m1 = new Matrix3();
-
-			return function applyMatrix4( matrix, optionalNormalMatrix ) {
-
-				var normalMatrix = optionalNormalMatrix || m1.getNormalMatrix( matrix );
-
-				var referencePoint = this.coplanarPoint( v1 ).applyMatrix4( matrix );
-
-				var normal = this.normal.applyMatrix3( normalMatrix ).normalize();
-
-				this.constant = - referencePoint.dot( normal );
-
-				return this;
-
-			};
-
-		}(),
-
-		translate: function ( offset ) {
-
-			this.constant -= offset.dot( this.normal );
-
-			return this;
-
-		},
-
-		equals: function ( plane ) {
-
-			return plane.normal.equals( this.normal ) && ( plane.constant === this.constant );
-
-		}
-
-	} );
-
-	/**
 	 * @author mrdoob / http://mrdoob.com/
 	 * @author alteredq / http://alteredqualia.com/
 	 * @author bhouston / http://clara.io
 	 */
+
+	var _sphere$1 = new Sphere();
+	var _vector$5 = new Vector3();
 
 	function Frustum( p0, p1, p2, p3, p4, p5 ) {
 
@@ -14211,7 +14184,7 @@ var Spacekit = (function (exports) {
 
 		},
 
-		setFromMatrix: function ( m ) {
+		setFromProjectionMatrix: function ( m ) {
 
 			var planes = this.planes;
 			var me = m.elements;
@@ -14231,41 +14204,27 @@ var Spacekit = (function (exports) {
 
 		},
 
-		intersectsObject: function () {
+		intersectsObject: function ( object ) {
 
-			var sphere = new Sphere();
+			var geometry = object.geometry;
 
-			return function intersectsObject( object ) {
+			if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
 
-				var geometry = object.geometry;
+			_sphere$1.copy( geometry.boundingSphere ).applyMatrix4( object.matrixWorld );
 
-				if ( geometry.boundingSphere === null )
-					geometry.computeBoundingSphere();
+			return this.intersectsSphere( _sphere$1 );
 
-				sphere.copy( geometry.boundingSphere )
-					.applyMatrix4( object.matrixWorld );
+		},
 
-				return this.intersectsSphere( sphere );
+		intersectsSprite: function ( sprite ) {
 
-			};
+			_sphere$1.center.set( 0, 0, 0 );
+			_sphere$1.radius = 0.7071067811865476;
+			_sphere$1.applyMatrix4( sprite.matrixWorld );
 
-		}(),
+			return this.intersectsSphere( _sphere$1 );
 
-		intersectsSprite: function () {
-
-			var sphere = new Sphere();
-
-			return function intersectsSprite( sprite ) {
-
-				sphere.center.set( 0, 0, 0 );
-				sphere.radius = 0.7071067811865476;
-				sphere.applyMatrix4( sprite.matrixWorld );
-
-				return this.intersectsSphere( sphere );
-
-			};
-
-		}(),
+		},
 
 		intersectsSphere: function ( sphere ) {
 
@@ -14289,37 +14248,31 @@ var Spacekit = (function (exports) {
 
 		},
 
-		intersectsBox: function () {
+		intersectsBox: function ( box ) {
 
-			var p = new Vector3();
+			var planes = this.planes;
 
-			return function intersectsBox( box ) {
+			for ( var i = 0; i < 6; i ++ ) {
 
-				var planes = this.planes;
+				var plane = planes[ i ];
 
-				for ( var i = 0; i < 6; i ++ ) {
+				// corner at max distance
 
-					var plane = planes[ i ];
+				_vector$5.x = plane.normal.x > 0 ? box.max.x : box.min.x;
+				_vector$5.y = plane.normal.y > 0 ? box.max.y : box.min.y;
+				_vector$5.z = plane.normal.z > 0 ? box.max.z : box.min.z;
 
-					// corner at max distance
+				if ( plane.distanceToPoint( _vector$5 ) < 0 ) {
 
-					p.x = plane.normal.x > 0 ? box.max.x : box.min.x;
-					p.y = plane.normal.y > 0 ? box.max.y : box.min.y;
-					p.z = plane.normal.z > 0 ? box.max.z : box.min.z;
-
-					if ( plane.distanceToPoint( p ) < 0 ) {
-
-						return false;
-
-					}
+					return false;
 
 				}
 
-				return true;
+			}
 
-			};
+			return true;
 
-		}(),
+		},
 
 		containsPoint: function ( point ) {
 
@@ -14341,367 +14294,6 @@ var Spacekit = (function (exports) {
 
 	} );
 
-	var alphamap_fragment = "#ifdef USE_ALPHAMAP\n\tdiffuseColor.a *= texture2D( alphaMap, vUv ).g;\n#endif";
-
-	var alphamap_pars_fragment = "#ifdef USE_ALPHAMAP\n\tuniform sampler2D alphaMap;\n#endif";
-
-	var alphatest_fragment = "#ifdef ALPHATEST\n\tif ( diffuseColor.a < ALPHATEST ) discard;\n#endif";
-
-	var aomap_fragment = "#ifdef USE_AOMAP\n\tfloat ambientOcclusion = ( texture2D( aoMap, vUv2 ).r - 1.0 ) * aoMapIntensity + 1.0;\n\treflectedLight.indirectDiffuse *= ambientOcclusion;\n\t#if defined( USE_ENVMAP ) && defined( PHYSICAL )\n\t\tfloat dotNV = saturate( dot( geometry.normal, geometry.viewDir ) );\n\t\treflectedLight.indirectSpecular *= computeSpecularOcclusion( dotNV, ambientOcclusion, material.specularRoughness );\n\t#endif\n#endif";
-
-	var aomap_pars_fragment = "#ifdef USE_AOMAP\n\tuniform sampler2D aoMap;\n\tuniform float aoMapIntensity;\n#endif";
-
-	var begin_vertex = "vec3 transformed = vec3( position );";
-
-	var beginnormal_vertex = "vec3 objectNormal = vec3( normal );\n#ifdef USE_TANGENT\n\tvec3 objectTangent = vec3( tangent.xyz );\n#endif";
-
-	var bsdfs = "vec2 integrateSpecularBRDF( const in float dotNV, const in float roughness ) {\n\tconst vec4 c0 = vec4( - 1, - 0.0275, - 0.572, 0.022 );\n\tconst vec4 c1 = vec4( 1, 0.0425, 1.04, - 0.04 );\n\tvec4 r = roughness * c0 + c1;\n\tfloat a004 = min( r.x * r.x, exp2( - 9.28 * dotNV ) ) * r.x + r.y;\n\treturn vec2( -1.04, 1.04 ) * a004 + r.zw;\n}\nfloat punctualLightIntensityToIrradianceFactor( const in float lightDistance, const in float cutoffDistance, const in float decayExponent ) {\n#if defined ( PHYSICALLY_CORRECT_LIGHTS )\n\tfloat distanceFalloff = 1.0 / max( pow( lightDistance, decayExponent ), 0.01 );\n\tif( cutoffDistance > 0.0 ) {\n\t\tdistanceFalloff *= pow2( saturate( 1.0 - pow4( lightDistance / cutoffDistance ) ) );\n\t}\n\treturn distanceFalloff;\n#else\n\tif( cutoffDistance > 0.0 && decayExponent > 0.0 ) {\n\t\treturn pow( saturate( -lightDistance / cutoffDistance + 1.0 ), decayExponent );\n\t}\n\treturn 1.0;\n#endif\n}\nvec3 BRDF_Diffuse_Lambert( const in vec3 diffuseColor ) {\n\treturn RECIPROCAL_PI * diffuseColor;\n}\nvec3 F_Schlick( const in vec3 specularColor, const in float dotLH ) {\n\tfloat fresnel = exp2( ( -5.55473 * dotLH - 6.98316 ) * dotLH );\n\treturn ( 1.0 - specularColor ) * fresnel + specularColor;\n}\nvec3 F_Schlick_RoughnessDependent( const in vec3 F0, const in float dotNV, const in float roughness ) {\n\tfloat fresnel = exp2( ( -5.55473 * dotNV - 6.98316 ) * dotNV );\n\tvec3 Fr = max( vec3( 1.0 - roughness ), F0 ) - F0;\n\treturn Fr * fresnel + F0;\n}\nfloat G_GGX_Smith( const in float alpha, const in float dotNL, const in float dotNV ) {\n\tfloat a2 = pow2( alpha );\n\tfloat gl = dotNL + sqrt( a2 + ( 1.0 - a2 ) * pow2( dotNL ) );\n\tfloat gv = dotNV + sqrt( a2 + ( 1.0 - a2 ) * pow2( dotNV ) );\n\treturn 1.0 / ( gl * gv );\n}\nfloat G_GGX_SmithCorrelated( const in float alpha, const in float dotNL, const in float dotNV ) {\n\tfloat a2 = pow2( alpha );\n\tfloat gv = dotNL * sqrt( a2 + ( 1.0 - a2 ) * pow2( dotNV ) );\n\tfloat gl = dotNV * sqrt( a2 + ( 1.0 - a2 ) * pow2( dotNL ) );\n\treturn 0.5 / max( gv + gl, EPSILON );\n}\nfloat D_GGX( const in float alpha, const in float dotNH ) {\n\tfloat a2 = pow2( alpha );\n\tfloat denom = pow2( dotNH ) * ( a2 - 1.0 ) + 1.0;\n\treturn RECIPROCAL_PI * a2 / pow2( denom );\n}\nvec3 BRDF_Specular_GGX( const in IncidentLight incidentLight, const in GeometricContext geometry, const in vec3 specularColor, const in float roughness ) {\n\tfloat alpha = pow2( roughness );\n\tvec3 halfDir = normalize( incidentLight.direction + geometry.viewDir );\n\tfloat dotNL = saturate( dot( geometry.normal, incidentLight.direction ) );\n\tfloat dotNV = saturate( dot( geometry.normal, geometry.viewDir ) );\n\tfloat dotNH = saturate( dot( geometry.normal, halfDir ) );\n\tfloat dotLH = saturate( dot( incidentLight.direction, halfDir ) );\n\tvec3 F = F_Schlick( specularColor, dotLH );\n\tfloat G = G_GGX_SmithCorrelated( alpha, dotNL, dotNV );\n\tfloat D = D_GGX( alpha, dotNH );\n\treturn F * ( G * D );\n}\nvec2 LTC_Uv( const in vec3 N, const in vec3 V, const in float roughness ) {\n\tconst float LUT_SIZE  = 64.0;\n\tconst float LUT_SCALE = ( LUT_SIZE - 1.0 ) / LUT_SIZE;\n\tconst float LUT_BIAS  = 0.5 / LUT_SIZE;\n\tfloat dotNV = saturate( dot( N, V ) );\n\tvec2 uv = vec2( roughness, sqrt( 1.0 - dotNV ) );\n\tuv = uv * LUT_SCALE + LUT_BIAS;\n\treturn uv;\n}\nfloat LTC_ClippedSphereFormFactor( const in vec3 f ) {\n\tfloat l = length( f );\n\treturn max( ( l * l + f.z ) / ( l + 1.0 ), 0.0 );\n}\nvec3 LTC_EdgeVectorFormFactor( const in vec3 v1, const in vec3 v2 ) {\n\tfloat x = dot( v1, v2 );\n\tfloat y = abs( x );\n\tfloat a = 0.8543985 + ( 0.4965155 + 0.0145206 * y ) * y;\n\tfloat b = 3.4175940 + ( 4.1616724 + y ) * y;\n\tfloat v = a / b;\n\tfloat theta_sintheta = ( x > 0.0 ) ? v : 0.5 * inversesqrt( max( 1.0 - x * x, 1e-7 ) ) - v;\n\treturn cross( v1, v2 ) * theta_sintheta;\n}\nvec3 LTC_Evaluate( const in vec3 N, const in vec3 V, const in vec3 P, const in mat3 mInv, const in vec3 rectCoords[ 4 ] ) {\n\tvec3 v1 = rectCoords[ 1 ] - rectCoords[ 0 ];\n\tvec3 v2 = rectCoords[ 3 ] - rectCoords[ 0 ];\n\tvec3 lightNormal = cross( v1, v2 );\n\tif( dot( lightNormal, P - rectCoords[ 0 ] ) < 0.0 ) return vec3( 0.0 );\n\tvec3 T1, T2;\n\tT1 = normalize( V - N * dot( V, N ) );\n\tT2 = - cross( N, T1 );\n\tmat3 mat = mInv * transposeMat3( mat3( T1, T2, N ) );\n\tvec3 coords[ 4 ];\n\tcoords[ 0 ] = mat * ( rectCoords[ 0 ] - P );\n\tcoords[ 1 ] = mat * ( rectCoords[ 1 ] - P );\n\tcoords[ 2 ] = mat * ( rectCoords[ 2 ] - P );\n\tcoords[ 3 ] = mat * ( rectCoords[ 3 ] - P );\n\tcoords[ 0 ] = normalize( coords[ 0 ] );\n\tcoords[ 1 ] = normalize( coords[ 1 ] );\n\tcoords[ 2 ] = normalize( coords[ 2 ] );\n\tcoords[ 3 ] = normalize( coords[ 3 ] );\n\tvec3 vectorFormFactor = vec3( 0.0 );\n\tvectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 0 ], coords[ 1 ] );\n\tvectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 1 ], coords[ 2 ] );\n\tvectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 2 ], coords[ 3 ] );\n\tvectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 3 ], coords[ 0 ] );\n\tfloat result = LTC_ClippedSphereFormFactor( vectorFormFactor );\n\treturn vec3( result );\n}\nvec3 BRDF_Specular_GGX_Environment( const in GeometricContext geometry, const in vec3 specularColor, const in float roughness ) {\n\tfloat dotNV = saturate( dot( geometry.normal, geometry.viewDir ) );\n\tvec2 brdf = integrateSpecularBRDF( dotNV, roughness );\n\treturn specularColor * brdf.x + brdf.y;\n}\nvoid BRDF_Specular_Multiscattering_Environment( const in GeometricContext geometry, const in vec3 specularColor, const in float roughness, inout vec3 singleScatter, inout vec3 multiScatter ) {\n\tfloat dotNV = saturate( dot( geometry.normal, geometry.viewDir ) );\n\tvec3 F = F_Schlick_RoughnessDependent( specularColor, dotNV, roughness );\n\tvec2 brdf = integrateSpecularBRDF( dotNV, roughness );\n\tvec3 FssEss = F * brdf.x + brdf.y;\n\tfloat Ess = brdf.x + brdf.y;\n\tfloat Ems = 1.0 - Ess;\n\tvec3 Favg = specularColor + ( 1.0 - specularColor ) * 0.047619;\tvec3 Fms = FssEss * Favg / ( 1.0 - Ems * Favg );\n\tsingleScatter += FssEss;\n\tmultiScatter += Fms * Ems;\n}\nfloat G_BlinnPhong_Implicit( ) {\n\treturn 0.25;\n}\nfloat D_BlinnPhong( const in float shininess, const in float dotNH ) {\n\treturn RECIPROCAL_PI * ( shininess * 0.5 + 1.0 ) * pow( dotNH, shininess );\n}\nvec3 BRDF_Specular_BlinnPhong( const in IncidentLight incidentLight, const in GeometricContext geometry, const in vec3 specularColor, const in float shininess ) {\n\tvec3 halfDir = normalize( incidentLight.direction + geometry.viewDir );\n\tfloat dotNH = saturate( dot( geometry.normal, halfDir ) );\n\tfloat dotLH = saturate( dot( incidentLight.direction, halfDir ) );\n\tvec3 F = F_Schlick( specularColor, dotLH );\n\tfloat G = G_BlinnPhong_Implicit( );\n\tfloat D = D_BlinnPhong( shininess, dotNH );\n\treturn F * ( G * D );\n}\nfloat GGXRoughnessToBlinnExponent( const in float ggxRoughness ) {\n\treturn ( 2.0 / pow2( ggxRoughness + 0.0001 ) - 2.0 );\n}\nfloat BlinnExponentToGGXRoughness( const in float blinnExponent ) {\n\treturn sqrt( 2.0 / ( blinnExponent + 2.0 ) );\n}";
-
-	var bumpmap_pars_fragment = "#ifdef USE_BUMPMAP\n\tuniform sampler2D bumpMap;\n\tuniform float bumpScale;\n\tvec2 dHdxy_fwd() {\n\t\tvec2 dSTdx = dFdx( vUv );\n\t\tvec2 dSTdy = dFdy( vUv );\n\t\tfloat Hll = bumpScale * texture2D( bumpMap, vUv ).x;\n\t\tfloat dBx = bumpScale * texture2D( bumpMap, vUv + dSTdx ).x - Hll;\n\t\tfloat dBy = bumpScale * texture2D( bumpMap, vUv + dSTdy ).x - Hll;\n\t\treturn vec2( dBx, dBy );\n\t}\n\tvec3 perturbNormalArb( vec3 surf_pos, vec3 surf_norm, vec2 dHdxy ) {\n\t\tvec3 vSigmaX = vec3( dFdx( surf_pos.x ), dFdx( surf_pos.y ), dFdx( surf_pos.z ) );\n\t\tvec3 vSigmaY = vec3( dFdy( surf_pos.x ), dFdy( surf_pos.y ), dFdy( surf_pos.z ) );\n\t\tvec3 vN = surf_norm;\n\t\tvec3 R1 = cross( vSigmaY, vN );\n\t\tvec3 R2 = cross( vN, vSigmaX );\n\t\tfloat fDet = dot( vSigmaX, R1 );\n\t\tfDet *= ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t\tvec3 vGrad = sign( fDet ) * ( dHdxy.x * R1 + dHdxy.y * R2 );\n\t\treturn normalize( abs( fDet ) * surf_norm - vGrad );\n\t}\n#endif";
-
-	var clipping_planes_fragment = "#if NUM_CLIPPING_PLANES > 0\n\tvec4 plane;\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < UNION_CLIPPING_PLANES; i ++ ) {\n\t\tplane = clippingPlanes[ i ];\n\t\tif ( dot( vViewPosition, plane.xyz ) > plane.w ) discard;\n\t}\n\t#if UNION_CLIPPING_PLANES < NUM_CLIPPING_PLANES\n\t\tbool clipped = true;\n\t\t#pragma unroll_loop\n\t\tfor ( int i = UNION_CLIPPING_PLANES; i < NUM_CLIPPING_PLANES; i ++ ) {\n\t\t\tplane = clippingPlanes[ i ];\n\t\t\tclipped = ( dot( vViewPosition, plane.xyz ) > plane.w ) && clipped;\n\t\t}\n\t\tif ( clipped ) discard;\n\t#endif\n#endif";
-
-	var clipping_planes_pars_fragment = "#if NUM_CLIPPING_PLANES > 0\n\t#if ! defined( PHYSICAL ) && ! defined( PHONG ) && ! defined( MATCAP )\n\t\tvarying vec3 vViewPosition;\n\t#endif\n\tuniform vec4 clippingPlanes[ NUM_CLIPPING_PLANES ];\n#endif";
-
-	var clipping_planes_pars_vertex = "#if NUM_CLIPPING_PLANES > 0 && ! defined( PHYSICAL ) && ! defined( PHONG ) && ! defined( MATCAP )\n\tvarying vec3 vViewPosition;\n#endif";
-
-	var clipping_planes_vertex = "#if NUM_CLIPPING_PLANES > 0 && ! defined( PHYSICAL ) && ! defined( PHONG ) && ! defined( MATCAP )\n\tvViewPosition = - mvPosition.xyz;\n#endif";
-
-	var color_fragment = "#ifdef USE_COLOR\n\tdiffuseColor.rgb *= vColor;\n#endif";
-
-	var color_pars_fragment = "#ifdef USE_COLOR\n\tvarying vec3 vColor;\n#endif";
-
-	var color_pars_vertex = "#ifdef USE_COLOR\n\tvarying vec3 vColor;\n#endif";
-
-	var color_vertex = "#ifdef USE_COLOR\n\tvColor.xyz = color.xyz;\n#endif";
-
-	var common = "#define PI 3.14159265359\n#define PI2 6.28318530718\n#define PI_HALF 1.5707963267949\n#define RECIPROCAL_PI 0.31830988618\n#define RECIPROCAL_PI2 0.15915494\n#define LOG2 1.442695\n#define EPSILON 1e-6\n#define saturate(a) clamp( a, 0.0, 1.0 )\n#define whiteCompliment(a) ( 1.0 - saturate( a ) )\nfloat pow2( const in float x ) { return x*x; }\nfloat pow3( const in float x ) { return x*x*x; }\nfloat pow4( const in float x ) { float x2 = x*x; return x2*x2; }\nfloat average( const in vec3 color ) { return dot( color, vec3( 0.3333 ) ); }\nhighp float rand( const in vec2 uv ) {\n\tconst highp float a = 12.9898, b = 78.233, c = 43758.5453;\n\thighp float dt = dot( uv.xy, vec2( a,b ) ), sn = mod( dt, PI );\n\treturn fract(sin(sn) * c);\n}\nstruct IncidentLight {\n\tvec3 color;\n\tvec3 direction;\n\tbool visible;\n};\nstruct ReflectedLight {\n\tvec3 directDiffuse;\n\tvec3 directSpecular;\n\tvec3 indirectDiffuse;\n\tvec3 indirectSpecular;\n};\nstruct GeometricContext {\n\tvec3 position;\n\tvec3 normal;\n\tvec3 viewDir;\n};\nvec3 transformDirection( in vec3 dir, in mat4 matrix ) {\n\treturn normalize( ( matrix * vec4( dir, 0.0 ) ).xyz );\n}\nvec3 inverseTransformDirection( in vec3 dir, in mat4 matrix ) {\n\treturn normalize( ( vec4( dir, 0.0 ) * matrix ).xyz );\n}\nvec3 projectOnPlane(in vec3 point, in vec3 pointOnPlane, in vec3 planeNormal ) {\n\tfloat distance = dot( planeNormal, point - pointOnPlane );\n\treturn - distance * planeNormal + point;\n}\nfloat sideOfPlane( in vec3 point, in vec3 pointOnPlane, in vec3 planeNormal ) {\n\treturn sign( dot( point - pointOnPlane, planeNormal ) );\n}\nvec3 linePlaneIntersect( in vec3 pointOnLine, in vec3 lineDirection, in vec3 pointOnPlane, in vec3 planeNormal ) {\n\treturn lineDirection * ( dot( planeNormal, pointOnPlane - pointOnLine ) / dot( planeNormal, lineDirection ) ) + pointOnLine;\n}\nmat3 transposeMat3( const in mat3 m ) {\n\tmat3 tmp;\n\ttmp[ 0 ] = vec3( m[ 0 ].x, m[ 1 ].x, m[ 2 ].x );\n\ttmp[ 1 ] = vec3( m[ 0 ].y, m[ 1 ].y, m[ 2 ].y );\n\ttmp[ 2 ] = vec3( m[ 0 ].z, m[ 1 ].z, m[ 2 ].z );\n\treturn tmp;\n}\nfloat linearToRelativeLuminance( const in vec3 color ) {\n\tvec3 weights = vec3( 0.2126, 0.7152, 0.0722 );\n\treturn dot( weights, color.rgb );\n}";
-
-	var cube_uv_reflection_fragment = "#ifdef ENVMAP_TYPE_CUBE_UV\n#define cubeUV_textureSize (1024.0)\nint getFaceFromDirection(vec3 direction) {\n\tvec3 absDirection = abs(direction);\n\tint face = -1;\n\tif( absDirection.x > absDirection.z ) {\n\t\tif(absDirection.x > absDirection.y )\n\t\t\tface = direction.x > 0.0 ? 0 : 3;\n\t\telse\n\t\t\tface = direction.y > 0.0 ? 1 : 4;\n\t}\n\telse {\n\t\tif(absDirection.z > absDirection.y )\n\t\t\tface = direction.z > 0.0 ? 2 : 5;\n\t\telse\n\t\t\tface = direction.y > 0.0 ? 1 : 4;\n\t}\n\treturn face;\n}\n#define cubeUV_maxLods1  (log2(cubeUV_textureSize*0.25) - 1.0)\n#define cubeUV_rangeClamp (exp2((6.0 - 1.0) * 2.0))\nvec2 MipLevelInfo( vec3 vec, float roughnessLevel, float roughness ) {\n\tfloat scale = exp2(cubeUV_maxLods1 - roughnessLevel);\n\tfloat dxRoughness = dFdx(roughness);\n\tfloat dyRoughness = dFdy(roughness);\n\tvec3 dx = dFdx( vec * scale * dxRoughness );\n\tvec3 dy = dFdy( vec * scale * dyRoughness );\n\tfloat d = max( dot( dx, dx ), dot( dy, dy ) );\n\td = clamp(d, 1.0, cubeUV_rangeClamp);\n\tfloat mipLevel = 0.5 * log2(d);\n\treturn vec2(floor(mipLevel), fract(mipLevel));\n}\n#define cubeUV_maxLods2 (log2(cubeUV_textureSize*0.25) - 2.0)\n#define cubeUV_rcpTextureSize (1.0 / cubeUV_textureSize)\nvec2 getCubeUV(vec3 direction, float roughnessLevel, float mipLevel) {\n\tmipLevel = roughnessLevel > cubeUV_maxLods2 - 3.0 ? 0.0 : mipLevel;\n\tfloat a = 16.0 * cubeUV_rcpTextureSize;\n\tvec2 exp2_packed = exp2( vec2( roughnessLevel, mipLevel ) );\n\tvec2 rcp_exp2_packed = vec2( 1.0 ) / exp2_packed;\n\tfloat powScale = exp2_packed.x * exp2_packed.y;\n\tfloat scale = rcp_exp2_packed.x * rcp_exp2_packed.y * 0.25;\n\tfloat mipOffset = 0.75*(1.0 - rcp_exp2_packed.y) * rcp_exp2_packed.x;\n\tbool bRes = mipLevel == 0.0;\n\tscale =  bRes && (scale < a) ? a : scale;\n\tvec3 r;\n\tvec2 offset;\n\tint face = getFaceFromDirection(direction);\n\tfloat rcpPowScale = 1.0 / powScale;\n\tif( face == 0) {\n\t\tr = vec3(direction.x, -direction.z, direction.y);\n\t\toffset = vec2(0.0+mipOffset,0.75 * rcpPowScale);\n\t\toffset.y = bRes && (offset.y < 2.0*a) ? a : offset.y;\n\t}\n\telse if( face == 1) {\n\t\tr = vec3(direction.y, direction.x, direction.z);\n\t\toffset = vec2(scale+mipOffset, 0.75 * rcpPowScale);\n\t\toffset.y = bRes && (offset.y < 2.0*a) ? a : offset.y;\n\t}\n\telse if( face == 2) {\n\t\tr = vec3(direction.z, direction.x, direction.y);\n\t\toffset = vec2(2.0*scale+mipOffset, 0.75 * rcpPowScale);\n\t\toffset.y = bRes && (offset.y < 2.0*a) ? a : offset.y;\n\t}\n\telse if( face == 3) {\n\t\tr = vec3(direction.x, direction.z, direction.y);\n\t\toffset = vec2(0.0+mipOffset,0.5 * rcpPowScale);\n\t\toffset.y = bRes && (offset.y < 2.0*a) ? 0.0 : offset.y;\n\t}\n\telse if( face == 4) {\n\t\tr = vec3(direction.y, direction.x, -direction.z);\n\t\toffset = vec2(scale+mipOffset, 0.5 * rcpPowScale);\n\t\toffset.y = bRes && (offset.y < 2.0*a) ? 0.0 : offset.y;\n\t}\n\telse {\n\t\tr = vec3(direction.z, -direction.x, direction.y);\n\t\toffset = vec2(2.0*scale+mipOffset, 0.5 * rcpPowScale);\n\t\toffset.y = bRes && (offset.y < 2.0*a) ? 0.0 : offset.y;\n\t}\n\tr = normalize(r);\n\tfloat texelOffset = 0.5 * cubeUV_rcpTextureSize;\n\tvec2 s = ( r.yz / abs( r.x ) + vec2( 1.0 ) ) * 0.5;\n\tvec2 base = offset + vec2( texelOffset );\n\treturn base + s * ( scale - 2.0 * texelOffset );\n}\n#define cubeUV_maxLods3 (log2(cubeUV_textureSize*0.25) - 3.0)\nvec4 textureCubeUV( sampler2D envMap, vec3 reflectedDirection, float roughness ) {\n\tfloat roughnessVal = roughness* cubeUV_maxLods3;\n\tfloat r1 = floor(roughnessVal);\n\tfloat r2 = r1 + 1.0;\n\tfloat t = fract(roughnessVal);\n\tvec2 mipInfo = MipLevelInfo(reflectedDirection, r1, roughness);\n\tfloat s = mipInfo.y;\n\tfloat level0 = mipInfo.x;\n\tfloat level1 = level0 + 1.0;\n\tlevel1 = level1 > 5.0 ? 5.0 : level1;\n\tlevel0 += min( floor( s + 0.5 ), 5.0 );\n\tvec2 uv_10 = getCubeUV(reflectedDirection, r1, level0);\n\tvec4 color10 = envMapTexelToLinear(texture2D(envMap, uv_10));\n\tvec2 uv_20 = getCubeUV(reflectedDirection, r2, level0);\n\tvec4 color20 = envMapTexelToLinear(texture2D(envMap, uv_20));\n\tvec4 result = mix(color10, color20, t);\n\treturn vec4(result.rgb, 1.0);\n}\n#endif";
-
-	var defaultnormal_vertex = "vec3 transformedNormal = normalMatrix * objectNormal;\n#ifdef FLIP_SIDED\n\ttransformedNormal = - transformedNormal;\n#endif\n#ifdef USE_TANGENT\n\tvec3 transformedTangent = normalMatrix * objectTangent;\n\t#ifdef FLIP_SIDED\n\t\ttransformedTangent = - transformedTangent;\n\t#endif\n#endif";
-
-	var displacementmap_pars_vertex = "#ifdef USE_DISPLACEMENTMAP\n\tuniform sampler2D displacementMap;\n\tuniform float displacementScale;\n\tuniform float displacementBias;\n#endif";
-
-	var displacementmap_vertex = "#ifdef USE_DISPLACEMENTMAP\n\ttransformed += normalize( objectNormal ) * ( texture2D( displacementMap, uv ).x * displacementScale + displacementBias );\n#endif";
-
-	var emissivemap_fragment = "#ifdef USE_EMISSIVEMAP\n\tvec4 emissiveColor = texture2D( emissiveMap, vUv );\n\temissiveColor.rgb = emissiveMapTexelToLinear( emissiveColor ).rgb;\n\ttotalEmissiveRadiance *= emissiveColor.rgb;\n#endif";
-
-	var emissivemap_pars_fragment = "#ifdef USE_EMISSIVEMAP\n\tuniform sampler2D emissiveMap;\n#endif";
-
-	var encodings_fragment = "gl_FragColor = linearToOutputTexel( gl_FragColor );";
-
-	var encodings_pars_fragment = "\nvec4 LinearToLinear( in vec4 value ) {\n\treturn value;\n}\nvec4 GammaToLinear( in vec4 value, in float gammaFactor ) {\n\treturn vec4( pow( value.rgb, vec3( gammaFactor ) ), value.a );\n}\nvec4 LinearToGamma( in vec4 value, in float gammaFactor ) {\n\treturn vec4( pow( value.rgb, vec3( 1.0 / gammaFactor ) ), value.a );\n}\nvec4 sRGBToLinear( in vec4 value ) {\n\treturn vec4( mix( pow( value.rgb * 0.9478672986 + vec3( 0.0521327014 ), vec3( 2.4 ) ), value.rgb * 0.0773993808, vec3( lessThanEqual( value.rgb, vec3( 0.04045 ) ) ) ), value.a );\n}\nvec4 LinearTosRGB( in vec4 value ) {\n\treturn vec4( mix( pow( value.rgb, vec3( 0.41666 ) ) * 1.055 - vec3( 0.055 ), value.rgb * 12.92, vec3( lessThanEqual( value.rgb, vec3( 0.0031308 ) ) ) ), value.a );\n}\nvec4 RGBEToLinear( in vec4 value ) {\n\treturn vec4( value.rgb * exp2( value.a * 255.0 - 128.0 ), 1.0 );\n}\nvec4 LinearToRGBE( in vec4 value ) {\n\tfloat maxComponent = max( max( value.r, value.g ), value.b );\n\tfloat fExp = clamp( ceil( log2( maxComponent ) ), -128.0, 127.0 );\n\treturn vec4( value.rgb / exp2( fExp ), ( fExp + 128.0 ) / 255.0 );\n}\nvec4 RGBMToLinear( in vec4 value, in float maxRange ) {\n\treturn vec4( value.rgb * value.a * maxRange, 1.0 );\n}\nvec4 LinearToRGBM( in vec4 value, in float maxRange ) {\n\tfloat maxRGB = max( value.r, max( value.g, value.b ) );\n\tfloat M = clamp( maxRGB / maxRange, 0.0, 1.0 );\n\tM = ceil( M * 255.0 ) / 255.0;\n\treturn vec4( value.rgb / ( M * maxRange ), M );\n}\nvec4 RGBDToLinear( in vec4 value, in float maxRange ) {\n\treturn vec4( value.rgb * ( ( maxRange / 255.0 ) / value.a ), 1.0 );\n}\nvec4 LinearToRGBD( in vec4 value, in float maxRange ) {\n\tfloat maxRGB = max( value.r, max( value.g, value.b ) );\n\tfloat D = max( maxRange / maxRGB, 1.0 );\n\tD = min( floor( D ) / 255.0, 1.0 );\n\treturn vec4( value.rgb * ( D * ( 255.0 / maxRange ) ), D );\n}\nconst mat3 cLogLuvM = mat3( 0.2209, 0.3390, 0.4184, 0.1138, 0.6780, 0.7319, 0.0102, 0.1130, 0.2969 );\nvec4 LinearToLogLuv( in vec4 value )  {\n\tvec3 Xp_Y_XYZp = cLogLuvM * value.rgb;\n\tXp_Y_XYZp = max( Xp_Y_XYZp, vec3( 1e-6, 1e-6, 1e-6 ) );\n\tvec4 vResult;\n\tvResult.xy = Xp_Y_XYZp.xy / Xp_Y_XYZp.z;\n\tfloat Le = 2.0 * log2(Xp_Y_XYZp.y) + 127.0;\n\tvResult.w = fract( Le );\n\tvResult.z = ( Le - ( floor( vResult.w * 255.0 ) ) / 255.0 ) / 255.0;\n\treturn vResult;\n}\nconst mat3 cLogLuvInverseM = mat3( 6.0014, -2.7008, -1.7996, -1.3320, 3.1029, -5.7721, 0.3008, -1.0882, 5.6268 );\nvec4 LogLuvToLinear( in vec4 value ) {\n\tfloat Le = value.z * 255.0 + value.w;\n\tvec3 Xp_Y_XYZp;\n\tXp_Y_XYZp.y = exp2( ( Le - 127.0 ) / 2.0 );\n\tXp_Y_XYZp.z = Xp_Y_XYZp.y / value.y;\n\tXp_Y_XYZp.x = value.x * Xp_Y_XYZp.z;\n\tvec3 vRGB = cLogLuvInverseM * Xp_Y_XYZp.rgb;\n\treturn vec4( max( vRGB, 0.0 ), 1.0 );\n}";
-
-	var envmap_fragment = "#ifdef USE_ENVMAP\n\t#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG )\n\t\tvec3 cameraToVertex = normalize( vWorldPosition - cameraPosition );\n\t\tvec3 worldNormal = inverseTransformDirection( normal, viewMatrix );\n\t\t#ifdef ENVMAP_MODE_REFLECTION\n\t\t\tvec3 reflectVec = reflect( cameraToVertex, worldNormal );\n\t\t#else\n\t\t\tvec3 reflectVec = refract( cameraToVertex, worldNormal, refractionRatio );\n\t\t#endif\n\t#else\n\t\tvec3 reflectVec = vReflect;\n\t#endif\n\t#ifdef ENVMAP_TYPE_CUBE\n\t\tvec4 envColor = textureCube( envMap, vec3( flipEnvMap * reflectVec.x, reflectVec.yz ) );\n\t#elif defined( ENVMAP_TYPE_EQUIREC )\n\t\tvec2 sampleUV;\n\t\treflectVec = normalize( reflectVec );\n\t\tsampleUV.y = asin( clamp( reflectVec.y, - 1.0, 1.0 ) ) * RECIPROCAL_PI + 0.5;\n\t\tsampleUV.x = atan( reflectVec.z, reflectVec.x ) * RECIPROCAL_PI2 + 0.5;\n\t\tvec4 envColor = texture2D( envMap, sampleUV );\n\t#elif defined( ENVMAP_TYPE_SPHERE )\n\t\treflectVec = normalize( reflectVec );\n\t\tvec3 reflectView = normalize( ( viewMatrix * vec4( reflectVec, 0.0 ) ).xyz + vec3( 0.0, 0.0, 1.0 ) );\n\t\tvec4 envColor = texture2D( envMap, reflectView.xy * 0.5 + 0.5 );\n\t#else\n\t\tvec4 envColor = vec4( 0.0 );\n\t#endif\n\tenvColor = envMapTexelToLinear( envColor );\n\t#ifdef ENVMAP_BLENDING_MULTIPLY\n\t\toutgoingLight = mix( outgoingLight, outgoingLight * envColor.xyz, specularStrength * reflectivity );\n\t#elif defined( ENVMAP_BLENDING_MIX )\n\t\toutgoingLight = mix( outgoingLight, envColor.xyz, specularStrength * reflectivity );\n\t#elif defined( ENVMAP_BLENDING_ADD )\n\t\toutgoingLight += envColor.xyz * specularStrength * reflectivity;\n\t#endif\n#endif";
-
-	var envmap_pars_fragment = "#if defined( USE_ENVMAP ) || defined( PHYSICAL )\n\tuniform float reflectivity;\n\tuniform float envMapIntensity;\n#endif\n#ifdef USE_ENVMAP\n\t#if ! defined( PHYSICAL ) && ( defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG ) )\n\t\tvarying vec3 vWorldPosition;\n\t#endif\n\t#ifdef ENVMAP_TYPE_CUBE\n\t\tuniform samplerCube envMap;\n\t#else\n\t\tuniform sampler2D envMap;\n\t#endif\n\tuniform float flipEnvMap;\n\tuniform int maxMipLevel;\n\t#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG ) || defined( PHYSICAL )\n\t\tuniform float refractionRatio;\n\t#else\n\t\tvarying vec3 vReflect;\n\t#endif\n#endif";
-
-	var envmap_pars_vertex = "#ifdef USE_ENVMAP\n\t#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG )\n\t\tvarying vec3 vWorldPosition;\n\t#else\n\t\tvarying vec3 vReflect;\n\t\tuniform float refractionRatio;\n\t#endif\n#endif";
-
-	var envmap_vertex = "#ifdef USE_ENVMAP\n\t#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG )\n\t\tvWorldPosition = worldPosition.xyz;\n\t#else\n\t\tvec3 cameraToVertex = normalize( worldPosition.xyz - cameraPosition );\n\t\tvec3 worldNormal = inverseTransformDirection( transformedNormal, viewMatrix );\n\t\t#ifdef ENVMAP_MODE_REFLECTION\n\t\t\tvReflect = reflect( cameraToVertex, worldNormal );\n\t\t#else\n\t\t\tvReflect = refract( cameraToVertex, worldNormal, refractionRatio );\n\t\t#endif\n\t#endif\n#endif";
-
-	var fog_vertex = "#ifdef USE_FOG\n\tfogDepth = -mvPosition.z;\n#endif";
-
-	var fog_pars_vertex = "#ifdef USE_FOG\n\tvarying float fogDepth;\n#endif";
-
-	var fog_fragment = "#ifdef USE_FOG\n\t#ifdef FOG_EXP2\n\t\tfloat fogFactor = whiteCompliment( exp2( - fogDensity * fogDensity * fogDepth * fogDepth * LOG2 ) );\n\t#else\n\t\tfloat fogFactor = smoothstep( fogNear, fogFar, fogDepth );\n\t#endif\n\tgl_FragColor.rgb = mix( gl_FragColor.rgb, fogColor, fogFactor );\n#endif";
-
-	var fog_pars_fragment = "#ifdef USE_FOG\n\tuniform vec3 fogColor;\n\tvarying float fogDepth;\n\t#ifdef FOG_EXP2\n\t\tuniform float fogDensity;\n\t#else\n\t\tuniform float fogNear;\n\t\tuniform float fogFar;\n\t#endif\n#endif";
-
-	var gradientmap_pars_fragment = "#ifdef TOON\n\tuniform sampler2D gradientMap;\n\tvec3 getGradientIrradiance( vec3 normal, vec3 lightDirection ) {\n\t\tfloat dotNL = dot( normal, lightDirection );\n\t\tvec2 coord = vec2( dotNL * 0.5 + 0.5, 0.0 );\n\t\t#ifdef USE_GRADIENTMAP\n\t\t\treturn texture2D( gradientMap, coord ).rgb;\n\t\t#else\n\t\t\treturn ( coord.x < 0.7 ) ? vec3( 0.7 ) : vec3( 1.0 );\n\t\t#endif\n\t}\n#endif";
-
-	var lightmap_fragment = "#ifdef USE_LIGHTMAP\n\treflectedLight.indirectDiffuse += PI * texture2D( lightMap, vUv2 ).xyz * lightMapIntensity;\n#endif";
-
-	var lightmap_pars_fragment = "#ifdef USE_LIGHTMAP\n\tuniform sampler2D lightMap;\n\tuniform float lightMapIntensity;\n#endif";
-
-	var lights_lambert_vertex = "vec3 diffuse = vec3( 1.0 );\nGeometricContext geometry;\ngeometry.position = mvPosition.xyz;\ngeometry.normal = normalize( transformedNormal );\ngeometry.viewDir = normalize( -mvPosition.xyz );\nGeometricContext backGeometry;\nbackGeometry.position = geometry.position;\nbackGeometry.normal = -geometry.normal;\nbackGeometry.viewDir = geometry.viewDir;\nvLightFront = vec3( 0.0 );\nvIndirectFront = vec3( 0.0 );\n#ifdef DOUBLE_SIDED\n\tvLightBack = vec3( 0.0 );\n\tvIndirectBack = vec3( 0.0 );\n#endif\nIncidentLight directLight;\nfloat dotNL;\nvec3 directLightColor_Diffuse;\n#if NUM_POINT_LIGHTS > 0\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {\n\t\tgetPointDirectLightIrradiance( pointLights[ i ], geometry, directLight );\n\t\tdotNL = dot( geometry.normal, directLight.direction );\n\t\tdirectLightColor_Diffuse = PI * directLight.color;\n\t\tvLightFront += saturate( dotNL ) * directLightColor_Diffuse;\n\t\t#ifdef DOUBLE_SIDED\n\t\t\tvLightBack += saturate( -dotNL ) * directLightColor_Diffuse;\n\t\t#endif\n\t}\n#endif\n#if NUM_SPOT_LIGHTS > 0\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {\n\t\tgetSpotDirectLightIrradiance( spotLights[ i ], geometry, directLight );\n\t\tdotNL = dot( geometry.normal, directLight.direction );\n\t\tdirectLightColor_Diffuse = PI * directLight.color;\n\t\tvLightFront += saturate( dotNL ) * directLightColor_Diffuse;\n\t\t#ifdef DOUBLE_SIDED\n\t\t\tvLightBack += saturate( -dotNL ) * directLightColor_Diffuse;\n\t\t#endif\n\t}\n#endif\n#if NUM_DIR_LIGHTS > 0\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {\n\t\tgetDirectionalDirectLightIrradiance( directionalLights[ i ], geometry, directLight );\n\t\tdotNL = dot( geometry.normal, directLight.direction );\n\t\tdirectLightColor_Diffuse = PI * directLight.color;\n\t\tvLightFront += saturate( dotNL ) * directLightColor_Diffuse;\n\t\t#ifdef DOUBLE_SIDED\n\t\t\tvLightBack += saturate( -dotNL ) * directLightColor_Diffuse;\n\t\t#endif\n\t}\n#endif\n#if NUM_HEMI_LIGHTS > 0\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {\n\t\tvIndirectFront += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );\n\t\t#ifdef DOUBLE_SIDED\n\t\t\tvIndirectBack += getHemisphereLightIrradiance( hemisphereLights[ i ], backGeometry );\n\t\t#endif\n\t}\n#endif";
-
-	var lights_pars_begin = "uniform vec3 ambientLightColor;\nuniform vec3 lightProbe[ 9 ];\nvec3 shGetIrradianceAt( in vec3 normal, in vec3 shCoefficients[ 9 ] ) {\n\tfloat x = normal.x, y = normal.y, z = normal.z;\n\tvec3 result = shCoefficients[ 0 ] * 0.886227;\n\tresult += shCoefficients[ 1 ] * 2.0 * 0.511664 * y;\n\tresult += shCoefficients[ 2 ] * 2.0 * 0.511664 * z;\n\tresult += shCoefficients[ 3 ] * 2.0 * 0.511664 * x;\n\tresult += shCoefficients[ 4 ] * 2.0 * 0.429043 * x * y;\n\tresult += shCoefficients[ 5 ] * 2.0 * 0.429043 * y * z;\n\tresult += shCoefficients[ 6 ] * ( 0.743125 * z * z - 0.247708 );\n\tresult += shCoefficients[ 7 ] * 2.0 * 0.429043 * x * z;\n\tresult += shCoefficients[ 8 ] * 0.429043 * ( x * x - y * y );\n\treturn result;\n}\nvec3 getLightProbeIrradiance( const in vec3 lightProbe[ 9 ], const in GeometricContext geometry ) {\n\tvec3 worldNormal = inverseTransformDirection( geometry.normal, viewMatrix );\n\tvec3 irradiance = shGetIrradianceAt( worldNormal, lightProbe );\n\treturn irradiance;\n}\nvec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {\n\tvec3 irradiance = ambientLightColor;\n\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\tirradiance *= PI;\n\t#endif\n\treturn irradiance;\n}\n#if NUM_DIR_LIGHTS > 0\n\tstruct DirectionalLight {\n\t\tvec3 direction;\n\t\tvec3 color;\n\t\tint shadow;\n\t\tfloat shadowBias;\n\t\tfloat shadowRadius;\n\t\tvec2 shadowMapSize;\n\t};\n\tuniform DirectionalLight directionalLights[ NUM_DIR_LIGHTS ];\n\tvoid getDirectionalDirectLightIrradiance( const in DirectionalLight directionalLight, const in GeometricContext geometry, out IncidentLight directLight ) {\n\t\tdirectLight.color = directionalLight.color;\n\t\tdirectLight.direction = directionalLight.direction;\n\t\tdirectLight.visible = true;\n\t}\n#endif\n#if NUM_POINT_LIGHTS > 0\n\tstruct PointLight {\n\t\tvec3 position;\n\t\tvec3 color;\n\t\tfloat distance;\n\t\tfloat decay;\n\t\tint shadow;\n\t\tfloat shadowBias;\n\t\tfloat shadowRadius;\n\t\tvec2 shadowMapSize;\n\t\tfloat shadowCameraNear;\n\t\tfloat shadowCameraFar;\n\t};\n\tuniform PointLight pointLights[ NUM_POINT_LIGHTS ];\n\tvoid getPointDirectLightIrradiance( const in PointLight pointLight, const in GeometricContext geometry, out IncidentLight directLight ) {\n\t\tvec3 lVector = pointLight.position - geometry.position;\n\t\tdirectLight.direction = normalize( lVector );\n\t\tfloat lightDistance = length( lVector );\n\t\tdirectLight.color = pointLight.color;\n\t\tdirectLight.color *= punctualLightIntensityToIrradianceFactor( lightDistance, pointLight.distance, pointLight.decay );\n\t\tdirectLight.visible = ( directLight.color != vec3( 0.0 ) );\n\t}\n#endif\n#if NUM_SPOT_LIGHTS > 0\n\tstruct SpotLight {\n\t\tvec3 position;\n\t\tvec3 direction;\n\t\tvec3 color;\n\t\tfloat distance;\n\t\tfloat decay;\n\t\tfloat coneCos;\n\t\tfloat penumbraCos;\n\t\tint shadow;\n\t\tfloat shadowBias;\n\t\tfloat shadowRadius;\n\t\tvec2 shadowMapSize;\n\t};\n\tuniform SpotLight spotLights[ NUM_SPOT_LIGHTS ];\n\tvoid getSpotDirectLightIrradiance( const in SpotLight spotLight, const in GeometricContext geometry, out IncidentLight directLight  ) {\n\t\tvec3 lVector = spotLight.position - geometry.position;\n\t\tdirectLight.direction = normalize( lVector );\n\t\tfloat lightDistance = length( lVector );\n\t\tfloat angleCos = dot( directLight.direction, spotLight.direction );\n\t\tif ( angleCos > spotLight.coneCos ) {\n\t\t\tfloat spotEffect = smoothstep( spotLight.coneCos, spotLight.penumbraCos, angleCos );\n\t\t\tdirectLight.color = spotLight.color;\n\t\t\tdirectLight.color *= spotEffect * punctualLightIntensityToIrradianceFactor( lightDistance, spotLight.distance, spotLight.decay );\n\t\t\tdirectLight.visible = true;\n\t\t} else {\n\t\t\tdirectLight.color = vec3( 0.0 );\n\t\t\tdirectLight.visible = false;\n\t\t}\n\t}\n#endif\n#if NUM_RECT_AREA_LIGHTS > 0\n\tstruct RectAreaLight {\n\t\tvec3 color;\n\t\tvec3 position;\n\t\tvec3 halfWidth;\n\t\tvec3 halfHeight;\n\t};\n\tuniform sampler2D ltc_1;\tuniform sampler2D ltc_2;\n\tuniform RectAreaLight rectAreaLights[ NUM_RECT_AREA_LIGHTS ];\n#endif\n#if NUM_HEMI_LIGHTS > 0\n\tstruct HemisphereLight {\n\t\tvec3 direction;\n\t\tvec3 skyColor;\n\t\tvec3 groundColor;\n\t};\n\tuniform HemisphereLight hemisphereLights[ NUM_HEMI_LIGHTS ];\n\tvec3 getHemisphereLightIrradiance( const in HemisphereLight hemiLight, const in GeometricContext geometry ) {\n\t\tfloat dotNL = dot( geometry.normal, hemiLight.direction );\n\t\tfloat hemiDiffuseWeight = 0.5 * dotNL + 0.5;\n\t\tvec3 irradiance = mix( hemiLight.groundColor, hemiLight.skyColor, hemiDiffuseWeight );\n\t\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\t\tirradiance *= PI;\n\t\t#endif\n\t\treturn irradiance;\n\t}\n#endif";
-
-	var envmap_physical_pars_fragment = "#if defined( USE_ENVMAP ) && defined( PHYSICAL )\n\tvec3 getLightProbeIndirectIrradiance( const in GeometricContext geometry, const in int maxMIPLevel ) {\n\t\tvec3 worldNormal = inverseTransformDirection( geometry.normal, viewMatrix );\n\t\t#ifdef ENVMAP_TYPE_CUBE\n\t\t\tvec3 queryVec = vec3( flipEnvMap * worldNormal.x, worldNormal.yz );\n\t\t\t#ifdef TEXTURE_LOD_EXT\n\t\t\t\tvec4 envMapColor = textureCubeLodEXT( envMap, queryVec, float( maxMIPLevel ) );\n\t\t\t#else\n\t\t\t\tvec4 envMapColor = textureCube( envMap, queryVec, float( maxMIPLevel ) );\n\t\t\t#endif\n\t\t\tenvMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;\n\t\t#elif defined( ENVMAP_TYPE_CUBE_UV )\n\t\t\tvec3 queryVec = vec3( flipEnvMap * worldNormal.x, worldNormal.yz );\n\t\t\tvec4 envMapColor = textureCubeUV( envMap, queryVec, 1.0 );\n\t\t#else\n\t\t\tvec4 envMapColor = vec4( 0.0 );\n\t\t#endif\n\t\treturn PI * envMapColor.rgb * envMapIntensity;\n\t}\n\tfloat getSpecularMIPLevel( const in float blinnShininessExponent, const in int maxMIPLevel ) {\n\t\tfloat maxMIPLevelScalar = float( maxMIPLevel );\n\t\tfloat desiredMIPLevel = maxMIPLevelScalar + 0.79248 - 0.5 * log2( pow2( blinnShininessExponent ) + 1.0 );\n\t\treturn clamp( desiredMIPLevel, 0.0, maxMIPLevelScalar );\n\t}\n\tvec3 getLightProbeIndirectRadiance( const in GeometricContext geometry, const in float blinnShininessExponent, const in int maxMIPLevel ) {\n\t\t#ifdef ENVMAP_MODE_REFLECTION\n\t\t\tvec3 reflectVec = reflect( -geometry.viewDir, geometry.normal );\n\t\t#else\n\t\t\tvec3 reflectVec = refract( -geometry.viewDir, geometry.normal, refractionRatio );\n\t\t#endif\n\t\treflectVec = inverseTransformDirection( reflectVec, viewMatrix );\n\t\tfloat specularMIPLevel = getSpecularMIPLevel( blinnShininessExponent, maxMIPLevel );\n\t\t#ifdef ENVMAP_TYPE_CUBE\n\t\t\tvec3 queryReflectVec = vec3( flipEnvMap * reflectVec.x, reflectVec.yz );\n\t\t\t#ifdef TEXTURE_LOD_EXT\n\t\t\t\tvec4 envMapColor = textureCubeLodEXT( envMap, queryReflectVec, specularMIPLevel );\n\t\t\t#else\n\t\t\t\tvec4 envMapColor = textureCube( envMap, queryReflectVec, specularMIPLevel );\n\t\t\t#endif\n\t\t\tenvMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;\n\t\t#elif defined( ENVMAP_TYPE_CUBE_UV )\n\t\t\tvec3 queryReflectVec = vec3( flipEnvMap * reflectVec.x, reflectVec.yz );\n\t\t\tvec4 envMapColor = textureCubeUV( envMap, queryReflectVec, BlinnExponentToGGXRoughness(blinnShininessExponent ));\n\t\t#elif defined( ENVMAP_TYPE_EQUIREC )\n\t\t\tvec2 sampleUV;\n\t\t\tsampleUV.y = asin( clamp( reflectVec.y, - 1.0, 1.0 ) ) * RECIPROCAL_PI + 0.5;\n\t\t\tsampleUV.x = atan( reflectVec.z, reflectVec.x ) * RECIPROCAL_PI2 + 0.5;\n\t\t\t#ifdef TEXTURE_LOD_EXT\n\t\t\t\tvec4 envMapColor = texture2DLodEXT( envMap, sampleUV, specularMIPLevel );\n\t\t\t#else\n\t\t\t\tvec4 envMapColor = texture2D( envMap, sampleUV, specularMIPLevel );\n\t\t\t#endif\n\t\t\tenvMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;\n\t\t#elif defined( ENVMAP_TYPE_SPHERE )\n\t\t\tvec3 reflectView = normalize( ( viewMatrix * vec4( reflectVec, 0.0 ) ).xyz + vec3( 0.0,0.0,1.0 ) );\n\t\t\t#ifdef TEXTURE_LOD_EXT\n\t\t\t\tvec4 envMapColor = texture2DLodEXT( envMap, reflectView.xy * 0.5 + 0.5, specularMIPLevel );\n\t\t\t#else\n\t\t\t\tvec4 envMapColor = texture2D( envMap, reflectView.xy * 0.5 + 0.5, specularMIPLevel );\n\t\t\t#endif\n\t\t\tenvMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;\n\t\t#endif\n\t\treturn envMapColor.rgb * envMapIntensity;\n\t}\n#endif";
-
-	var lights_phong_fragment = "BlinnPhongMaterial material;\nmaterial.diffuseColor = diffuseColor.rgb;\nmaterial.specularColor = specular;\nmaterial.specularShininess = shininess;\nmaterial.specularStrength = specularStrength;";
-
-	var lights_phong_pars_fragment = "varying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\nstruct BlinnPhongMaterial {\n\tvec3\tdiffuseColor;\n\tvec3\tspecularColor;\n\tfloat\tspecularShininess;\n\tfloat\tspecularStrength;\n};\nvoid RE_Direct_BlinnPhong( const in IncidentLight directLight, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {\n\t#ifdef TOON\n\t\tvec3 irradiance = getGradientIrradiance( geometry.normal, directLight.direction ) * directLight.color;\n\t#else\n\t\tfloat dotNL = saturate( dot( geometry.normal, directLight.direction ) );\n\t\tvec3 irradiance = dotNL * directLight.color;\n\t#endif\n\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\tirradiance *= PI;\n\t#endif\n\treflectedLight.directDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );\n\treflectedLight.directSpecular += irradiance * BRDF_Specular_BlinnPhong( directLight, geometry, material.specularColor, material.specularShininess ) * material.specularStrength;\n}\nvoid RE_IndirectDiffuse_BlinnPhong( const in vec3 irradiance, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {\n\treflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );\n}\n#define RE_Direct\t\t\t\tRE_Direct_BlinnPhong\n#define RE_IndirectDiffuse\t\tRE_IndirectDiffuse_BlinnPhong\n#define Material_LightProbeLOD( material )\t(0)";
-
-	var lights_physical_fragment = "PhysicalMaterial material;\nmaterial.diffuseColor = diffuseColor.rgb * ( 1.0 - metalnessFactor );\nmaterial.specularRoughness = clamp( roughnessFactor, 0.04, 1.0 );\n#ifdef STANDARD\n\tmaterial.specularColor = mix( vec3( DEFAULT_SPECULAR_COEFFICIENT ), diffuseColor.rgb, metalnessFactor );\n#else\n\tmaterial.specularColor = mix( vec3( MAXIMUM_SPECULAR_COEFFICIENT * pow2( reflectivity ) ), diffuseColor.rgb, metalnessFactor );\n\tmaterial.clearCoat = saturate( clearCoat );\tmaterial.clearCoatRoughness = clamp( clearCoatRoughness, 0.04, 1.0 );\n#endif";
-
-	var lights_physical_pars_fragment = "struct PhysicalMaterial {\n\tvec3\tdiffuseColor;\n\tfloat\tspecularRoughness;\n\tvec3\tspecularColor;\n\t#ifndef STANDARD\n\t\tfloat clearCoat;\n\t\tfloat clearCoatRoughness;\n\t#endif\n};\n#define MAXIMUM_SPECULAR_COEFFICIENT 0.16\n#define DEFAULT_SPECULAR_COEFFICIENT 0.04\nfloat clearCoatDHRApprox( const in float roughness, const in float dotNL ) {\n\treturn DEFAULT_SPECULAR_COEFFICIENT + ( 1.0 - DEFAULT_SPECULAR_COEFFICIENT ) * ( pow( 1.0 - dotNL, 5.0 ) * pow( 1.0 - roughness, 2.0 ) );\n}\n#if NUM_RECT_AREA_LIGHTS > 0\n\tvoid RE_Direct_RectArea_Physical( const in RectAreaLight rectAreaLight, const in GeometricContext geometry, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {\n\t\tvec3 normal = geometry.normal;\n\t\tvec3 viewDir = geometry.viewDir;\n\t\tvec3 position = geometry.position;\n\t\tvec3 lightPos = rectAreaLight.position;\n\t\tvec3 halfWidth = rectAreaLight.halfWidth;\n\t\tvec3 halfHeight = rectAreaLight.halfHeight;\n\t\tvec3 lightColor = rectAreaLight.color;\n\t\tfloat roughness = material.specularRoughness;\n\t\tvec3 rectCoords[ 4 ];\n\t\trectCoords[ 0 ] = lightPos + halfWidth - halfHeight;\t\trectCoords[ 1 ] = lightPos - halfWidth - halfHeight;\n\t\trectCoords[ 2 ] = lightPos - halfWidth + halfHeight;\n\t\trectCoords[ 3 ] = lightPos + halfWidth + halfHeight;\n\t\tvec2 uv = LTC_Uv( normal, viewDir, roughness );\n\t\tvec4 t1 = texture2D( ltc_1, uv );\n\t\tvec4 t2 = texture2D( ltc_2, uv );\n\t\tmat3 mInv = mat3(\n\t\t\tvec3( t1.x, 0, t1.y ),\n\t\t\tvec3(    0, 1,    0 ),\n\t\t\tvec3( t1.z, 0, t1.w )\n\t\t);\n\t\tvec3 fresnel = ( material.specularColor * t2.x + ( vec3( 1.0 ) - material.specularColor ) * t2.y );\n\t\treflectedLight.directSpecular += lightColor * fresnel * LTC_Evaluate( normal, viewDir, position, mInv, rectCoords );\n\t\treflectedLight.directDiffuse += lightColor * material.diffuseColor * LTC_Evaluate( normal, viewDir, position, mat3( 1.0 ), rectCoords );\n\t}\n#endif\nvoid RE_Direct_Physical( const in IncidentLight directLight, const in GeometricContext geometry, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {\n\tfloat dotNL = saturate( dot( geometry.normal, directLight.direction ) );\n\tvec3 irradiance = dotNL * directLight.color;\n\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\tirradiance *= PI;\n\t#endif\n\t#ifndef STANDARD\n\t\tfloat clearCoatDHR = material.clearCoat * clearCoatDHRApprox( material.clearCoatRoughness, dotNL );\n\t#else\n\t\tfloat clearCoatDHR = 0.0;\n\t#endif\n\treflectedLight.directSpecular += ( 1.0 - clearCoatDHR ) * irradiance * BRDF_Specular_GGX( directLight, geometry, material.specularColor, material.specularRoughness );\n\treflectedLight.directDiffuse += ( 1.0 - clearCoatDHR ) * irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );\n\t#ifndef STANDARD\n\t\treflectedLight.directSpecular += irradiance * material.clearCoat * BRDF_Specular_GGX( directLight, geometry, vec3( DEFAULT_SPECULAR_COEFFICIENT ), material.clearCoatRoughness );\n\t#endif\n}\nvoid RE_IndirectDiffuse_Physical( const in vec3 irradiance, const in GeometricContext geometry, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {\n\t#ifndef ENVMAP_TYPE_CUBE_UV\n\t\treflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );\n\t#endif\n}\nvoid RE_IndirectSpecular_Physical( const in vec3 radiance, const in vec3 irradiance, const in vec3 clearCoatRadiance, const in GeometricContext geometry, const in PhysicalMaterial material, inout ReflectedLight reflectedLight) {\n\t#ifndef STANDARD\n\t\tfloat dotNV = saturate( dot( geometry.normal, geometry.viewDir ) );\n\t\tfloat dotNL = dotNV;\n\t\tfloat clearCoatDHR = material.clearCoat * clearCoatDHRApprox( material.clearCoatRoughness, dotNL );\n\t#else\n\t\tfloat clearCoatDHR = 0.0;\n\t#endif\n\tfloat clearCoatInv = 1.0 - clearCoatDHR;\n\t#if defined( ENVMAP_TYPE_CUBE_UV )\n\t\tvec3 singleScattering = vec3( 0.0 );\n\t\tvec3 multiScattering = vec3( 0.0 );\n\t\tvec3 cosineWeightedIrradiance = irradiance * RECIPROCAL_PI;\n\t\tBRDF_Specular_Multiscattering_Environment( geometry, material.specularColor, material.specularRoughness, singleScattering, multiScattering );\n\t\tvec3 diffuse = material.diffuseColor * ( 1.0 - ( singleScattering + multiScattering ) );\n\t\treflectedLight.indirectSpecular += clearCoatInv * radiance * singleScattering;\n\t\treflectedLight.indirectDiffuse += multiScattering * cosineWeightedIrradiance;\n\t\treflectedLight.indirectDiffuse += diffuse * cosineWeightedIrradiance;\n\t#else\n\t\treflectedLight.indirectSpecular += clearCoatInv * radiance * BRDF_Specular_GGX_Environment( geometry, material.specularColor, material.specularRoughness );\n\t#endif\n\t#ifndef STANDARD\n\t\treflectedLight.indirectSpecular += clearCoatRadiance * material.clearCoat * BRDF_Specular_GGX_Environment( geometry, vec3( DEFAULT_SPECULAR_COEFFICIENT ), material.clearCoatRoughness );\n\t#endif\n}\n#define RE_Direct\t\t\t\tRE_Direct_Physical\n#define RE_Direct_RectArea\t\tRE_Direct_RectArea_Physical\n#define RE_IndirectDiffuse\t\tRE_IndirectDiffuse_Physical\n#define RE_IndirectSpecular\t\tRE_IndirectSpecular_Physical\n#define Material_BlinnShininessExponent( material )   GGXRoughnessToBlinnExponent( material.specularRoughness )\n#define Material_ClearCoat_BlinnShininessExponent( material )   GGXRoughnessToBlinnExponent( material.clearCoatRoughness )\nfloat computeSpecularOcclusion( const in float dotNV, const in float ambientOcclusion, const in float roughness ) {\n\treturn saturate( pow( dotNV + ambientOcclusion, exp2( - 16.0 * roughness - 1.0 ) ) - 1.0 + ambientOcclusion );\n}";
-
-	var lights_fragment_begin = "\nGeometricContext geometry;\ngeometry.position = - vViewPosition;\ngeometry.normal = normal;\ngeometry.viewDir = normalize( vViewPosition );\nIncidentLight directLight;\n#if ( NUM_POINT_LIGHTS > 0 ) && defined( RE_Direct )\n\tPointLight pointLight;\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {\n\t\tpointLight = pointLights[ i ];\n\t\tgetPointDirectLightIrradiance( pointLight, geometry, directLight );\n\t\t#ifdef USE_SHADOWMAP\n\t\tdirectLight.color *= all( bvec2( pointLight.shadow, directLight.visible ) ) ? getPointShadow( pointShadowMap[ i ], pointLight.shadowMapSize, pointLight.shadowBias, pointLight.shadowRadius, vPointShadowCoord[ i ], pointLight.shadowCameraNear, pointLight.shadowCameraFar ) : 1.0;\n\t\t#endif\n\t\tRE_Direct( directLight, geometry, material, reflectedLight );\n\t}\n#endif\n#if ( NUM_SPOT_LIGHTS > 0 ) && defined( RE_Direct )\n\tSpotLight spotLight;\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {\n\t\tspotLight = spotLights[ i ];\n\t\tgetSpotDirectLightIrradiance( spotLight, geometry, directLight );\n\t\t#ifdef USE_SHADOWMAP\n\t\tdirectLight.color *= all( bvec2( spotLight.shadow, directLight.visible ) ) ? getShadow( spotShadowMap[ i ], spotLight.shadowMapSize, spotLight.shadowBias, spotLight.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;\n\t\t#endif\n\t\tRE_Direct( directLight, geometry, material, reflectedLight );\n\t}\n#endif\n#if ( NUM_DIR_LIGHTS > 0 ) && defined( RE_Direct )\n\tDirectionalLight directionalLight;\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {\n\t\tdirectionalLight = directionalLights[ i ];\n\t\tgetDirectionalDirectLightIrradiance( directionalLight, geometry, directLight );\n\t\t#ifdef USE_SHADOWMAP\n\t\tdirectLight.color *= all( bvec2( directionalLight.shadow, directLight.visible ) ) ? getShadow( directionalShadowMap[ i ], directionalLight.shadowMapSize, directionalLight.shadowBias, directionalLight.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;\n\t\t#endif\n\t\tRE_Direct( directLight, geometry, material, reflectedLight );\n\t}\n#endif\n#if ( NUM_RECT_AREA_LIGHTS > 0 ) && defined( RE_Direct_RectArea )\n\tRectAreaLight rectAreaLight;\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_RECT_AREA_LIGHTS; i ++ ) {\n\t\trectAreaLight = rectAreaLights[ i ];\n\t\tRE_Direct_RectArea( rectAreaLight, geometry, material, reflectedLight );\n\t}\n#endif\n#if defined( RE_IndirectDiffuse )\n\tvec3 irradiance = getAmbientLightIrradiance( ambientLightColor );\n\tirradiance += getLightProbeIrradiance( lightProbe, geometry );\n\t#if ( NUM_HEMI_LIGHTS > 0 )\n\t\t#pragma unroll_loop\n\t\tfor ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {\n\t\t\tirradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );\n\t\t}\n\t#endif\n#endif\n#if defined( RE_IndirectSpecular )\n\tvec3 radiance = vec3( 0.0 );\n\tvec3 clearCoatRadiance = vec3( 0.0 );\n#endif";
-
-	var lights_fragment_maps = "#if defined( RE_IndirectDiffuse )\n\t#ifdef USE_LIGHTMAP\n\t\tvec3 lightMapIrradiance = texture2D( lightMap, vUv2 ).xyz * lightMapIntensity;\n\t\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\t\tlightMapIrradiance *= PI;\n\t\t#endif\n\t\tirradiance += lightMapIrradiance;\n\t#endif\n\t#if defined( USE_ENVMAP ) && defined( PHYSICAL ) && defined( ENVMAP_TYPE_CUBE_UV )\n\t\tirradiance += getLightProbeIndirectIrradiance( geometry, maxMipLevel );\n\t#endif\n#endif\n#if defined( USE_ENVMAP ) && defined( RE_IndirectSpecular )\n\tradiance += getLightProbeIndirectRadiance( geometry, Material_BlinnShininessExponent( material ), maxMipLevel );\n\t#ifndef STANDARD\n\t\tclearCoatRadiance += getLightProbeIndirectRadiance( geometry, Material_ClearCoat_BlinnShininessExponent( material ), maxMipLevel );\n\t#endif\n#endif";
-
-	var lights_fragment_end = "#if defined( RE_IndirectDiffuse )\n\tRE_IndirectDiffuse( irradiance, geometry, material, reflectedLight );\n#endif\n#if defined( RE_IndirectSpecular )\n\tRE_IndirectSpecular( radiance, irradiance, clearCoatRadiance, geometry, material, reflectedLight );\n#endif";
-
-	var logdepthbuf_fragment = "#if defined( USE_LOGDEPTHBUF ) && defined( USE_LOGDEPTHBUF_EXT )\n\tgl_FragDepthEXT = log2( vFragDepth ) * logDepthBufFC * 0.5;\n#endif";
-
-	var logdepthbuf_pars_fragment = "#if defined( USE_LOGDEPTHBUF ) && defined( USE_LOGDEPTHBUF_EXT )\n\tuniform float logDepthBufFC;\n\tvarying float vFragDepth;\n#endif";
-
-	var logdepthbuf_pars_vertex = "#ifdef USE_LOGDEPTHBUF\n\t#ifdef USE_LOGDEPTHBUF_EXT\n\t\tvarying float vFragDepth;\n\t#else\n\t\tuniform float logDepthBufFC;\n\t#endif\n#endif";
-
-	var logdepthbuf_vertex = "#ifdef USE_LOGDEPTHBUF\n\t#ifdef USE_LOGDEPTHBUF_EXT\n\t\tvFragDepth = 1.0 + gl_Position.w;\n\t#else\n\t\tgl_Position.z = log2( max( EPSILON, gl_Position.w + 1.0 ) ) * logDepthBufFC - 1.0;\n\t\tgl_Position.z *= gl_Position.w;\n\t#endif\n#endif";
-
-	var map_fragment = "#ifdef USE_MAP\n\tvec4 texelColor = texture2D( map, vUv );\n\ttexelColor = mapTexelToLinear( texelColor );\n\tdiffuseColor *= texelColor;\n#endif";
-
-	var map_pars_fragment = "#ifdef USE_MAP\n\tuniform sampler2D map;\n#endif";
-
-	var map_particle_fragment = "#ifdef USE_MAP\n\tvec2 uv = ( uvTransform * vec3( gl_PointCoord.x, 1.0 - gl_PointCoord.y, 1 ) ).xy;\n\tvec4 mapTexel = texture2D( map, uv );\n\tdiffuseColor *= mapTexelToLinear( mapTexel );\n#endif";
-
-	var map_particle_pars_fragment = "#ifdef USE_MAP\n\tuniform mat3 uvTransform;\n\tuniform sampler2D map;\n#endif";
-
-	var metalnessmap_fragment = "float metalnessFactor = metalness;\n#ifdef USE_METALNESSMAP\n\tvec4 texelMetalness = texture2D( metalnessMap, vUv );\n\tmetalnessFactor *= texelMetalness.b;\n#endif";
-
-	var metalnessmap_pars_fragment = "#ifdef USE_METALNESSMAP\n\tuniform sampler2D metalnessMap;\n#endif";
-
-	var morphnormal_vertex = "#ifdef USE_MORPHNORMALS\n\tobjectNormal += ( morphNormal0 - normal ) * morphTargetInfluences[ 0 ];\n\tobjectNormal += ( morphNormal1 - normal ) * morphTargetInfluences[ 1 ];\n\tobjectNormal += ( morphNormal2 - normal ) * morphTargetInfluences[ 2 ];\n\tobjectNormal += ( morphNormal3 - normal ) * morphTargetInfluences[ 3 ];\n#endif";
-
-	var morphtarget_pars_vertex = "#ifdef USE_MORPHTARGETS\n\t#ifndef USE_MORPHNORMALS\n\tuniform float morphTargetInfluences[ 8 ];\n\t#else\n\tuniform float morphTargetInfluences[ 4 ];\n\t#endif\n#endif";
-
-	var morphtarget_vertex = "#ifdef USE_MORPHTARGETS\n\ttransformed += ( morphTarget0 - position ) * morphTargetInfluences[ 0 ];\n\ttransformed += ( morphTarget1 - position ) * morphTargetInfluences[ 1 ];\n\ttransformed += ( morphTarget2 - position ) * morphTargetInfluences[ 2 ];\n\ttransformed += ( morphTarget3 - position ) * morphTargetInfluences[ 3 ];\n\t#ifndef USE_MORPHNORMALS\n\ttransformed += ( morphTarget4 - position ) * morphTargetInfluences[ 4 ];\n\ttransformed += ( morphTarget5 - position ) * morphTargetInfluences[ 5 ];\n\ttransformed += ( morphTarget6 - position ) * morphTargetInfluences[ 6 ];\n\ttransformed += ( morphTarget7 - position ) * morphTargetInfluences[ 7 ];\n\t#endif\n#endif";
-
-	var normal_fragment_begin = "#ifdef FLAT_SHADED\n\tvec3 fdx = vec3( dFdx( vViewPosition.x ), dFdx( vViewPosition.y ), dFdx( vViewPosition.z ) );\n\tvec3 fdy = vec3( dFdy( vViewPosition.x ), dFdy( vViewPosition.y ), dFdy( vViewPosition.z ) );\n\tvec3 normal = normalize( cross( fdx, fdy ) );\n#else\n\tvec3 normal = normalize( vNormal );\n\t#ifdef DOUBLE_SIDED\n\t\tnormal = normal * ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t#endif\n\t#ifdef USE_TANGENT\n\t\tvec3 tangent = normalize( vTangent );\n\t\tvec3 bitangent = normalize( vBitangent );\n\t\t#ifdef DOUBLE_SIDED\n\t\t\ttangent = tangent * ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t\t\tbitangent = bitangent * ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t\t#endif\n\t#endif\n#endif";
-
-	var normal_fragment_maps = "#ifdef USE_NORMALMAP\n\t#ifdef OBJECTSPACE_NORMALMAP\n\t\tnormal = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0;\n\t\t#ifdef FLIP_SIDED\n\t\t\tnormal = - normal;\n\t\t#endif\n\t\t#ifdef DOUBLE_SIDED\n\t\t\tnormal = normal * ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t\t#endif\n\t\tnormal = normalize( normalMatrix * normal );\n\t#else\n\t\t#ifdef USE_TANGENT\n\t\t\tmat3 vTBN = mat3( tangent, bitangent, normal );\n\t\t\tvec3 mapN = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0;\n\t\t\tmapN.xy = normalScale * mapN.xy;\n\t\t\tnormal = normalize( vTBN * mapN );\n\t\t#else\n\t\t\tnormal = perturbNormal2Arb( -vViewPosition, normal );\n\t\t#endif\n\t#endif\n#elif defined( USE_BUMPMAP )\n\tnormal = perturbNormalArb( -vViewPosition, normal, dHdxy_fwd() );\n#endif";
-
-	var normalmap_pars_fragment = "#ifdef USE_NORMALMAP\n\tuniform sampler2D normalMap;\n\tuniform vec2 normalScale;\n\t#ifdef OBJECTSPACE_NORMALMAP\n\t\tuniform mat3 normalMatrix;\n\t#else\n\t\tvec3 perturbNormal2Arb( vec3 eye_pos, vec3 surf_norm ) {\n\t\t\tvec3 q0 = vec3( dFdx( eye_pos.x ), dFdx( eye_pos.y ), dFdx( eye_pos.z ) );\n\t\t\tvec3 q1 = vec3( dFdy( eye_pos.x ), dFdy( eye_pos.y ), dFdy( eye_pos.z ) );\n\t\t\tvec2 st0 = dFdx( vUv.st );\n\t\t\tvec2 st1 = dFdy( vUv.st );\n\t\t\tfloat scale = sign( st1.t * st0.s - st0.t * st1.s );\n\t\t\tvec3 S = normalize( ( q0 * st1.t - q1 * st0.t ) * scale );\n\t\t\tvec3 T = normalize( ( - q0 * st1.s + q1 * st0.s ) * scale );\n\t\t\tvec3 N = normalize( surf_norm );\n\t\t\tmat3 tsn = mat3( S, T, N );\n\t\t\tvec3 mapN = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0;\n\t\t\tmapN.xy *= normalScale;\n\t\t\tmapN.xy *= ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t\t\treturn normalize( tsn * mapN );\n\t\t}\n\t#endif\n#endif";
-
-	var packing = "vec3 packNormalToRGB( const in vec3 normal ) {\n\treturn normalize( normal ) * 0.5 + 0.5;\n}\nvec3 unpackRGBToNormal( const in vec3 rgb ) {\n\treturn 2.0 * rgb.xyz - 1.0;\n}\nconst float PackUpscale = 256. / 255.;const float UnpackDownscale = 255. / 256.;\nconst vec3 PackFactors = vec3( 256. * 256. * 256., 256. * 256.,  256. );\nconst vec4 UnpackFactors = UnpackDownscale / vec4( PackFactors, 1. );\nconst float ShiftRight8 = 1. / 256.;\nvec4 packDepthToRGBA( const in float v ) {\n\tvec4 r = vec4( fract( v * PackFactors ), v );\n\tr.yzw -= r.xyz * ShiftRight8;\treturn r * PackUpscale;\n}\nfloat unpackRGBAToDepth( const in vec4 v ) {\n\treturn dot( v, UnpackFactors );\n}\nfloat viewZToOrthographicDepth( const in float viewZ, const in float near, const in float far ) {\n\treturn ( viewZ + near ) / ( near - far );\n}\nfloat orthographicDepthToViewZ( const in float linearClipZ, const in float near, const in float far ) {\n\treturn linearClipZ * ( near - far ) - near;\n}\nfloat viewZToPerspectiveDepth( const in float viewZ, const in float near, const in float far ) {\n\treturn (( near + viewZ ) * far ) / (( far - near ) * viewZ );\n}\nfloat perspectiveDepthToViewZ( const in float invClipZ, const in float near, const in float far ) {\n\treturn ( near * far ) / ( ( far - near ) * invClipZ - far );\n}";
-
-	var premultiplied_alpha_fragment = "#ifdef PREMULTIPLIED_ALPHA\n\tgl_FragColor.rgb *= gl_FragColor.a;\n#endif";
-
-	var project_vertex = "vec4 mvPosition = modelViewMatrix * vec4( transformed, 1.0 );\ngl_Position = projectionMatrix * mvPosition;";
-
-	var dithering_fragment = "#if defined( DITHERING )\n\tgl_FragColor.rgb = dithering( gl_FragColor.rgb );\n#endif";
-
-	var dithering_pars_fragment = "#if defined( DITHERING )\n\tvec3 dithering( vec3 color ) {\n\t\tfloat grid_position = rand( gl_FragCoord.xy );\n\t\tvec3 dither_shift_RGB = vec3( 0.25 / 255.0, -0.25 / 255.0, 0.25 / 255.0 );\n\t\tdither_shift_RGB = mix( 2.0 * dither_shift_RGB, -2.0 * dither_shift_RGB, grid_position );\n\t\treturn color + dither_shift_RGB;\n\t}\n#endif";
-
-	var roughnessmap_fragment = "float roughnessFactor = roughness;\n#ifdef USE_ROUGHNESSMAP\n\tvec4 texelRoughness = texture2D( roughnessMap, vUv );\n\troughnessFactor *= texelRoughness.g;\n#endif";
-
-	var roughnessmap_pars_fragment = "#ifdef USE_ROUGHNESSMAP\n\tuniform sampler2D roughnessMap;\n#endif";
-
-	var shadowmap_pars_fragment = "#ifdef USE_SHADOWMAP\n\t#if NUM_DIR_LIGHTS > 0\n\t\tuniform sampler2D directionalShadowMap[ NUM_DIR_LIGHTS ];\n\t\tvarying vec4 vDirectionalShadowCoord[ NUM_DIR_LIGHTS ];\n\t#endif\n\t#if NUM_SPOT_LIGHTS > 0\n\t\tuniform sampler2D spotShadowMap[ NUM_SPOT_LIGHTS ];\n\t\tvarying vec4 vSpotShadowCoord[ NUM_SPOT_LIGHTS ];\n\t#endif\n\t#if NUM_POINT_LIGHTS > 0\n\t\tuniform sampler2D pointShadowMap[ NUM_POINT_LIGHTS ];\n\t\tvarying vec4 vPointShadowCoord[ NUM_POINT_LIGHTS ];\n\t#endif\n\tfloat texture2DCompare( sampler2D depths, vec2 uv, float compare ) {\n\t\treturn step( compare, unpackRGBAToDepth( texture2D( depths, uv ) ) );\n\t}\n\tfloat texture2DShadowLerp( sampler2D depths, vec2 size, vec2 uv, float compare ) {\n\t\tconst vec2 offset = vec2( 0.0, 1.0 );\n\t\tvec2 texelSize = vec2( 1.0 ) / size;\n\t\tvec2 centroidUV = floor( uv * size + 0.5 ) / size;\n\t\tfloat lb = texture2DCompare( depths, centroidUV + texelSize * offset.xx, compare );\n\t\tfloat lt = texture2DCompare( depths, centroidUV + texelSize * offset.xy, compare );\n\t\tfloat rb = texture2DCompare( depths, centroidUV + texelSize * offset.yx, compare );\n\t\tfloat rt = texture2DCompare( depths, centroidUV + texelSize * offset.yy, compare );\n\t\tvec2 f = fract( uv * size + 0.5 );\n\t\tfloat a = mix( lb, lt, f.y );\n\t\tfloat b = mix( rb, rt, f.y );\n\t\tfloat c = mix( a, b, f.x );\n\t\treturn c;\n\t}\n\tfloat getShadow( sampler2D shadowMap, vec2 shadowMapSize, float shadowBias, float shadowRadius, vec4 shadowCoord ) {\n\t\tfloat shadow = 1.0;\n\t\tshadowCoord.xyz /= shadowCoord.w;\n\t\tshadowCoord.z += shadowBias;\n\t\tbvec4 inFrustumVec = bvec4 ( shadowCoord.x >= 0.0, shadowCoord.x <= 1.0, shadowCoord.y >= 0.0, shadowCoord.y <= 1.0 );\n\t\tbool inFrustum = all( inFrustumVec );\n\t\tbvec2 frustumTestVec = bvec2( inFrustum, shadowCoord.z <= 1.0 );\n\t\tbool frustumTest = all( frustumTestVec );\n\t\tif ( frustumTest ) {\n\t\t#if defined( SHADOWMAP_TYPE_PCF )\n\t\t\tvec2 texelSize = vec2( 1.0 ) / shadowMapSize;\n\t\t\tfloat dx0 = - texelSize.x * shadowRadius;\n\t\t\tfloat dy0 = - texelSize.y * shadowRadius;\n\t\t\tfloat dx1 = + texelSize.x * shadowRadius;\n\t\t\tfloat dy1 = + texelSize.y * shadowRadius;\n\t\t\tfloat dx2 = dx0 / 2.0;\n\t\t\tfloat dy2 = dy0 / 2.0;\n\t\t\tfloat dx3 = dx1 / 2.0;\n\t\t\tfloat dy3 = dy1 / 2.0;\n\t\t\tshadow = (\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx0, dy0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( 0.0, dy0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx1, dy0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx2, dy2 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( 0.0, dy2 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx3, dy2 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx0, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx2, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy, shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx3, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx1, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx2, dy3 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( 0.0, dy3 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx3, dy3 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx0, dy1 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( 0.0, dy1 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx1, dy1 ), shadowCoord.z )\n\t\t\t) * ( 1.0 / 17.0 );\n\t\t#elif defined( SHADOWMAP_TYPE_PCF_SOFT )\n\t\t\tvec2 texelSize = vec2( 1.0 ) / shadowMapSize;\n\t\t\tfloat dx0 = - texelSize.x * shadowRadius;\n\t\t\tfloat dy0 = - texelSize.y * shadowRadius;\n\t\t\tfloat dx1 = + texelSize.x * shadowRadius;\n\t\t\tfloat dy1 = + texelSize.y * shadowRadius;\n\t\t\tshadow = (\n\t\t\t\ttexture2DShadowLerp( shadowMap, shadowMapSize, shadowCoord.xy + vec2( dx0, dy0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DShadowLerp( shadowMap, shadowMapSize, shadowCoord.xy + vec2( 0.0, dy0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DShadowLerp( shadowMap, shadowMapSize, shadowCoord.xy + vec2( dx1, dy0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DShadowLerp( shadowMap, shadowMapSize, shadowCoord.xy + vec2( dx0, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DShadowLerp( shadowMap, shadowMapSize, shadowCoord.xy, shadowCoord.z ) +\n\t\t\t\ttexture2DShadowLerp( shadowMap, shadowMapSize, shadowCoord.xy + vec2( dx1, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DShadowLerp( shadowMap, shadowMapSize, shadowCoord.xy + vec2( dx0, dy1 ), shadowCoord.z ) +\n\t\t\t\ttexture2DShadowLerp( shadowMap, shadowMapSize, shadowCoord.xy + vec2( 0.0, dy1 ), shadowCoord.z ) +\n\t\t\t\ttexture2DShadowLerp( shadowMap, shadowMapSize, shadowCoord.xy + vec2( dx1, dy1 ), shadowCoord.z )\n\t\t\t) * ( 1.0 / 9.0 );\n\t\t#else\n\t\t\tshadow = texture2DCompare( shadowMap, shadowCoord.xy, shadowCoord.z );\n\t\t#endif\n\t\t}\n\t\treturn shadow;\n\t}\n\tvec2 cubeToUV( vec3 v, float texelSizeY ) {\n\t\tvec3 absV = abs( v );\n\t\tfloat scaleToCube = 1.0 / max( absV.x, max( absV.y, absV.z ) );\n\t\tabsV *= scaleToCube;\n\t\tv *= scaleToCube * ( 1.0 - 2.0 * texelSizeY );\n\t\tvec2 planar = v.xy;\n\t\tfloat almostATexel = 1.5 * texelSizeY;\n\t\tfloat almostOne = 1.0 - almostATexel;\n\t\tif ( absV.z >= almostOne ) {\n\t\t\tif ( v.z > 0.0 )\n\t\t\t\tplanar.x = 4.0 - v.x;\n\t\t} else if ( absV.x >= almostOne ) {\n\t\t\tfloat signX = sign( v.x );\n\t\t\tplanar.x = v.z * signX + 2.0 * signX;\n\t\t} else if ( absV.y >= almostOne ) {\n\t\t\tfloat signY = sign( v.y );\n\t\t\tplanar.x = v.x + 2.0 * signY + 2.0;\n\t\t\tplanar.y = v.z * signY - 2.0;\n\t\t}\n\t\treturn vec2( 0.125, 0.25 ) * planar + vec2( 0.375, 0.75 );\n\t}\n\tfloat getPointShadow( sampler2D shadowMap, vec2 shadowMapSize, float shadowBias, float shadowRadius, vec4 shadowCoord, float shadowCameraNear, float shadowCameraFar ) {\n\t\tvec2 texelSize = vec2( 1.0 ) / ( shadowMapSize * vec2( 4.0, 2.0 ) );\n\t\tvec3 lightToPosition = shadowCoord.xyz;\n\t\tfloat dp = ( length( lightToPosition ) - shadowCameraNear ) / ( shadowCameraFar - shadowCameraNear );\t\tdp += shadowBias;\n\t\tvec3 bd3D = normalize( lightToPosition );\n\t\t#if defined( SHADOWMAP_TYPE_PCF ) || defined( SHADOWMAP_TYPE_PCF_SOFT )\n\t\t\tvec2 offset = vec2( - 1, 1 ) * shadowRadius * texelSize.y;\n\t\t\treturn (\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.xyy, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.yyy, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.xyx, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.yyx, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.xxy, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.yxy, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.xxx, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.yxx, texelSize.y ), dp )\n\t\t\t) * ( 1.0 / 9.0 );\n\t\t#else\n\t\t\treturn texture2DCompare( shadowMap, cubeToUV( bd3D, texelSize.y ), dp );\n\t\t#endif\n\t}\n#endif";
-
-	var shadowmap_pars_vertex = "#ifdef USE_SHADOWMAP\n\t#if NUM_DIR_LIGHTS > 0\n\t\tuniform mat4 directionalShadowMatrix[ NUM_DIR_LIGHTS ];\n\t\tvarying vec4 vDirectionalShadowCoord[ NUM_DIR_LIGHTS ];\n\t#endif\n\t#if NUM_SPOT_LIGHTS > 0\n\t\tuniform mat4 spotShadowMatrix[ NUM_SPOT_LIGHTS ];\n\t\tvarying vec4 vSpotShadowCoord[ NUM_SPOT_LIGHTS ];\n\t#endif\n\t#if NUM_POINT_LIGHTS > 0\n\t\tuniform mat4 pointShadowMatrix[ NUM_POINT_LIGHTS ];\n\t\tvarying vec4 vPointShadowCoord[ NUM_POINT_LIGHTS ];\n\t#endif\n#endif";
-
-	var shadowmap_vertex = "#ifdef USE_SHADOWMAP\n\t#if NUM_DIR_LIGHTS > 0\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {\n\t\tvDirectionalShadowCoord[ i ] = directionalShadowMatrix[ i ] * worldPosition;\n\t}\n\t#endif\n\t#if NUM_SPOT_LIGHTS > 0\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {\n\t\tvSpotShadowCoord[ i ] = spotShadowMatrix[ i ] * worldPosition;\n\t}\n\t#endif\n\t#if NUM_POINT_LIGHTS > 0\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {\n\t\tvPointShadowCoord[ i ] = pointShadowMatrix[ i ] * worldPosition;\n\t}\n\t#endif\n#endif";
-
-	var shadowmask_pars_fragment = "float getShadowMask() {\n\tfloat shadow = 1.0;\n\t#ifdef USE_SHADOWMAP\n\t#if NUM_DIR_LIGHTS > 0\n\tDirectionalLight directionalLight;\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {\n\t\tdirectionalLight = directionalLights[ i ];\n\t\tshadow *= bool( directionalLight.shadow ) ? getShadow( directionalShadowMap[ i ], directionalLight.shadowMapSize, directionalLight.shadowBias, directionalLight.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;\n\t}\n\t#endif\n\t#if NUM_SPOT_LIGHTS > 0\n\tSpotLight spotLight;\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {\n\t\tspotLight = spotLights[ i ];\n\t\tshadow *= bool( spotLight.shadow ) ? getShadow( spotShadowMap[ i ], spotLight.shadowMapSize, spotLight.shadowBias, spotLight.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;\n\t}\n\t#endif\n\t#if NUM_POINT_LIGHTS > 0\n\tPointLight pointLight;\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {\n\t\tpointLight = pointLights[ i ];\n\t\tshadow *= bool( pointLight.shadow ) ? getPointShadow( pointShadowMap[ i ], pointLight.shadowMapSize, pointLight.shadowBias, pointLight.shadowRadius, vPointShadowCoord[ i ], pointLight.shadowCameraNear, pointLight.shadowCameraFar ) : 1.0;\n\t}\n\t#endif\n\t#endif\n\treturn shadow;\n}";
-
-	var skinbase_vertex = "#ifdef USE_SKINNING\n\tmat4 boneMatX = getBoneMatrix( skinIndex.x );\n\tmat4 boneMatY = getBoneMatrix( skinIndex.y );\n\tmat4 boneMatZ = getBoneMatrix( skinIndex.z );\n\tmat4 boneMatW = getBoneMatrix( skinIndex.w );\n#endif";
-
-	var skinning_pars_vertex = "#ifdef USE_SKINNING\n\tuniform mat4 bindMatrix;\n\tuniform mat4 bindMatrixInverse;\n\t#ifdef BONE_TEXTURE\n\t\tuniform highp sampler2D boneTexture;\n\t\tuniform int boneTextureSize;\n\t\tmat4 getBoneMatrix( const in float i ) {\n\t\t\tfloat j = i * 4.0;\n\t\t\tfloat x = mod( j, float( boneTextureSize ) );\n\t\t\tfloat y = floor( j / float( boneTextureSize ) );\n\t\t\tfloat dx = 1.0 / float( boneTextureSize );\n\t\t\tfloat dy = 1.0 / float( boneTextureSize );\n\t\t\ty = dy * ( y + 0.5 );\n\t\t\tvec4 v1 = texture2D( boneTexture, vec2( dx * ( x + 0.5 ), y ) );\n\t\t\tvec4 v2 = texture2D( boneTexture, vec2( dx * ( x + 1.5 ), y ) );\n\t\t\tvec4 v3 = texture2D( boneTexture, vec2( dx * ( x + 2.5 ), y ) );\n\t\t\tvec4 v4 = texture2D( boneTexture, vec2( dx * ( x + 3.5 ), y ) );\n\t\t\tmat4 bone = mat4( v1, v2, v3, v4 );\n\t\t\treturn bone;\n\t\t}\n\t#else\n\t\tuniform mat4 boneMatrices[ MAX_BONES ];\n\t\tmat4 getBoneMatrix( const in float i ) {\n\t\t\tmat4 bone = boneMatrices[ int(i) ];\n\t\t\treturn bone;\n\t\t}\n\t#endif\n#endif";
-
-	var skinning_vertex = "#ifdef USE_SKINNING\n\tvec4 skinVertex = bindMatrix * vec4( transformed, 1.0 );\n\tvec4 skinned = vec4( 0.0 );\n\tskinned += boneMatX * skinVertex * skinWeight.x;\n\tskinned += boneMatY * skinVertex * skinWeight.y;\n\tskinned += boneMatZ * skinVertex * skinWeight.z;\n\tskinned += boneMatW * skinVertex * skinWeight.w;\n\ttransformed = ( bindMatrixInverse * skinned ).xyz;\n#endif";
-
-	var skinnormal_vertex = "#ifdef USE_SKINNING\n\tmat4 skinMatrix = mat4( 0.0 );\n\tskinMatrix += skinWeight.x * boneMatX;\n\tskinMatrix += skinWeight.y * boneMatY;\n\tskinMatrix += skinWeight.z * boneMatZ;\n\tskinMatrix += skinWeight.w * boneMatW;\n\tskinMatrix  = bindMatrixInverse * skinMatrix * bindMatrix;\n\tobjectNormal = vec4( skinMatrix * vec4( objectNormal, 0.0 ) ).xyz;\n\t#ifdef USE_TANGENT\n\t\tobjectTangent = vec4( skinMatrix * vec4( objectTangent, 0.0 ) ).xyz;\n\t#endif\n#endif";
-
-	var specularmap_fragment = "float specularStrength;\n#ifdef USE_SPECULARMAP\n\tvec4 texelSpecular = texture2D( specularMap, vUv );\n\tspecularStrength = texelSpecular.r;\n#else\n\tspecularStrength = 1.0;\n#endif";
-
-	var specularmap_pars_fragment = "#ifdef USE_SPECULARMAP\n\tuniform sampler2D specularMap;\n#endif";
-
-	var tonemapping_fragment = "#if defined( TONE_MAPPING )\n\tgl_FragColor.rgb = toneMapping( gl_FragColor.rgb );\n#endif";
-
-	var tonemapping_pars_fragment = "#ifndef saturate\n\t#define saturate(a) clamp( a, 0.0, 1.0 )\n#endif\nuniform float toneMappingExposure;\nuniform float toneMappingWhitePoint;\nvec3 LinearToneMapping( vec3 color ) {\n\treturn toneMappingExposure * color;\n}\nvec3 ReinhardToneMapping( vec3 color ) {\n\tcolor *= toneMappingExposure;\n\treturn saturate( color / ( vec3( 1.0 ) + color ) );\n}\n#define Uncharted2Helper( x ) max( ( ( x * ( 0.15 * x + 0.10 * 0.50 ) + 0.20 * 0.02 ) / ( x * ( 0.15 * x + 0.50 ) + 0.20 * 0.30 ) ) - 0.02 / 0.30, vec3( 0.0 ) )\nvec3 Uncharted2ToneMapping( vec3 color ) {\n\tcolor *= toneMappingExposure;\n\treturn saturate( Uncharted2Helper( color ) / Uncharted2Helper( vec3( toneMappingWhitePoint ) ) );\n}\nvec3 OptimizedCineonToneMapping( vec3 color ) {\n\tcolor *= toneMappingExposure;\n\tcolor = max( vec3( 0.0 ), color - 0.004 );\n\treturn pow( ( color * ( 6.2 * color + 0.5 ) ) / ( color * ( 6.2 * color + 1.7 ) + 0.06 ), vec3( 2.2 ) );\n}\nvec3 ACESFilmicToneMapping( vec3 color ) {\n\tcolor *= toneMappingExposure;\n\treturn saturate( ( color * ( 2.51 * color + 0.03 ) ) / ( color * ( 2.43 * color + 0.59 ) + 0.14 ) );\n}";
-
-	var uv_pars_fragment = "#if defined( USE_MAP ) || defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( USE_SPECULARMAP ) || defined( USE_ALPHAMAP ) || defined( USE_EMISSIVEMAP ) || defined( USE_ROUGHNESSMAP ) || defined( USE_METALNESSMAP )\n\tvarying vec2 vUv;\n#endif";
-
-	var uv_pars_vertex = "#if defined( USE_MAP ) || defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( USE_SPECULARMAP ) || defined( USE_ALPHAMAP ) || defined( USE_EMISSIVEMAP ) || defined( USE_ROUGHNESSMAP ) || defined( USE_METALNESSMAP )\n\tvarying vec2 vUv;\n\tuniform mat3 uvTransform;\n#endif";
-
-	var uv_vertex = "#if defined( USE_MAP ) || defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( USE_SPECULARMAP ) || defined( USE_ALPHAMAP ) || defined( USE_EMISSIVEMAP ) || defined( USE_ROUGHNESSMAP ) || defined( USE_METALNESSMAP )\n\tvUv = ( uvTransform * vec3( uv, 1 ) ).xy;\n#endif";
-
-	var uv2_pars_fragment = "#if defined( USE_LIGHTMAP ) || defined( USE_AOMAP )\n\tvarying vec2 vUv2;\n#endif";
-
-	var uv2_pars_vertex = "#if defined( USE_LIGHTMAP ) || defined( USE_AOMAP )\n\tattribute vec2 uv2;\n\tvarying vec2 vUv2;\n#endif";
-
-	var uv2_vertex = "#if defined( USE_LIGHTMAP ) || defined( USE_AOMAP )\n\tvUv2 = uv2;\n#endif";
-
-	var worldpos_vertex = "#if defined( USE_ENVMAP ) || defined( DISTANCE ) || defined ( USE_SHADOWMAP )\n\tvec4 worldPosition = modelMatrix * vec4( transformed, 1.0 );\n#endif";
-
-	var background_frag = "uniform sampler2D t2D;\nvarying vec2 vUv;\nvoid main() {\n\tvec4 texColor = texture2D( t2D, vUv );\n\tgl_FragColor = mapTexelToLinear( texColor );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n}";
-
-	var background_vert = "varying vec2 vUv;\nuniform mat3 uvTransform;\nvoid main() {\n\tvUv = ( uvTransform * vec3( uv, 1 ) ).xy;\n\tgl_Position = vec4( position.xy, 1.0, 1.0 );\n}";
-
-	var cube_frag = "uniform samplerCube tCube;\nuniform float tFlip;\nuniform float opacity;\nvarying vec3 vWorldDirection;\nvoid main() {\n\tvec4 texColor = textureCube( tCube, vec3( tFlip * vWorldDirection.x, vWorldDirection.yz ) );\n\tgl_FragColor = mapTexelToLinear( texColor );\n\tgl_FragColor.a *= opacity;\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n}";
-
-	var cube_vert = "varying vec3 vWorldDirection;\n#include <common>\nvoid main() {\n\tvWorldDirection = transformDirection( position, modelMatrix );\n\t#include <begin_vertex>\n\t#include <project_vertex>\n\tgl_Position.z = gl_Position.w;\n}";
-
-	var depth_frag = "#if DEPTH_PACKING == 3200\n\tuniform float opacity;\n#endif\n#include <common>\n#include <packing>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( 1.0 );\n\t#if DEPTH_PACKING == 3200\n\t\tdiffuseColor.a = opacity;\n\t#endif\n\t#include <map_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <logdepthbuf_fragment>\n\t#if DEPTH_PACKING == 3200\n\t\tgl_FragColor = vec4( vec3( 1.0 - gl_FragCoord.z ), opacity );\n\t#elif DEPTH_PACKING == 3201\n\t\tgl_FragColor = packDepthToRGBA( gl_FragCoord.z );\n\t#endif\n}";
-
-	var depth_vert = "#include <common>\n#include <uv_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <skinbase_vertex>\n\t#ifdef USE_DISPLACEMENTMAP\n\t\t#include <beginnormal_vertex>\n\t\t#include <morphnormal_vertex>\n\t\t#include <skinnormal_vertex>\n\t#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n}";
-
-	var distanceRGBA_frag = "#define DISTANCE\nuniform vec3 referencePosition;\nuniform float nearDistance;\nuniform float farDistance;\nvarying vec3 vWorldPosition;\n#include <common>\n#include <packing>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main () {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( 1.0 );\n\t#include <map_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\tfloat dist = length( vWorldPosition - referencePosition );\n\tdist = ( dist - nearDistance ) / ( farDistance - nearDistance );\n\tdist = saturate( dist );\n\tgl_FragColor = packDepthToRGBA( dist );\n}";
-
-	var distanceRGBA_vert = "#define DISTANCE\nvarying vec3 vWorldPosition;\n#include <common>\n#include <uv_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <skinbase_vertex>\n\t#ifdef USE_DISPLACEMENTMAP\n\t\t#include <beginnormal_vertex>\n\t\t#include <morphnormal_vertex>\n\t\t#include <skinnormal_vertex>\n\t#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <worldpos_vertex>\n\t#include <clipping_planes_vertex>\n\tvWorldPosition = worldPosition.xyz;\n}";
-
-	var equirect_frag = "uniform sampler2D tEquirect;\nvarying vec3 vWorldDirection;\n#include <common>\nvoid main() {\n\tvec3 direction = normalize( vWorldDirection );\n\tvec2 sampleUV;\n\tsampleUV.y = asin( clamp( direction.y, - 1.0, 1.0 ) ) * RECIPROCAL_PI + 0.5;\n\tsampleUV.x = atan( direction.z, direction.x ) * RECIPROCAL_PI2 + 0.5;\n\tvec4 texColor = texture2D( tEquirect, sampleUV );\n\tgl_FragColor = mapTexelToLinear( texColor );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n}";
-
-	var equirect_vert = "varying vec3 vWorldDirection;\n#include <common>\nvoid main() {\n\tvWorldDirection = transformDirection( position, modelMatrix );\n\t#include <begin_vertex>\n\t#include <project_vertex>\n}";
-
-	var linedashed_frag = "uniform vec3 diffuse;\nuniform float opacity;\nuniform float dashSize;\nuniform float totalSize;\nvarying float vLineDistance;\n#include <common>\n#include <color_pars_fragment>\n#include <fog_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tif ( mod( vLineDistance, totalSize ) > dashSize ) {\n\t\tdiscard;\n\t}\n\tvec3 outgoingLight = vec3( 0.0 );\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\t#include <logdepthbuf_fragment>\n\t#include <color_fragment>\n\toutgoingLight = diffuseColor.rgb;\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <premultiplied_alpha_fragment>\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n}";
-
-	var linedashed_vert = "uniform float scale;\nattribute float lineDistance;\nvarying float vLineDistance;\n#include <common>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <color_vertex>\n\tvLineDistance = scale * lineDistance;\n\tvec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );\n\tgl_Position = projectionMatrix * mvPosition;\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <fog_vertex>\n}";
-
-	var meshbasic_frag = "uniform vec3 diffuse;\nuniform float opacity;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\n#include <common>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <uv2_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <envmap_pars_fragment>\n#include <fog_pars_fragment>\n#include <specularmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <color_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <specularmap_fragment>\n\tReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n\t#ifdef USE_LIGHTMAP\n\t\treflectedLight.indirectDiffuse += texture2D( lightMap, vUv2 ).xyz * lightMapIntensity;\n\t#else\n\t\treflectedLight.indirectDiffuse += vec3( 1.0 );\n\t#endif\n\t#include <aomap_fragment>\n\treflectedLight.indirectDiffuse *= diffuseColor.rgb;\n\tvec3 outgoingLight = reflectedLight.indirectDiffuse;\n\t#include <envmap_fragment>\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <premultiplied_alpha_fragment>\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n}";
-
-	var meshbasic_vert = "#include <common>\n#include <uv_pars_vertex>\n#include <uv2_pars_vertex>\n#include <envmap_pars_vertex>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <uv2_vertex>\n\t#include <color_vertex>\n\t#include <skinbase_vertex>\n\t#ifdef USE_ENVMAP\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n\t#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <worldpos_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <envmap_vertex>\n\t#include <fog_vertex>\n}";
-
-	var meshlambert_frag = "uniform vec3 diffuse;\nuniform vec3 emissive;\nuniform float opacity;\nvarying vec3 vLightFront;\nvarying vec3 vIndirectFront;\n#ifdef DOUBLE_SIDED\n\tvarying vec3 vLightBack;\n\tvarying vec3 vIndirectBack;\n#endif\n#include <common>\n#include <packing>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <uv2_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <emissivemap_pars_fragment>\n#include <envmap_pars_fragment>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <fog_pars_fragment>\n#include <shadowmap_pars_fragment>\n#include <shadowmask_pars_fragment>\n#include <specularmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\tReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n\tvec3 totalEmissiveRadiance = emissive;\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <color_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <specularmap_fragment>\n\t#include <emissivemap_fragment>\n\treflectedLight.indirectDiffuse = getAmbientLightIrradiance( ambientLightColor );\n\t#ifdef DOUBLE_SIDED\n\t\treflectedLight.indirectDiffuse += ( gl_FrontFacing ) ? vIndirectFront : vIndirectBack;\n\t#else\n\t\treflectedLight.indirectDiffuse += vIndirectFront;\n\t#endif\n\t#include <lightmap_fragment>\n\treflectedLight.indirectDiffuse *= BRDF_Diffuse_Lambert( diffuseColor.rgb );\n\t#ifdef DOUBLE_SIDED\n\t\treflectedLight.directDiffuse = ( gl_FrontFacing ) ? vLightFront : vLightBack;\n\t#else\n\t\treflectedLight.directDiffuse = vLightFront;\n\t#endif\n\treflectedLight.directDiffuse *= BRDF_Diffuse_Lambert( diffuseColor.rgb ) * getShadowMask();\n\t#include <aomap_fragment>\n\tvec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + totalEmissiveRadiance;\n\t#include <envmap_fragment>\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n\t#include <dithering_fragment>\n}";
-
-	var meshlambert_vert = "#define LAMBERT\nvarying vec3 vLightFront;\nvarying vec3 vIndirectFront;\n#ifdef DOUBLE_SIDED\n\tvarying vec3 vLightBack;\n\tvarying vec3 vIndirectBack;\n#endif\n#include <common>\n#include <uv_pars_vertex>\n#include <uv2_pars_vertex>\n#include <envmap_pars_vertex>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <shadowmap_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <uv2_vertex>\n\t#include <color_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <worldpos_vertex>\n\t#include <envmap_vertex>\n\t#include <lights_lambert_vertex>\n\t#include <shadowmap_vertex>\n\t#include <fog_vertex>\n}";
-
-	var meshmatcap_frag = "#define MATCAP\nuniform vec3 diffuse;\nuniform float opacity;\nuniform sampler2D matcap;\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\n#include <common>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <fog_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <normal_fragment_begin>\n\t#include <normal_fragment_maps>\n\tvec3 viewDir = normalize( vViewPosition );\n\tvec3 x = normalize( vec3( viewDir.z, 0.0, - viewDir.x ) );\n\tvec3 y = cross( viewDir, x );\n\tvec2 uv = vec2( dot( x, normal ), dot( y, normal ) ) * 0.495 + 0.5;\n\t#ifdef USE_MATCAP\n\t\tvec4 matcapColor = texture2D( matcap, uv );\n\t\tmatcapColor = matcapTexelToLinear( matcapColor );\n\t#else\n\t\tvec4 matcapColor = vec4( 1.0 );\n\t#endif\n\tvec3 outgoingLight = diffuseColor.rgb * matcapColor.rgb;\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <premultiplied_alpha_fragment>\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n}";
-
-	var meshmatcap_vert = "#define MATCAP\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\n#include <common>\n#include <uv_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n\t#ifndef FLAT_SHADED\n\t\tvNormal = normalize( transformedNormal );\n\t#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <fog_vertex>\n\tvViewPosition = - mvPosition.xyz;\n}";
-
-	var meshphong_frag = "#define PHONG\nuniform vec3 diffuse;\nuniform vec3 emissive;\nuniform vec3 specular;\nuniform float shininess;\nuniform float opacity;\n#include <common>\n#include <packing>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <uv2_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <emissivemap_pars_fragment>\n#include <envmap_pars_fragment>\n#include <gradientmap_pars_fragment>\n#include <fog_pars_fragment>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <lights_phong_pars_fragment>\n#include <shadowmap_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <specularmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\tReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n\tvec3 totalEmissiveRadiance = emissive;\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <color_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <specularmap_fragment>\n\t#include <normal_fragment_begin>\n\t#include <normal_fragment_maps>\n\t#include <emissivemap_fragment>\n\t#include <lights_phong_fragment>\n\t#include <lights_fragment_begin>\n\t#include <lights_fragment_maps>\n\t#include <lights_fragment_end>\n\t#include <aomap_fragment>\n\tvec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;\n\t#include <envmap_fragment>\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n\t#include <dithering_fragment>\n}";
-
-	var meshphong_vert = "#define PHONG\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\n#include <common>\n#include <uv_pars_vertex>\n#include <uv2_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <envmap_pars_vertex>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <shadowmap_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <uv2_vertex>\n\t#include <color_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n#ifndef FLAT_SHADED\n\tvNormal = normalize( transformedNormal );\n#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\tvViewPosition = - mvPosition.xyz;\n\t#include <worldpos_vertex>\n\t#include <envmap_vertex>\n\t#include <shadowmap_vertex>\n\t#include <fog_vertex>\n}";
-
-	var meshphysical_frag = "#define PHYSICAL\nuniform vec3 diffuse;\nuniform vec3 emissive;\nuniform float roughness;\nuniform float metalness;\nuniform float opacity;\n#ifndef STANDARD\n\tuniform float clearCoat;\n\tuniform float clearCoatRoughness;\n#endif\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n\t#ifdef USE_TANGENT\n\t\tvarying vec3 vTangent;\n\t\tvarying vec3 vBitangent;\n\t#endif\n#endif\n#include <common>\n#include <packing>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <uv2_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <emissivemap_pars_fragment>\n#include <bsdfs>\n#include <cube_uv_reflection_fragment>\n#include <envmap_pars_fragment>\n#include <envmap_physical_pars_fragment>\n#include <fog_pars_fragment>\n#include <lights_pars_begin>\n#include <lights_physical_pars_fragment>\n#include <shadowmap_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <roughnessmap_pars_fragment>\n#include <metalnessmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\tReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n\tvec3 totalEmissiveRadiance = emissive;\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <color_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <roughnessmap_fragment>\n\t#include <metalnessmap_fragment>\n\t#include <normal_fragment_begin>\n\t#include <normal_fragment_maps>\n\t#include <emissivemap_fragment>\n\t#include <lights_physical_fragment>\n\t#include <lights_fragment_begin>\n\t#include <lights_fragment_maps>\n\t#include <lights_fragment_end>\n\t#include <aomap_fragment>\n\tvec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n\t#include <dithering_fragment>\n}";
-
-	var meshphysical_vert = "#define PHYSICAL\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n\t#ifdef USE_TANGENT\n\t\tvarying vec3 vTangent;\n\t\tvarying vec3 vBitangent;\n\t#endif\n#endif\n#include <common>\n#include <uv_pars_vertex>\n#include <uv2_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <shadowmap_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <uv2_vertex>\n\t#include <color_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n#ifndef FLAT_SHADED\n\tvNormal = normalize( transformedNormal );\n\t#ifdef USE_TANGENT\n\t\tvTangent = normalize( transformedTangent );\n\t\tvBitangent = normalize( cross( vNormal, vTangent ) * tangent.w );\n\t#endif\n#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\tvViewPosition = - mvPosition.xyz;\n\t#include <worldpos_vertex>\n\t#include <shadowmap_vertex>\n\t#include <fog_vertex>\n}";
-
-	var normal_frag = "#define NORMAL\nuniform float opacity;\n#if defined( FLAT_SHADED ) || defined( USE_BUMPMAP ) || ( defined( USE_NORMALMAP ) && ! defined( OBJECTSPACE_NORMALMAP ) )\n\tvarying vec3 vViewPosition;\n#endif\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n\t#ifdef USE_TANGENT\n\t\tvarying vec3 vTangent;\n\t\tvarying vec3 vBitangent;\n\t#endif\n#endif\n#include <packing>\n#include <uv_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\t#include <logdepthbuf_fragment>\n\t#include <normal_fragment_begin>\n\t#include <normal_fragment_maps>\n\tgl_FragColor = vec4( packNormalToRGB( normal ), opacity );\n}";
-
-	var normal_vert = "#define NORMAL\n#if defined( FLAT_SHADED ) || defined( USE_BUMPMAP ) || ( defined( USE_NORMALMAP ) && ! defined( OBJECTSPACE_NORMALMAP ) )\n\tvarying vec3 vViewPosition;\n#endif\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n\t#ifdef USE_TANGENT\n\t\tvarying vec3 vTangent;\n\t\tvarying vec3 vBitangent;\n\t#endif\n#endif\n#include <uv_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n#ifndef FLAT_SHADED\n\tvNormal = normalize( transformedNormal );\n\t#ifdef USE_TANGENT\n\t\tvTangent = normalize( transformedTangent );\n\t\tvBitangent = normalize( cross( vNormal, vTangent ) * tangent.w );\n\t#endif\n#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n#if defined( FLAT_SHADED ) || defined( USE_BUMPMAP ) || ( defined( USE_NORMALMAP ) && ! defined( OBJECTSPACE_NORMALMAP ) )\n\tvViewPosition = - mvPosition.xyz;\n#endif\n}";
-
-	var points_frag = "uniform vec3 diffuse;\nuniform float opacity;\n#include <common>\n#include <color_pars_fragment>\n#include <map_particle_pars_fragment>\n#include <fog_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec3 outgoingLight = vec3( 0.0 );\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\t#include <logdepthbuf_fragment>\n\t#include <map_particle_fragment>\n\t#include <color_fragment>\n\t#include <alphatest_fragment>\n\toutgoingLight = diffuseColor.rgb;\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <premultiplied_alpha_fragment>\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n}";
-
-	var points_vert = "uniform float size;\nuniform float scale;\n#include <common>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <color_vertex>\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <project_vertex>\n\tgl_PointSize = size;\n\t#ifdef USE_SIZEATTENUATION\n\t\tbool isPerspective = ( projectionMatrix[ 2 ][ 3 ] == - 1.0 );\n\t\tif ( isPerspective ) gl_PointSize *= ( scale / - mvPosition.z );\n\t#endif\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <worldpos_vertex>\n\t#include <fog_vertex>\n}";
-
-	var shadow_frag = "uniform vec3 color;\nuniform float opacity;\n#include <common>\n#include <packing>\n#include <fog_pars_fragment>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <shadowmap_pars_fragment>\n#include <shadowmask_pars_fragment>\nvoid main() {\n\tgl_FragColor = vec4( color, opacity * ( 1.0 - getShadowMask() ) );\n\t#include <fog_fragment>\n}";
-
-	var shadow_vert = "#include <fog_pars_vertex>\n#include <shadowmap_pars_vertex>\nvoid main() {\n\t#include <begin_vertex>\n\t#include <project_vertex>\n\t#include <worldpos_vertex>\n\t#include <shadowmap_vertex>\n\t#include <fog_vertex>\n}";
-
-	var sprite_frag = "uniform vec3 diffuse;\nuniform float opacity;\n#include <common>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <fog_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec3 outgoingLight = vec3( 0.0 );\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <alphatest_fragment>\n\toutgoingLight = diffuseColor.rgb;\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n}";
-
-	var sprite_vert = "uniform float rotation;\nuniform vec2 center;\n#include <common>\n#include <uv_pars_vertex>\n#include <fog_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\tvec4 mvPosition = modelViewMatrix * vec4( 0.0, 0.0, 0.0, 1.0 );\n\tvec2 scale;\n\tscale.x = length( vec3( modelMatrix[ 0 ].x, modelMatrix[ 0 ].y, modelMatrix[ 0 ].z ) );\n\tscale.y = length( vec3( modelMatrix[ 1 ].x, modelMatrix[ 1 ].y, modelMatrix[ 1 ].z ) );\n\t#ifndef USE_SIZEATTENUATION\n\t\tbool isPerspective = ( projectionMatrix[ 2 ][ 3 ] == - 1.0 );\n\t\tif ( isPerspective ) scale *= - mvPosition.z;\n\t#endif\n\tvec2 alignedPosition = ( position.xy - ( center - vec2( 0.5 ) ) ) * scale;\n\tvec2 rotatedPosition;\n\trotatedPosition.x = cos( rotation ) * alignedPosition.x - sin( rotation ) * alignedPosition.y;\n\trotatedPosition.y = sin( rotation ) * alignedPosition.x + cos( rotation ) * alignedPosition.y;\n\tmvPosition.xy += rotatedPosition;\n\tgl_Position = projectionMatrix * mvPosition;\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <fog_vertex>\n}";
-
-	var ShaderChunk = {
-		alphamap_fragment: alphamap_fragment,
-		alphamap_pars_fragment: alphamap_pars_fragment,
-		alphatest_fragment: alphatest_fragment,
-		aomap_fragment: aomap_fragment,
-		aomap_pars_fragment: aomap_pars_fragment,
-		begin_vertex: begin_vertex,
-		beginnormal_vertex: beginnormal_vertex,
-		bsdfs: bsdfs,
-		bumpmap_pars_fragment: bumpmap_pars_fragment,
-		clipping_planes_fragment: clipping_planes_fragment,
-		clipping_planes_pars_fragment: clipping_planes_pars_fragment,
-		clipping_planes_pars_vertex: clipping_planes_pars_vertex,
-		clipping_planes_vertex: clipping_planes_vertex,
-		color_fragment: color_fragment,
-		color_pars_fragment: color_pars_fragment,
-		color_pars_vertex: color_pars_vertex,
-		color_vertex: color_vertex,
-		common: common,
-		cube_uv_reflection_fragment: cube_uv_reflection_fragment,
-		defaultnormal_vertex: defaultnormal_vertex,
-		displacementmap_pars_vertex: displacementmap_pars_vertex,
-		displacementmap_vertex: displacementmap_vertex,
-		emissivemap_fragment: emissivemap_fragment,
-		emissivemap_pars_fragment: emissivemap_pars_fragment,
-		encodings_fragment: encodings_fragment,
-		encodings_pars_fragment: encodings_pars_fragment,
-		envmap_fragment: envmap_fragment,
-		envmap_pars_fragment: envmap_pars_fragment,
-		envmap_pars_vertex: envmap_pars_vertex,
-		envmap_physical_pars_fragment: envmap_physical_pars_fragment,
-		envmap_vertex: envmap_vertex,
-		fog_vertex: fog_vertex,
-		fog_pars_vertex: fog_pars_vertex,
-		fog_fragment: fog_fragment,
-		fog_pars_fragment: fog_pars_fragment,
-		gradientmap_pars_fragment: gradientmap_pars_fragment,
-		lightmap_fragment: lightmap_fragment,
-		lightmap_pars_fragment: lightmap_pars_fragment,
-		lights_lambert_vertex: lights_lambert_vertex,
-		lights_pars_begin: lights_pars_begin,
-		lights_phong_fragment: lights_phong_fragment,
-		lights_phong_pars_fragment: lights_phong_pars_fragment,
-		lights_physical_fragment: lights_physical_fragment,
-		lights_physical_pars_fragment: lights_physical_pars_fragment,
-		lights_fragment_begin: lights_fragment_begin,
-		lights_fragment_maps: lights_fragment_maps,
-		lights_fragment_end: lights_fragment_end,
-		logdepthbuf_fragment: logdepthbuf_fragment,
-		logdepthbuf_pars_fragment: logdepthbuf_pars_fragment,
-		logdepthbuf_pars_vertex: logdepthbuf_pars_vertex,
-		logdepthbuf_vertex: logdepthbuf_vertex,
-		map_fragment: map_fragment,
-		map_pars_fragment: map_pars_fragment,
-		map_particle_fragment: map_particle_fragment,
-		map_particle_pars_fragment: map_particle_pars_fragment,
-		metalnessmap_fragment: metalnessmap_fragment,
-		metalnessmap_pars_fragment: metalnessmap_pars_fragment,
-		morphnormal_vertex: morphnormal_vertex,
-		morphtarget_pars_vertex: morphtarget_pars_vertex,
-		morphtarget_vertex: morphtarget_vertex,
-		normal_fragment_begin: normal_fragment_begin,
-		normal_fragment_maps: normal_fragment_maps,
-		normalmap_pars_fragment: normalmap_pars_fragment,
-		packing: packing,
-		premultiplied_alpha_fragment: premultiplied_alpha_fragment,
-		project_vertex: project_vertex,
-		dithering_fragment: dithering_fragment,
-		dithering_pars_fragment: dithering_pars_fragment,
-		roughnessmap_fragment: roughnessmap_fragment,
-		roughnessmap_pars_fragment: roughnessmap_pars_fragment,
-		shadowmap_pars_fragment: shadowmap_pars_fragment,
-		shadowmap_pars_vertex: shadowmap_pars_vertex,
-		shadowmap_vertex: shadowmap_vertex,
-		shadowmask_pars_fragment: shadowmask_pars_fragment,
-		skinbase_vertex: skinbase_vertex,
-		skinning_pars_vertex: skinning_pars_vertex,
-		skinning_vertex: skinning_vertex,
-		skinnormal_vertex: skinnormal_vertex,
-		specularmap_fragment: specularmap_fragment,
-		specularmap_pars_fragment: specularmap_pars_fragment,
-		tonemapping_fragment: tonemapping_fragment,
-		tonemapping_pars_fragment: tonemapping_pars_fragment,
-		uv_pars_fragment: uv_pars_fragment,
-		uv_pars_vertex: uv_pars_vertex,
-		uv_vertex: uv_vertex,
-		uv2_pars_fragment: uv2_pars_fragment,
-		uv2_pars_vertex: uv2_pars_vertex,
-		uv2_vertex: uv2_vertex,
-		worldpos_vertex: worldpos_vertex,
-
-		background_frag: background_frag,
-		background_vert: background_vert,
-		cube_frag: cube_frag,
-		cube_vert: cube_vert,
-		depth_frag: depth_frag,
-		depth_vert: depth_vert,
-		distanceRGBA_frag: distanceRGBA_frag,
-		distanceRGBA_vert: distanceRGBA_vert,
-		equirect_frag: equirect_frag,
-		equirect_vert: equirect_vert,
-		linedashed_frag: linedashed_frag,
-		linedashed_vert: linedashed_vert,
-		meshbasic_frag: meshbasic_frag,
-		meshbasic_vert: meshbasic_vert,
-		meshlambert_frag: meshlambert_frag,
-		meshlambert_vert: meshlambert_vert,
-		meshmatcap_frag: meshmatcap_frag,
-		meshmatcap_vert: meshmatcap_vert,
-		meshphong_frag: meshphong_frag,
-		meshphong_vert: meshphong_vert,
-		meshphysical_frag: meshphysical_frag,
-		meshphysical_vert: meshphysical_vert,
-		normal_frag: normal_frag,
-		normal_vert: normal_vert,
-		points_frag: points_frag,
-		points_vert: points_vert,
-		shadow_frag: shadow_frag,
-		shadow_vert: shadow_vert,
-		sprite_frag: sprite_frag,
-		sprite_vert: sprite_vert
-	};
-
 	/**
 	 * Uniforms library for shared webgl shaders
 	 */
@@ -14715,6 +14307,7 @@ var Spacekit = (function (exports) {
 
 			map: { value: null },
 			uvTransform: { value: new Matrix3() },
+			uv2Transform: { value: new Matrix3() },
 
 			alphaMap: { value: null },
 
@@ -14813,9 +14406,10 @@ var Spacekit = (function (exports) {
 
 			directionalLights: { value: [], properties: {
 				direction: {},
-				color: {},
+				color: {}
+			} },
 
-				shadow: {},
+			directionalLightShadows: { value: [], properties: {
 				shadowBias: {},
 				shadowRadius: {},
 				shadowMapSize: {}
@@ -14831,9 +14425,10 @@ var Spacekit = (function (exports) {
 				distance: {},
 				coneCos: {},
 				penumbraCos: {},
-				decay: {},
+				decay: {}
+			} },
 
-				shadow: {},
+			spotLightShadows: { value: [], properties: {
 				shadowBias: {},
 				shadowRadius: {},
 				shadowMapSize: {}
@@ -14846,9 +14441,10 @@ var Spacekit = (function (exports) {
 				color: {},
 				position: {},
 				decay: {},
-				distance: {},
+				distance: {}
+			} },
 
-				shadow: {},
+			pointLightShadows: { value: [], properties: {
 				shadowBias: {},
 				shadowRadius: {},
 				shadowMapSize: {},
@@ -14882,6 +14478,7 @@ var Spacekit = (function (exports) {
 			size: { value: 1.0 },
 			scale: { value: 1.0 },
 			map: { value: null },
+			alphaMap: { value: null },
 			uvTransform: { value: new Matrix3() }
 
 		},
@@ -14893,286 +14490,10 @@ var Spacekit = (function (exports) {
 			center: { value: new Vector2( 0.5, 0.5 ) },
 			rotation: { value: 0.0 },
 			map: { value: null },
+			alphaMap: { value: null },
 			uvTransform: { value: new Matrix3() }
 
 		}
-
-	};
-
-	/**
-	 * @author alteredq / http://alteredqualia.com/
-	 * @author mrdoob / http://mrdoob.com/
-	 * @author mikael emtinger / http://gomo.se/
-	 */
-
-	var ShaderLib = {
-
-		basic: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.common,
-				UniformsLib.specularmap,
-				UniformsLib.envmap,
-				UniformsLib.aomap,
-				UniformsLib.lightmap,
-				UniformsLib.fog
-			] ),
-
-			vertexShader: ShaderChunk.meshbasic_vert,
-			fragmentShader: ShaderChunk.meshbasic_frag
-
-		},
-
-		lambert: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.common,
-				UniformsLib.specularmap,
-				UniformsLib.envmap,
-				UniformsLib.aomap,
-				UniformsLib.lightmap,
-				UniformsLib.emissivemap,
-				UniformsLib.fog,
-				UniformsLib.lights,
-				{
-					emissive: { value: new Color( 0x000000 ) }
-				}
-			] ),
-
-			vertexShader: ShaderChunk.meshlambert_vert,
-			fragmentShader: ShaderChunk.meshlambert_frag
-
-		},
-
-		phong: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.common,
-				UniformsLib.specularmap,
-				UniformsLib.envmap,
-				UniformsLib.aomap,
-				UniformsLib.lightmap,
-				UniformsLib.emissivemap,
-				UniformsLib.bumpmap,
-				UniformsLib.normalmap,
-				UniformsLib.displacementmap,
-				UniformsLib.gradientmap,
-				UniformsLib.fog,
-				UniformsLib.lights,
-				{
-					emissive: { value: new Color( 0x000000 ) },
-					specular: { value: new Color( 0x111111 ) },
-					shininess: { value: 30 }
-				}
-			] ),
-
-			vertexShader: ShaderChunk.meshphong_vert,
-			fragmentShader: ShaderChunk.meshphong_frag
-
-		},
-
-		standard: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.common,
-				UniformsLib.envmap,
-				UniformsLib.aomap,
-				UniformsLib.lightmap,
-				UniformsLib.emissivemap,
-				UniformsLib.bumpmap,
-				UniformsLib.normalmap,
-				UniformsLib.displacementmap,
-				UniformsLib.roughnessmap,
-				UniformsLib.metalnessmap,
-				UniformsLib.fog,
-				UniformsLib.lights,
-				{
-					emissive: { value: new Color( 0x000000 ) },
-					roughness: { value: 0.5 },
-					metalness: { value: 0.5 },
-					envMapIntensity: { value: 1 } // temporary
-				}
-			] ),
-
-			vertexShader: ShaderChunk.meshphysical_vert,
-			fragmentShader: ShaderChunk.meshphysical_frag
-
-		},
-
-		matcap: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.common,
-				UniformsLib.bumpmap,
-				UniformsLib.normalmap,
-				UniformsLib.displacementmap,
-				UniformsLib.fog,
-				{
-					matcap: { value: null }
-				}
-			] ),
-
-			vertexShader: ShaderChunk.meshmatcap_vert,
-			fragmentShader: ShaderChunk.meshmatcap_frag
-
-		},
-
-		points: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.points,
-				UniformsLib.fog
-			] ),
-
-			vertexShader: ShaderChunk.points_vert,
-			fragmentShader: ShaderChunk.points_frag
-
-		},
-
-		dashed: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.common,
-				UniformsLib.fog,
-				{
-					scale: { value: 1 },
-					dashSize: { value: 1 },
-					totalSize: { value: 2 }
-				}
-			] ),
-
-			vertexShader: ShaderChunk.linedashed_vert,
-			fragmentShader: ShaderChunk.linedashed_frag
-
-		},
-
-		depth: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.common,
-				UniformsLib.displacementmap
-			] ),
-
-			vertexShader: ShaderChunk.depth_vert,
-			fragmentShader: ShaderChunk.depth_frag
-
-		},
-
-		normal: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.common,
-				UniformsLib.bumpmap,
-				UniformsLib.normalmap,
-				UniformsLib.displacementmap,
-				{
-					opacity: { value: 1.0 }
-				}
-			] ),
-
-			vertexShader: ShaderChunk.normal_vert,
-			fragmentShader: ShaderChunk.normal_frag
-
-		},
-
-		sprite: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.sprite,
-				UniformsLib.fog
-			] ),
-
-			vertexShader: ShaderChunk.sprite_vert,
-			fragmentShader: ShaderChunk.sprite_frag
-
-		},
-
-		background: {
-
-			uniforms: {
-				uvTransform: { value: new Matrix3() },
-				t2D: { value: null },
-			},
-
-			vertexShader: ShaderChunk.background_vert,
-			fragmentShader: ShaderChunk.background_frag
-
-		},
-		/* -------------------------------------------------------------------------
-		//	Cube map shader
-		 ------------------------------------------------------------------------- */
-
-		cube: {
-
-			uniforms: {
-				tCube: { value: null },
-				tFlip: { value: - 1 },
-				opacity: { value: 1.0 }
-			},
-
-			vertexShader: ShaderChunk.cube_vert,
-			fragmentShader: ShaderChunk.cube_frag
-
-		},
-
-		equirect: {
-
-			uniforms: {
-				tEquirect: { value: null },
-			},
-
-			vertexShader: ShaderChunk.equirect_vert,
-			fragmentShader: ShaderChunk.equirect_frag
-
-		},
-
-		distanceRGBA: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.common,
-				UniformsLib.displacementmap,
-				{
-					referencePosition: { value: new Vector3() },
-					nearDistance: { value: 1 },
-					farDistance: { value: 1000 }
-				}
-			] ),
-
-			vertexShader: ShaderChunk.distanceRGBA_vert,
-			fragmentShader: ShaderChunk.distanceRGBA_frag
-
-		},
-
-		shadow: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.lights,
-				UniformsLib.fog,
-				{
-					color: { value: new Color( 0x00000 ) },
-					opacity: { value: 1.0 }
-				},
-			] ),
-
-			vertexShader: ShaderChunk.shadow_vert,
-			fragmentShader: ShaderChunk.shadow_frag
-
-		}
-
-	};
-
-	ShaderLib.physical = {
-
-		uniforms: mergeUniforms( [
-			ShaderLib.standard.uniforms,
-			{
-				clearCoat: { value: 0 },
-				clearCoatRoughness: { value: 0 }
-			}
-		] ),
-
-		vertexShader: ShaderChunk.meshphysical_vert,
-		fragmentShader: ShaderChunk.meshphysical_frag
 
 	};
 
@@ -15235,14 +14556,16 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-	function WebGLAttributes( gl ) {
+	function WebGLAttributes( gl, capabilities ) {
+
+		var isWebGL2 = capabilities.isWebGL2;
 
 		var buffers = new WeakMap();
 
 		function createBuffer( attribute, bufferType ) {
 
 			var array = attribute.array;
-			var usage = attribute.dynamic ? 35048 : 35044;
+			var usage = attribute.usage;
 
 			var buffer = gl.createBuffer();
 
@@ -15303,24 +14626,25 @@ var Spacekit = (function (exports) {
 
 			gl.bindBuffer( bufferType, buffer );
 
-			if ( attribute.dynamic === false ) {
-
-				gl.bufferData( bufferType, array, 35044 );
-
-			} else if ( updateRange.count === - 1 ) {
+			if ( updateRange.count === - 1 ) {
 
 				// Not using update ranges
 
 				gl.bufferSubData( bufferType, 0, array );
 
-			} else if ( updateRange.count === 0 ) {
-
-				console.error( 'THREE.WebGLObjects.updateBuffer: dynamic THREE.BufferAttribute marked as needsUpdate but updateRange.count is 0, ensure you are using set methods or updating manually.' );
-
 			} else {
 
-				gl.bufferSubData( bufferType, updateRange.offset * array.BYTES_PER_ELEMENT,
-					array.subarray( updateRange.offset, updateRange.offset + updateRange.count ) );
+				if ( isWebGL2 ) {
+
+					gl.bufferSubData( bufferType, updateRange.offset * array.BYTES_PER_ELEMENT,
+						array, updateRange.offset, updateRange.count );
+
+				} else {
+
+					gl.bufferSubData( bufferType, updateRange.offset * array.BYTES_PER_ELEMENT,
+						array.subarray( updateRange.offset, updateRange.offset + updateRange.count ) );
+
+				}
 
 				updateRange.count = - 1; // reset range
 
@@ -15495,14 +14819,708 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	}
 
 	PlaneBufferGeometry.prototype = Object.create( BufferGeometry.prototype );
 	PlaneBufferGeometry.prototype.constructor = PlaneBufferGeometry;
+
+	var alphamap_fragment = "#ifdef USE_ALPHAMAP\n\tdiffuseColor.a *= texture2D( alphaMap, vUv ).g;\n#endif";
+
+	var alphamap_pars_fragment = "#ifdef USE_ALPHAMAP\n\tuniform sampler2D alphaMap;\n#endif";
+
+	var alphatest_fragment = "#ifdef ALPHATEST\n\tif ( diffuseColor.a < ALPHATEST ) discard;\n#endif";
+
+	var aomap_fragment = "#ifdef USE_AOMAP\n\tfloat ambientOcclusion = ( texture2D( aoMap, vUv2 ).r - 1.0 ) * aoMapIntensity + 1.0;\n\treflectedLight.indirectDiffuse *= ambientOcclusion;\n\t#if defined( USE_ENVMAP ) && defined( STANDARD )\n\t\tfloat dotNV = saturate( dot( geometry.normal, geometry.viewDir ) );\n\t\treflectedLight.indirectSpecular *= computeSpecularOcclusion( dotNV, ambientOcclusion, material.specularRoughness );\n\t#endif\n#endif";
+
+	var aomap_pars_fragment = "#ifdef USE_AOMAP\n\tuniform sampler2D aoMap;\n\tuniform float aoMapIntensity;\n#endif";
+
+	var begin_vertex = "vec3 transformed = vec3( position );";
+
+	var beginnormal_vertex = "vec3 objectNormal = vec3( normal );\n#ifdef USE_TANGENT\n\tvec3 objectTangent = vec3( tangent.xyz );\n#endif";
+
+	var bsdfs = "vec2 integrateSpecularBRDF( const in float dotNV, const in float roughness ) {\n\tconst vec4 c0 = vec4( - 1, - 0.0275, - 0.572, 0.022 );\n\tconst vec4 c1 = vec4( 1, 0.0425, 1.04, - 0.04 );\n\tvec4 r = roughness * c0 + c1;\n\tfloat a004 = min( r.x * r.x, exp2( - 9.28 * dotNV ) ) * r.x + r.y;\n\treturn vec2( -1.04, 1.04 ) * a004 + r.zw;\n}\nfloat punctualLightIntensityToIrradianceFactor( const in float lightDistance, const in float cutoffDistance, const in float decayExponent ) {\n#if defined ( PHYSICALLY_CORRECT_LIGHTS )\n\tfloat distanceFalloff = 1.0 / max( pow( lightDistance, decayExponent ), 0.01 );\n\tif( cutoffDistance > 0.0 ) {\n\t\tdistanceFalloff *= pow2( saturate( 1.0 - pow4( lightDistance / cutoffDistance ) ) );\n\t}\n\treturn distanceFalloff;\n#else\n\tif( cutoffDistance > 0.0 && decayExponent > 0.0 ) {\n\t\treturn pow( saturate( -lightDistance / cutoffDistance + 1.0 ), decayExponent );\n\t}\n\treturn 1.0;\n#endif\n}\nvec3 BRDF_Diffuse_Lambert( const in vec3 diffuseColor ) {\n\treturn RECIPROCAL_PI * diffuseColor;\n}\nvec3 F_Schlick( const in vec3 specularColor, const in float dotLH ) {\n\tfloat fresnel = exp2( ( -5.55473 * dotLH - 6.98316 ) * dotLH );\n\treturn ( 1.0 - specularColor ) * fresnel + specularColor;\n}\nvec3 F_Schlick_RoughnessDependent( const in vec3 F0, const in float dotNV, const in float roughness ) {\n\tfloat fresnel = exp2( ( -5.55473 * dotNV - 6.98316 ) * dotNV );\n\tvec3 Fr = max( vec3( 1.0 - roughness ), F0 ) - F0;\n\treturn Fr * fresnel + F0;\n}\nfloat G_GGX_Smith( const in float alpha, const in float dotNL, const in float dotNV ) {\n\tfloat a2 = pow2( alpha );\n\tfloat gl = dotNL + sqrt( a2 + ( 1.0 - a2 ) * pow2( dotNL ) );\n\tfloat gv = dotNV + sqrt( a2 + ( 1.0 - a2 ) * pow2( dotNV ) );\n\treturn 1.0 / ( gl * gv );\n}\nfloat G_GGX_SmithCorrelated( const in float alpha, const in float dotNL, const in float dotNV ) {\n\tfloat a2 = pow2( alpha );\n\tfloat gv = dotNL * sqrt( a2 + ( 1.0 - a2 ) * pow2( dotNV ) );\n\tfloat gl = dotNV * sqrt( a2 + ( 1.0 - a2 ) * pow2( dotNL ) );\n\treturn 0.5 / max( gv + gl, EPSILON );\n}\nfloat D_GGX( const in float alpha, const in float dotNH ) {\n\tfloat a2 = pow2( alpha );\n\tfloat denom = pow2( dotNH ) * ( a2 - 1.0 ) + 1.0;\n\treturn RECIPROCAL_PI * a2 / pow2( denom );\n}\nvec3 BRDF_Specular_GGX( const in IncidentLight incidentLight, const in vec3 viewDir, const in vec3 normal, const in vec3 specularColor, const in float roughness ) {\n\tfloat alpha = pow2( roughness );\n\tvec3 halfDir = normalize( incidentLight.direction + viewDir );\n\tfloat dotNL = saturate( dot( normal, incidentLight.direction ) );\n\tfloat dotNV = saturate( dot( normal, viewDir ) );\n\tfloat dotNH = saturate( dot( normal, halfDir ) );\n\tfloat dotLH = saturate( dot( incidentLight.direction, halfDir ) );\n\tvec3 F = F_Schlick( specularColor, dotLH );\n\tfloat G = G_GGX_SmithCorrelated( alpha, dotNL, dotNV );\n\tfloat D = D_GGX( alpha, dotNH );\n\treturn F * ( G * D );\n}\nvec2 LTC_Uv( const in vec3 N, const in vec3 V, const in float roughness ) {\n\tconst float LUT_SIZE  = 64.0;\n\tconst float LUT_SCALE = ( LUT_SIZE - 1.0 ) / LUT_SIZE;\n\tconst float LUT_BIAS  = 0.5 / LUT_SIZE;\n\tfloat dotNV = saturate( dot( N, V ) );\n\tvec2 uv = vec2( roughness, sqrt( 1.0 - dotNV ) );\n\tuv = uv * LUT_SCALE + LUT_BIAS;\n\treturn uv;\n}\nfloat LTC_ClippedSphereFormFactor( const in vec3 f ) {\n\tfloat l = length( f );\n\treturn max( ( l * l + f.z ) / ( l + 1.0 ), 0.0 );\n}\nvec3 LTC_EdgeVectorFormFactor( const in vec3 v1, const in vec3 v2 ) {\n\tfloat x = dot( v1, v2 );\n\tfloat y = abs( x );\n\tfloat a = 0.8543985 + ( 0.4965155 + 0.0145206 * y ) * y;\n\tfloat b = 3.4175940 + ( 4.1616724 + y ) * y;\n\tfloat v = a / b;\n\tfloat theta_sintheta = ( x > 0.0 ) ? v : 0.5 * inversesqrt( max( 1.0 - x * x, 1e-7 ) ) - v;\n\treturn cross( v1, v2 ) * theta_sintheta;\n}\nvec3 LTC_Evaluate( const in vec3 N, const in vec3 V, const in vec3 P, const in mat3 mInv, const in vec3 rectCoords[ 4 ] ) {\n\tvec3 v1 = rectCoords[ 1 ] - rectCoords[ 0 ];\n\tvec3 v2 = rectCoords[ 3 ] - rectCoords[ 0 ];\n\tvec3 lightNormal = cross( v1, v2 );\n\tif( dot( lightNormal, P - rectCoords[ 0 ] ) < 0.0 ) return vec3( 0.0 );\n\tvec3 T1, T2;\n\tT1 = normalize( V - N * dot( V, N ) );\n\tT2 = - cross( N, T1 );\n\tmat3 mat = mInv * transposeMat3( mat3( T1, T2, N ) );\n\tvec3 coords[ 4 ];\n\tcoords[ 0 ] = mat * ( rectCoords[ 0 ] - P );\n\tcoords[ 1 ] = mat * ( rectCoords[ 1 ] - P );\n\tcoords[ 2 ] = mat * ( rectCoords[ 2 ] - P );\n\tcoords[ 3 ] = mat * ( rectCoords[ 3 ] - P );\n\tcoords[ 0 ] = normalize( coords[ 0 ] );\n\tcoords[ 1 ] = normalize( coords[ 1 ] );\n\tcoords[ 2 ] = normalize( coords[ 2 ] );\n\tcoords[ 3 ] = normalize( coords[ 3 ] );\n\tvec3 vectorFormFactor = vec3( 0.0 );\n\tvectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 0 ], coords[ 1 ] );\n\tvectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 1 ], coords[ 2 ] );\n\tvectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 2 ], coords[ 3 ] );\n\tvectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 3 ], coords[ 0 ] );\n\tfloat result = LTC_ClippedSphereFormFactor( vectorFormFactor );\n\treturn vec3( result );\n}\nvec3 BRDF_Specular_GGX_Environment( const in vec3 viewDir, const in vec3 normal, const in vec3 specularColor, const in float roughness ) {\n\tfloat dotNV = saturate( dot( normal, viewDir ) );\n\tvec2 brdf = integrateSpecularBRDF( dotNV, roughness );\n\treturn specularColor * brdf.x + brdf.y;\n}\nvoid BRDF_Specular_Multiscattering_Environment( const in GeometricContext geometry, const in vec3 specularColor, const in float roughness, inout vec3 singleScatter, inout vec3 multiScatter ) {\n\tfloat dotNV = saturate( dot( geometry.normal, geometry.viewDir ) );\n\tvec3 F = F_Schlick_RoughnessDependent( specularColor, dotNV, roughness );\n\tvec2 brdf = integrateSpecularBRDF( dotNV, roughness );\n\tvec3 FssEss = F * brdf.x + brdf.y;\n\tfloat Ess = brdf.x + brdf.y;\n\tfloat Ems = 1.0 - Ess;\n\tvec3 Favg = specularColor + ( 1.0 - specularColor ) * 0.047619;\tvec3 Fms = FssEss * Favg / ( 1.0 - Ems * Favg );\n\tsingleScatter += FssEss;\n\tmultiScatter += Fms * Ems;\n}\nfloat G_BlinnPhong_Implicit( ) {\n\treturn 0.25;\n}\nfloat D_BlinnPhong( const in float shininess, const in float dotNH ) {\n\treturn RECIPROCAL_PI * ( shininess * 0.5 + 1.0 ) * pow( dotNH, shininess );\n}\nvec3 BRDF_Specular_BlinnPhong( const in IncidentLight incidentLight, const in GeometricContext geometry, const in vec3 specularColor, const in float shininess ) {\n\tvec3 halfDir = normalize( incidentLight.direction + geometry.viewDir );\n\tfloat dotNH = saturate( dot( geometry.normal, halfDir ) );\n\tfloat dotLH = saturate( dot( incidentLight.direction, halfDir ) );\n\tvec3 F = F_Schlick( specularColor, dotLH );\n\tfloat G = G_BlinnPhong_Implicit( );\n\tfloat D = D_BlinnPhong( shininess, dotNH );\n\treturn F * ( G * D );\n}\nfloat GGXRoughnessToBlinnExponent( const in float ggxRoughness ) {\n\treturn ( 2.0 / pow2( ggxRoughness + 0.0001 ) - 2.0 );\n}\nfloat BlinnExponentToGGXRoughness( const in float blinnExponent ) {\n\treturn sqrt( 2.0 / ( blinnExponent + 2.0 ) );\n}\n#if defined( USE_SHEEN )\nfloat D_Charlie(float roughness, float NoH) {\n\tfloat invAlpha  = 1.0 / roughness;\n\tfloat cos2h = NoH * NoH;\n\tfloat sin2h = max(1.0 - cos2h, 0.0078125);\treturn (2.0 + invAlpha) * pow(sin2h, invAlpha * 0.5) / (2.0 * PI);\n}\nfloat V_Neubelt(float NoV, float NoL) {\n\treturn saturate(1.0 / (4.0 * (NoL + NoV - NoL * NoV)));\n}\nvec3 BRDF_Specular_Sheen( const in float roughness, const in vec3 L, const in GeometricContext geometry, vec3 specularColor ) {\n\tvec3 N = geometry.normal;\n\tvec3 V = geometry.viewDir;\n\tvec3 H = normalize( V + L );\n\tfloat dotNH = saturate( dot( N, H ) );\n\treturn specularColor * D_Charlie( roughness, dotNH ) * V_Neubelt( dot(N, V), dot(N, L) );\n}\n#endif";
+
+	var bumpmap_pars_fragment = "#ifdef USE_BUMPMAP\n\tuniform sampler2D bumpMap;\n\tuniform float bumpScale;\n\tvec2 dHdxy_fwd() {\n\t\tvec2 dSTdx = dFdx( vUv );\n\t\tvec2 dSTdy = dFdy( vUv );\n\t\tfloat Hll = bumpScale * texture2D( bumpMap, vUv ).x;\n\t\tfloat dBx = bumpScale * texture2D( bumpMap, vUv + dSTdx ).x - Hll;\n\t\tfloat dBy = bumpScale * texture2D( bumpMap, vUv + dSTdy ).x - Hll;\n\t\treturn vec2( dBx, dBy );\n\t}\n\tvec3 perturbNormalArb( vec3 surf_pos, vec3 surf_norm, vec2 dHdxy ) {\n\t\tvec3 vSigmaX = vec3( dFdx( surf_pos.x ), dFdx( surf_pos.y ), dFdx( surf_pos.z ) );\n\t\tvec3 vSigmaY = vec3( dFdy( surf_pos.x ), dFdy( surf_pos.y ), dFdy( surf_pos.z ) );\n\t\tvec3 vN = surf_norm;\n\t\tvec3 R1 = cross( vSigmaY, vN );\n\t\tvec3 R2 = cross( vN, vSigmaX );\n\t\tfloat fDet = dot( vSigmaX, R1 );\n\t\tfDet *= ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t\tvec3 vGrad = sign( fDet ) * ( dHdxy.x * R1 + dHdxy.y * R2 );\n\t\treturn normalize( abs( fDet ) * surf_norm - vGrad );\n\t}\n#endif";
+
+	var clipping_planes_fragment = "#if NUM_CLIPPING_PLANES > 0\n\tvec4 plane;\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < UNION_CLIPPING_PLANES; i ++ ) {\n\t\tplane = clippingPlanes[ i ];\n\t\tif ( dot( vClipPosition, plane.xyz ) > plane.w ) discard;\n\t}\n\t#pragma unroll_loop_end\n\t#if UNION_CLIPPING_PLANES < NUM_CLIPPING_PLANES\n\t\tbool clipped = true;\n\t\t#pragma unroll_loop_start\n\t\tfor ( int i = UNION_CLIPPING_PLANES; i < NUM_CLIPPING_PLANES; i ++ ) {\n\t\t\tplane = clippingPlanes[ i ];\n\t\t\tclipped = ( dot( vClipPosition, plane.xyz ) > plane.w ) && clipped;\n\t\t}\n\t\t#pragma unroll_loop_end\n\t\tif ( clipped ) discard;\n\t#endif\n#endif";
+
+	var clipping_planes_pars_fragment = "#if NUM_CLIPPING_PLANES > 0\n\tvarying vec3 vClipPosition;\n\tuniform vec4 clippingPlanes[ NUM_CLIPPING_PLANES ];\n#endif";
+
+	var clipping_planes_pars_vertex = "#if NUM_CLIPPING_PLANES > 0\n\tvarying vec3 vClipPosition;\n#endif";
+
+	var clipping_planes_vertex = "#if NUM_CLIPPING_PLANES > 0\n\tvClipPosition = - mvPosition.xyz;\n#endif";
+
+	var color_fragment = "#ifdef USE_COLOR\n\tdiffuseColor.rgb *= vColor;\n#endif";
+
+	var color_pars_fragment = "#ifdef USE_COLOR\n\tvarying vec3 vColor;\n#endif";
+
+	var color_pars_vertex = "#ifdef USE_COLOR\n\tvarying vec3 vColor;\n#endif";
+
+	var color_vertex = "#ifdef USE_COLOR\n\tvColor.xyz = color.xyz;\n#endif";
+
+	var common = "#define PI 3.14159265359\n#define PI2 6.28318530718\n#define PI_HALF 1.5707963267949\n#define RECIPROCAL_PI 0.31830988618\n#define RECIPROCAL_PI2 0.15915494\n#define LOG2 1.442695\n#define EPSILON 1e-6\n#ifndef saturate\n#define saturate(a) clamp( a, 0.0, 1.0 )\n#endif\n#define whiteComplement(a) ( 1.0 - saturate( a ) )\nfloat pow2( const in float x ) { return x*x; }\nfloat pow3( const in float x ) { return x*x*x; }\nfloat pow4( const in float x ) { float x2 = x*x; return x2*x2; }\nfloat average( const in vec3 color ) { return dot( color, vec3( 0.3333 ) ); }\nhighp float rand( const in vec2 uv ) {\n\tconst highp float a = 12.9898, b = 78.233, c = 43758.5453;\n\thighp float dt = dot( uv.xy, vec2( a,b ) ), sn = mod( dt, PI );\n\treturn fract(sin(sn) * c);\n}\n#ifdef HIGH_PRECISION\n\tfloat precisionSafeLength( vec3 v ) { return length( v ); }\n#else\n\tfloat max3( vec3 v ) { return max( max( v.x, v.y ), v.z ); }\n\tfloat precisionSafeLength( vec3 v ) {\n\t\tfloat maxComponent = max3( abs( v ) );\n\t\treturn length( v / maxComponent ) * maxComponent;\n\t}\n#endif\nstruct IncidentLight {\n\tvec3 color;\n\tvec3 direction;\n\tbool visible;\n};\nstruct ReflectedLight {\n\tvec3 directDiffuse;\n\tvec3 directSpecular;\n\tvec3 indirectDiffuse;\n\tvec3 indirectSpecular;\n};\nstruct GeometricContext {\n\tvec3 position;\n\tvec3 normal;\n\tvec3 viewDir;\n#ifdef CLEARCOAT\n\tvec3 clearcoatNormal;\n#endif\n};\nvec3 transformDirection( in vec3 dir, in mat4 matrix ) {\n\treturn normalize( ( matrix * vec4( dir, 0.0 ) ).xyz );\n}\nvec3 inverseTransformDirection( in vec3 dir, in mat4 matrix ) {\n\treturn normalize( ( vec4( dir, 0.0 ) * matrix ).xyz );\n}\nvec3 projectOnPlane(in vec3 point, in vec3 pointOnPlane, in vec3 planeNormal ) {\n\tfloat distance = dot( planeNormal, point - pointOnPlane );\n\treturn - distance * planeNormal + point;\n}\nfloat sideOfPlane( in vec3 point, in vec3 pointOnPlane, in vec3 planeNormal ) {\n\treturn sign( dot( point - pointOnPlane, planeNormal ) );\n}\nvec3 linePlaneIntersect( in vec3 pointOnLine, in vec3 lineDirection, in vec3 pointOnPlane, in vec3 planeNormal ) {\n\treturn lineDirection * ( dot( planeNormal, pointOnPlane - pointOnLine ) / dot( planeNormal, lineDirection ) ) + pointOnLine;\n}\nmat3 transposeMat3( const in mat3 m ) {\n\tmat3 tmp;\n\ttmp[ 0 ] = vec3( m[ 0 ].x, m[ 1 ].x, m[ 2 ].x );\n\ttmp[ 1 ] = vec3( m[ 0 ].y, m[ 1 ].y, m[ 2 ].y );\n\ttmp[ 2 ] = vec3( m[ 0 ].z, m[ 1 ].z, m[ 2 ].z );\n\treturn tmp;\n}\nfloat linearToRelativeLuminance( const in vec3 color ) {\n\tvec3 weights = vec3( 0.2126, 0.7152, 0.0722 );\n\treturn dot( weights, color.rgb );\n}\nbool isPerspectiveMatrix( mat4 m ) {\n  return m[ 2 ][ 3 ] == - 1.0;\n}";
+
+	var cube_uv_reflection_fragment = "#ifdef ENVMAP_TYPE_CUBE_UV\n#define cubeUV_maxMipLevel 8.0\n#define cubeUV_minMipLevel 4.0\n#define cubeUV_maxTileSize 256.0\n#define cubeUV_minTileSize 16.0\nfloat getFace(vec3 direction) {\n    vec3 absDirection = abs(direction);\n    float face = -1.0;\n    if (absDirection.x > absDirection.z) {\n      if (absDirection.x > absDirection.y)\n        face = direction.x > 0.0 ? 0.0 : 3.0;\n      else\n        face = direction.y > 0.0 ? 1.0 : 4.0;\n    } else {\n      if (absDirection.z > absDirection.y)\n        face = direction.z > 0.0 ? 2.0 : 5.0;\n      else\n        face = direction.y > 0.0 ? 1.0 : 4.0;\n    }\n    return face;\n}\nvec2 getUV(vec3 direction, float face) {\n    vec2 uv;\n    if (face == 0.0) {\n      uv = vec2(-direction.z, direction.y) / abs(direction.x);\n    } else if (face == 1.0) {\n      uv = vec2(direction.x, -direction.z) / abs(direction.y);\n    } else if (face == 2.0) {\n      uv = direction.xy / abs(direction.z);\n    } else if (face == 3.0) {\n      uv = vec2(direction.z, direction.y) / abs(direction.x);\n    } else if (face == 4.0) {\n      uv = direction.xz / abs(direction.y);\n    } else {\n      uv = vec2(-direction.x, direction.y) / abs(direction.z);\n    }\n    return 0.5 * (uv + 1.0);\n}\nvec3 bilinearCubeUV(sampler2D envMap, vec3 direction, float mipInt) {\n  float face = getFace(direction);\n  float filterInt = max(cubeUV_minMipLevel - mipInt, 0.0);\n  mipInt = max(mipInt, cubeUV_minMipLevel);\n  float faceSize = exp2(mipInt);\n  float texelSize = 1.0 / (3.0 * cubeUV_maxTileSize);\n  vec2 uv = getUV(direction, face) * (faceSize - 1.0);\n  vec2 f = fract(uv);\n  uv += 0.5 - f;\n  if (face > 2.0) {\n    uv.y += faceSize;\n    face -= 3.0;\n  }\n  uv.x += face * faceSize;\n  if(mipInt < cubeUV_maxMipLevel){\n    uv.y += 2.0 * cubeUV_maxTileSize;\n  }\n  uv.y += filterInt * 2.0 * cubeUV_minTileSize;\n  uv.x += 3.0 * max(0.0, cubeUV_maxTileSize - 2.0 * faceSize);\n  uv *= texelSize;\n  vec3 tl = envMapTexelToLinear(texture2D(envMap, uv)).rgb;\n  uv.x += texelSize;\n  vec3 tr = envMapTexelToLinear(texture2D(envMap, uv)).rgb;\n  uv.y += texelSize;\n  vec3 br = envMapTexelToLinear(texture2D(envMap, uv)).rgb;\n  uv.x -= texelSize;\n  vec3 bl = envMapTexelToLinear(texture2D(envMap, uv)).rgb;\n  vec3 tm = mix(tl, tr, f.x);\n  vec3 bm = mix(bl, br, f.x);\n  return mix(tm, bm, f.y);\n}\n#define r0 1.0\n#define v0 0.339\n#define m0 -2.0\n#define r1 0.8\n#define v1 0.276\n#define m1 -1.0\n#define r4 0.4\n#define v4 0.046\n#define m4 2.0\n#define r5 0.305\n#define v5 0.016\n#define m5 3.0\n#define r6 0.21\n#define v6 0.0038\n#define m6 4.0\nfloat roughnessToMip(float roughness) {\n  float mip = 0.0;\n  if (roughness >= r1) {\n    mip = (r0 - roughness) * (m1 - m0) / (r0 - r1) + m0;\n  } else if (roughness >= r4) {\n    mip = (r1 - roughness) * (m4 - m1) / (r1 - r4) + m1;\n  } else if (roughness >= r5) {\n    mip = (r4 - roughness) * (m5 - m4) / (r4 - r5) + m4;\n  } else if (roughness >= r6) {\n    mip = (r5 - roughness) * (m6 - m5) / (r5 - r6) + m5;\n  } else {\n    mip = -2.0 * log2(1.16 * roughness);  }\n  return mip;\n}\nvec4 textureCubeUV(sampler2D envMap, vec3 sampleDir, float roughness) {\n  float mip = clamp(roughnessToMip(roughness), m0, cubeUV_maxMipLevel);\n  float mipF = fract(mip);\n  float mipInt = floor(mip);\n  vec3 color0 = bilinearCubeUV(envMap, sampleDir, mipInt);\n  if (mipF == 0.0) {\n    return vec4(color0, 1.0);\n  } else {\n    vec3 color1 = bilinearCubeUV(envMap, sampleDir, mipInt + 1.0);\n    return vec4(mix(color0, color1, mipF), 1.0);\n  }\n}\n#endif";
+
+	var defaultnormal_vertex = "vec3 transformedNormal = objectNormal;\n#ifdef USE_INSTANCING\n\tmat3 m = mat3( instanceMatrix );\n\ttransformedNormal /= vec3( dot( m[ 0 ], m[ 0 ] ), dot( m[ 1 ], m[ 1 ] ), dot( m[ 2 ], m[ 2 ] ) );\n\ttransformedNormal = m * transformedNormal;\n#endif\ntransformedNormal = normalMatrix * transformedNormal;\n#ifdef FLIP_SIDED\n\ttransformedNormal = - transformedNormal;\n#endif\n#ifdef USE_TANGENT\n\tvec3 transformedTangent = ( modelViewMatrix * vec4( objectTangent, 0.0 ) ).xyz;\n\t#ifdef FLIP_SIDED\n\t\ttransformedTangent = - transformedTangent;\n\t#endif\n#endif";
+
+	var displacementmap_pars_vertex = "#ifdef USE_DISPLACEMENTMAP\n\tuniform sampler2D displacementMap;\n\tuniform float displacementScale;\n\tuniform float displacementBias;\n#endif";
+
+	var displacementmap_vertex = "#ifdef USE_DISPLACEMENTMAP\n\ttransformed += normalize( objectNormal ) * ( texture2D( displacementMap, vUv ).x * displacementScale + displacementBias );\n#endif";
+
+	var emissivemap_fragment = "#ifdef USE_EMISSIVEMAP\n\tvec4 emissiveColor = texture2D( emissiveMap, vUv );\n\temissiveColor.rgb = emissiveMapTexelToLinear( emissiveColor ).rgb;\n\ttotalEmissiveRadiance *= emissiveColor.rgb;\n#endif";
+
+	var emissivemap_pars_fragment = "#ifdef USE_EMISSIVEMAP\n\tuniform sampler2D emissiveMap;\n#endif";
+
+	var encodings_fragment = "gl_FragColor = linearToOutputTexel( gl_FragColor );";
+
+	var encodings_pars_fragment = "\nvec4 LinearToLinear( in vec4 value ) {\n\treturn value;\n}\nvec4 GammaToLinear( in vec4 value, in float gammaFactor ) {\n\treturn vec4( pow( value.rgb, vec3( gammaFactor ) ), value.a );\n}\nvec4 LinearToGamma( in vec4 value, in float gammaFactor ) {\n\treturn vec4( pow( value.rgb, vec3( 1.0 / gammaFactor ) ), value.a );\n}\nvec4 sRGBToLinear( in vec4 value ) {\n\treturn vec4( mix( pow( value.rgb * 0.9478672986 + vec3( 0.0521327014 ), vec3( 2.4 ) ), value.rgb * 0.0773993808, vec3( lessThanEqual( value.rgb, vec3( 0.04045 ) ) ) ), value.a );\n}\nvec4 LinearTosRGB( in vec4 value ) {\n\treturn vec4( mix( pow( value.rgb, vec3( 0.41666 ) ) * 1.055 - vec3( 0.055 ), value.rgb * 12.92, vec3( lessThanEqual( value.rgb, vec3( 0.0031308 ) ) ) ), value.a );\n}\nvec4 RGBEToLinear( in vec4 value ) {\n\treturn vec4( value.rgb * exp2( value.a * 255.0 - 128.0 ), 1.0 );\n}\nvec4 LinearToRGBE( in vec4 value ) {\n\tfloat maxComponent = max( max( value.r, value.g ), value.b );\n\tfloat fExp = clamp( ceil( log2( maxComponent ) ), -128.0, 127.0 );\n\treturn vec4( value.rgb / exp2( fExp ), ( fExp + 128.0 ) / 255.0 );\n}\nvec4 RGBMToLinear( in vec4 value, in float maxRange ) {\n\treturn vec4( value.rgb * value.a * maxRange, 1.0 );\n}\nvec4 LinearToRGBM( in vec4 value, in float maxRange ) {\n\tfloat maxRGB = max( value.r, max( value.g, value.b ) );\n\tfloat M = clamp( maxRGB / maxRange, 0.0, 1.0 );\n\tM = ceil( M * 255.0 ) / 255.0;\n\treturn vec4( value.rgb / ( M * maxRange ), M );\n}\nvec4 RGBDToLinear( in vec4 value, in float maxRange ) {\n\treturn vec4( value.rgb * ( ( maxRange / 255.0 ) / value.a ), 1.0 );\n}\nvec4 LinearToRGBD( in vec4 value, in float maxRange ) {\n\tfloat maxRGB = max( value.r, max( value.g, value.b ) );\n\tfloat D = max( maxRange / maxRGB, 1.0 );\n\tD = clamp( floor( D ) / 255.0, 0.0, 1.0 );\n\treturn vec4( value.rgb * ( D * ( 255.0 / maxRange ) ), D );\n}\nconst mat3 cLogLuvM = mat3( 0.2209, 0.3390, 0.4184, 0.1138, 0.6780, 0.7319, 0.0102, 0.1130, 0.2969 );\nvec4 LinearToLogLuv( in vec4 value )  {\n\tvec3 Xp_Y_XYZp = cLogLuvM * value.rgb;\n\tXp_Y_XYZp = max( Xp_Y_XYZp, vec3( 1e-6, 1e-6, 1e-6 ) );\n\tvec4 vResult;\n\tvResult.xy = Xp_Y_XYZp.xy / Xp_Y_XYZp.z;\n\tfloat Le = 2.0 * log2(Xp_Y_XYZp.y) + 127.0;\n\tvResult.w = fract( Le );\n\tvResult.z = ( Le - ( floor( vResult.w * 255.0 ) ) / 255.0 ) / 255.0;\n\treturn vResult;\n}\nconst mat3 cLogLuvInverseM = mat3( 6.0014, -2.7008, -1.7996, -1.3320, 3.1029, -5.7721, 0.3008, -1.0882, 5.6268 );\nvec4 LogLuvToLinear( in vec4 value ) {\n\tfloat Le = value.z * 255.0 + value.w;\n\tvec3 Xp_Y_XYZp;\n\tXp_Y_XYZp.y = exp2( ( Le - 127.0 ) / 2.0 );\n\tXp_Y_XYZp.z = Xp_Y_XYZp.y / value.y;\n\tXp_Y_XYZp.x = value.x * Xp_Y_XYZp.z;\n\tvec3 vRGB = cLogLuvInverseM * Xp_Y_XYZp.rgb;\n\treturn vec4( max( vRGB, 0.0 ), 1.0 );\n}";
+
+	var envmap_fragment = "#ifdef USE_ENVMAP\n\t#ifdef ENV_WORLDPOS\n\t\tvec3 cameraToFrag;\n\t\t\n\t\tif ( isOrthographic ) {\n\t\t\tcameraToFrag = normalize( vec3( - viewMatrix[ 0 ][ 2 ], - viewMatrix[ 1 ][ 2 ], - viewMatrix[ 2 ][ 2 ] ) );\n\t\t}  else {\n\t\t\tcameraToFrag = normalize( vWorldPosition - cameraPosition );\n\t\t}\n\t\tvec3 worldNormal = inverseTransformDirection( normal, viewMatrix );\n\t\t#ifdef ENVMAP_MODE_REFLECTION\n\t\t\tvec3 reflectVec = reflect( cameraToFrag, worldNormal );\n\t\t#else\n\t\t\tvec3 reflectVec = refract( cameraToFrag, worldNormal, refractionRatio );\n\t\t#endif\n\t#else\n\t\tvec3 reflectVec = vReflect;\n\t#endif\n\t#ifdef ENVMAP_TYPE_CUBE\n\t\tvec4 envColor = textureCube( envMap, vec3( flipEnvMap * reflectVec.x, reflectVec.yz ) );\n\t#elif defined( ENVMAP_TYPE_CUBE_UV )\n\t\tvec4 envColor = textureCubeUV( envMap, reflectVec, 0.0 );\n\t#elif defined( ENVMAP_TYPE_EQUIREC )\n\t\tvec2 sampleUV;\n\t\treflectVec = normalize( reflectVec );\n\t\tsampleUV.y = asin( clamp( reflectVec.y, - 1.0, 1.0 ) ) * RECIPROCAL_PI + 0.5;\n\t\tsampleUV.x = atan( reflectVec.z, reflectVec.x ) * RECIPROCAL_PI2 + 0.5;\n\t\tvec4 envColor = texture2D( envMap, sampleUV );\n\t#elif defined( ENVMAP_TYPE_SPHERE )\n\t\treflectVec = normalize( reflectVec );\n\t\tvec3 reflectView = normalize( ( viewMatrix * vec4( reflectVec, 0.0 ) ).xyz + vec3( 0.0, 0.0, 1.0 ) );\n\t\tvec4 envColor = texture2D( envMap, reflectView.xy * 0.5 + 0.5 );\n\t#else\n\t\tvec4 envColor = vec4( 0.0 );\n\t#endif\n\t#ifndef ENVMAP_TYPE_CUBE_UV\n\t\tenvColor = envMapTexelToLinear( envColor );\n\t#endif\n\t#ifdef ENVMAP_BLENDING_MULTIPLY\n\t\toutgoingLight = mix( outgoingLight, outgoingLight * envColor.xyz, specularStrength * reflectivity );\n\t#elif defined( ENVMAP_BLENDING_MIX )\n\t\toutgoingLight = mix( outgoingLight, envColor.xyz, specularStrength * reflectivity );\n\t#elif defined( ENVMAP_BLENDING_ADD )\n\t\toutgoingLight += envColor.xyz * specularStrength * reflectivity;\n\t#endif\n#endif";
+
+	var envmap_common_pars_fragment = "#ifdef USE_ENVMAP\n\tuniform float envMapIntensity;\n\tuniform float flipEnvMap;\n\tuniform int maxMipLevel;\n\t#ifdef ENVMAP_TYPE_CUBE\n\t\tuniform samplerCube envMap;\n\t#else\n\t\tuniform sampler2D envMap;\n\t#endif\n\t\n#endif";
+
+	var envmap_pars_fragment = "#ifdef USE_ENVMAP\n\tuniform float reflectivity;\n\t#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG )\n\t\t#define ENV_WORLDPOS\n\t#endif\n\t#ifdef ENV_WORLDPOS\n\t\tvarying vec3 vWorldPosition;\n\t\tuniform float refractionRatio;\n\t#else\n\t\tvarying vec3 vReflect;\n\t#endif\n#endif";
+
+	var envmap_pars_vertex = "#ifdef USE_ENVMAP\n\t#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) ||defined( PHONG )\n\t\t#define ENV_WORLDPOS\n\t#endif\n\t#ifdef ENV_WORLDPOS\n\t\t\n\t\tvarying vec3 vWorldPosition;\n\t#else\n\t\tvarying vec3 vReflect;\n\t\tuniform float refractionRatio;\n\t#endif\n#endif";
+
+	var envmap_vertex = "#ifdef USE_ENVMAP\n\t#ifdef ENV_WORLDPOS\n\t\tvWorldPosition = worldPosition.xyz;\n\t#else\n\t\tvec3 cameraToVertex;\n\t\tif ( isOrthographic ) { \n\t\t\tcameraToVertex = normalize( vec3( - viewMatrix[ 0 ][ 2 ], - viewMatrix[ 1 ][ 2 ], - viewMatrix[ 2 ][ 2 ] ) );\n\t\t} else {\n\t\t\tcameraToVertex = normalize( worldPosition.xyz - cameraPosition );\n\t\t}\n\t\tvec3 worldNormal = inverseTransformDirection( transformedNormal, viewMatrix );\n\t\t#ifdef ENVMAP_MODE_REFLECTION\n\t\t\tvReflect = reflect( cameraToVertex, worldNormal );\n\t\t#else\n\t\t\tvReflect = refract( cameraToVertex, worldNormal, refractionRatio );\n\t\t#endif\n\t#endif\n#endif";
+
+	var fog_vertex = "#ifdef USE_FOG\n\tfogDepth = -mvPosition.z;\n#endif";
+
+	var fog_pars_vertex = "#ifdef USE_FOG\n\tvarying float fogDepth;\n#endif";
+
+	var fog_fragment = "#ifdef USE_FOG\n\t#ifdef FOG_EXP2\n\t\tfloat fogFactor = 1.0 - exp( - fogDensity * fogDensity * fogDepth * fogDepth );\n\t#else\n\t\tfloat fogFactor = smoothstep( fogNear, fogFar, fogDepth );\n\t#endif\n\tgl_FragColor.rgb = mix( gl_FragColor.rgb, fogColor, fogFactor );\n#endif";
+
+	var fog_pars_fragment = "#ifdef USE_FOG\n\tuniform vec3 fogColor;\n\tvarying float fogDepth;\n\t#ifdef FOG_EXP2\n\t\tuniform float fogDensity;\n\t#else\n\t\tuniform float fogNear;\n\t\tuniform float fogFar;\n\t#endif\n#endif";
+
+	var gradientmap_pars_fragment = "#ifdef USE_GRADIENTMAP\n\tuniform sampler2D gradientMap;\n#endif\nvec3 getGradientIrradiance( vec3 normal, vec3 lightDirection ) {\n\tfloat dotNL = dot( normal, lightDirection );\n\tvec2 coord = vec2( dotNL * 0.5 + 0.5, 0.0 );\n\t#ifdef USE_GRADIENTMAP\n\t\treturn texture2D( gradientMap, coord ).rgb;\n\t#else\n\t\treturn ( coord.x < 0.7 ) ? vec3( 0.7 ) : vec3( 1.0 );\n\t#endif\n}";
+
+	var lightmap_fragment = "#ifdef USE_LIGHTMAP\n\tvec4 lightMapTexel= texture2D( lightMap, vUv2 );\n\treflectedLight.indirectDiffuse += PI * lightMapTexelToLinear( lightMapTexel ).rgb * lightMapIntensity;\n#endif";
+
+	var lightmap_pars_fragment = "#ifdef USE_LIGHTMAP\n\tuniform sampler2D lightMap;\n\tuniform float lightMapIntensity;\n#endif";
+
+	var lights_lambert_vertex = "vec3 diffuse = vec3( 1.0 );\nGeometricContext geometry;\ngeometry.position = mvPosition.xyz;\ngeometry.normal = normalize( transformedNormal );\ngeometry.viewDir = ( isOrthographic ) ? vec3( 0, 0, 1 ) : normalize( -mvPosition.xyz );\nGeometricContext backGeometry;\nbackGeometry.position = geometry.position;\nbackGeometry.normal = -geometry.normal;\nbackGeometry.viewDir = geometry.viewDir;\nvLightFront = vec3( 0.0 );\nvIndirectFront = vec3( 0.0 );\n#ifdef DOUBLE_SIDED\n\tvLightBack = vec3( 0.0 );\n\tvIndirectBack = vec3( 0.0 );\n#endif\nIncidentLight directLight;\nfloat dotNL;\nvec3 directLightColor_Diffuse;\nvIndirectFront += getAmbientLightIrradiance( ambientLightColor );\nvIndirectFront += getLightProbeIrradiance( lightProbe, geometry );\n#ifdef DOUBLE_SIDED\n\tvIndirectBack += getAmbientLightIrradiance( ambientLightColor );\n\tvIndirectBack += getLightProbeIrradiance( lightProbe, backGeometry );\n#endif\n#if NUM_POINT_LIGHTS > 0\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {\n\t\tgetPointDirectLightIrradiance( pointLights[ i ], geometry, directLight );\n\t\tdotNL = dot( geometry.normal, directLight.direction );\n\t\tdirectLightColor_Diffuse = PI * directLight.color;\n\t\tvLightFront += saturate( dotNL ) * directLightColor_Diffuse;\n\t\t#ifdef DOUBLE_SIDED\n\t\t\tvLightBack += saturate( -dotNL ) * directLightColor_Diffuse;\n\t\t#endif\n\t}\n\t#pragma unroll_loop_end\n#endif\n#if NUM_SPOT_LIGHTS > 0\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {\n\t\tgetSpotDirectLightIrradiance( spotLights[ i ], geometry, directLight );\n\t\tdotNL = dot( geometry.normal, directLight.direction );\n\t\tdirectLightColor_Diffuse = PI * directLight.color;\n\t\tvLightFront += saturate( dotNL ) * directLightColor_Diffuse;\n\t\t#ifdef DOUBLE_SIDED\n\t\t\tvLightBack += saturate( -dotNL ) * directLightColor_Diffuse;\n\t\t#endif\n\t}\n\t#pragma unroll_loop_end\n#endif\n#if NUM_DIR_LIGHTS > 0\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {\n\t\tgetDirectionalDirectLightIrradiance( directionalLights[ i ], geometry, directLight );\n\t\tdotNL = dot( geometry.normal, directLight.direction );\n\t\tdirectLightColor_Diffuse = PI * directLight.color;\n\t\tvLightFront += saturate( dotNL ) * directLightColor_Diffuse;\n\t\t#ifdef DOUBLE_SIDED\n\t\t\tvLightBack += saturate( -dotNL ) * directLightColor_Diffuse;\n\t\t#endif\n\t}\n\t#pragma unroll_loop_end\n#endif\n#if NUM_HEMI_LIGHTS > 0\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {\n\t\tvIndirectFront += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );\n\t\t#ifdef DOUBLE_SIDED\n\t\t\tvIndirectBack += getHemisphereLightIrradiance( hemisphereLights[ i ], backGeometry );\n\t\t#endif\n\t}\n\t#pragma unroll_loop_end\n#endif";
+
+	var lights_pars_begin = "uniform bool receiveShadow;\nuniform vec3 ambientLightColor;\nuniform vec3 lightProbe[ 9 ];\nvec3 shGetIrradianceAt( in vec3 normal, in vec3 shCoefficients[ 9 ] ) {\n\tfloat x = normal.x, y = normal.y, z = normal.z;\n\tvec3 result = shCoefficients[ 0 ] * 0.886227;\n\tresult += shCoefficients[ 1 ] * 2.0 * 0.511664 * y;\n\tresult += shCoefficients[ 2 ] * 2.0 * 0.511664 * z;\n\tresult += shCoefficients[ 3 ] * 2.0 * 0.511664 * x;\n\tresult += shCoefficients[ 4 ] * 2.0 * 0.429043 * x * y;\n\tresult += shCoefficients[ 5 ] * 2.0 * 0.429043 * y * z;\n\tresult += shCoefficients[ 6 ] * ( 0.743125 * z * z - 0.247708 );\n\tresult += shCoefficients[ 7 ] * 2.0 * 0.429043 * x * z;\n\tresult += shCoefficients[ 8 ] * 0.429043 * ( x * x - y * y );\n\treturn result;\n}\nvec3 getLightProbeIrradiance( const in vec3 lightProbe[ 9 ], const in GeometricContext geometry ) {\n\tvec3 worldNormal = inverseTransformDirection( geometry.normal, viewMatrix );\n\tvec3 irradiance = shGetIrradianceAt( worldNormal, lightProbe );\n\treturn irradiance;\n}\nvec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {\n\tvec3 irradiance = ambientLightColor;\n\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\tirradiance *= PI;\n\t#endif\n\treturn irradiance;\n}\n#if NUM_DIR_LIGHTS > 0\n\tstruct DirectionalLight {\n\t\tvec3 direction;\n\t\tvec3 color;\n\t};\n\tuniform DirectionalLight directionalLights[ NUM_DIR_LIGHTS ];\n\t#if defined( USE_SHADOWMAP ) && NUM_DIR_LIGHT_SHADOWS > 0\n\t\tstruct DirectionalLightShadow {\n\t\t\tfloat shadowBias;\n\t\t\tfloat shadowRadius;\n\t\t\tvec2 shadowMapSize;\n\t\t};\n\t\tuniform DirectionalLightShadow directionalLightShadows[ NUM_DIR_LIGHT_SHADOWS ];\n\t#endif\n\tvoid getDirectionalDirectLightIrradiance( const in DirectionalLight directionalLight, const in GeometricContext geometry, out IncidentLight directLight ) {\n\t\tdirectLight.color = directionalLight.color;\n\t\tdirectLight.direction = directionalLight.direction;\n\t\tdirectLight.visible = true;\n\t}\n#endif\n#if NUM_POINT_LIGHTS > 0\n\tstruct PointLight {\n\t\tvec3 position;\n\t\tvec3 color;\n\t\tfloat distance;\n\t\tfloat decay;\n\t};\n\tuniform PointLight pointLights[ NUM_POINT_LIGHTS ];\n\t#if defined( USE_SHADOWMAP ) && NUM_POINT_LIGHT_SHADOWS > 0\n\t\tstruct PointLightShadow {\n\t\t\tfloat shadowBias;\n\t\t\tfloat shadowRadius;\n\t\t\tvec2 shadowMapSize;\n\t\t\tfloat shadowCameraNear;\n\t\t\tfloat shadowCameraFar;\n\t\t};\n\t\tuniform PointLightShadow pointLightShadows[ NUM_POINT_LIGHT_SHADOWS ];\n\t#endif\n\tvoid getPointDirectLightIrradiance( const in PointLight pointLight, const in GeometricContext geometry, out IncidentLight directLight ) {\n\t\tvec3 lVector = pointLight.position - geometry.position;\n\t\tdirectLight.direction = normalize( lVector );\n\t\tfloat lightDistance = length( lVector );\n\t\tdirectLight.color = pointLight.color;\n\t\tdirectLight.color *= punctualLightIntensityToIrradianceFactor( lightDistance, pointLight.distance, pointLight.decay );\n\t\tdirectLight.visible = ( directLight.color != vec3( 0.0 ) );\n\t}\n#endif\n#if NUM_SPOT_LIGHTS > 0\n\tstruct SpotLight {\n\t\tvec3 position;\n\t\tvec3 direction;\n\t\tvec3 color;\n\t\tfloat distance;\n\t\tfloat decay;\n\t\tfloat coneCos;\n\t\tfloat penumbraCos;\n\t};\n\tuniform SpotLight spotLights[ NUM_SPOT_LIGHTS ];\n\t#if defined( USE_SHADOWMAP ) && NUM_SPOT_LIGHT_SHADOWS > 0\n\t\tstruct SpotLightShadow {\n\t\t\tfloat shadowBias;\n\t\t\tfloat shadowRadius;\n\t\t\tvec2 shadowMapSize;\n\t\t};\n\t\tuniform SpotLightShadow spotLightShadows[ NUM_SPOT_LIGHT_SHADOWS ];\n\t#endif\n\tvoid getSpotDirectLightIrradiance( const in SpotLight spotLight, const in GeometricContext geometry, out IncidentLight directLight  ) {\n\t\tvec3 lVector = spotLight.position - geometry.position;\n\t\tdirectLight.direction = normalize( lVector );\n\t\tfloat lightDistance = length( lVector );\n\t\tfloat angleCos = dot( directLight.direction, spotLight.direction );\n\t\tif ( angleCos > spotLight.coneCos ) {\n\t\t\tfloat spotEffect = smoothstep( spotLight.coneCos, spotLight.penumbraCos, angleCos );\n\t\t\tdirectLight.color = spotLight.color;\n\t\t\tdirectLight.color *= spotEffect * punctualLightIntensityToIrradianceFactor( lightDistance, spotLight.distance, spotLight.decay );\n\t\t\tdirectLight.visible = true;\n\t\t} else {\n\t\t\tdirectLight.color = vec3( 0.0 );\n\t\t\tdirectLight.visible = false;\n\t\t}\n\t}\n#endif\n#if NUM_RECT_AREA_LIGHTS > 0\n\tstruct RectAreaLight {\n\t\tvec3 color;\n\t\tvec3 position;\n\t\tvec3 halfWidth;\n\t\tvec3 halfHeight;\n\t};\n\tuniform sampler2D ltc_1;\tuniform sampler2D ltc_2;\n\tuniform RectAreaLight rectAreaLights[ NUM_RECT_AREA_LIGHTS ];\n#endif\n#if NUM_HEMI_LIGHTS > 0\n\tstruct HemisphereLight {\n\t\tvec3 direction;\n\t\tvec3 skyColor;\n\t\tvec3 groundColor;\n\t};\n\tuniform HemisphereLight hemisphereLights[ NUM_HEMI_LIGHTS ];\n\tvec3 getHemisphereLightIrradiance( const in HemisphereLight hemiLight, const in GeometricContext geometry ) {\n\t\tfloat dotNL = dot( geometry.normal, hemiLight.direction );\n\t\tfloat hemiDiffuseWeight = 0.5 * dotNL + 0.5;\n\t\tvec3 irradiance = mix( hemiLight.groundColor, hemiLight.skyColor, hemiDiffuseWeight );\n\t\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\t\tirradiance *= PI;\n\t\t#endif\n\t\treturn irradiance;\n\t}\n#endif";
+
+	var envmap_physical_pars_fragment = "#if defined( USE_ENVMAP )\n\t#ifdef ENVMAP_MODE_REFRACTION\n\t\tuniform float refractionRatio;\n\t#endif\n\tvec3 getLightProbeIndirectIrradiance( const in GeometricContext geometry, const in int maxMIPLevel ) {\n\t\tvec3 worldNormal = inverseTransformDirection( geometry.normal, viewMatrix );\n\t\t#ifdef ENVMAP_TYPE_CUBE\n\t\t\tvec3 queryVec = vec3( flipEnvMap * worldNormal.x, worldNormal.yz );\n\t\t\t#ifdef TEXTURE_LOD_EXT\n\t\t\t\tvec4 envMapColor = textureCubeLodEXT( envMap, queryVec, float( maxMIPLevel ) );\n\t\t\t#else\n\t\t\t\tvec4 envMapColor = textureCube( envMap, queryVec, float( maxMIPLevel ) );\n\t\t\t#endif\n\t\t\tenvMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;\n\t\t#elif defined( ENVMAP_TYPE_CUBE_UV )\n\t\t\tvec4 envMapColor = textureCubeUV( envMap, worldNormal, 1.0 );\n\t\t#else\n\t\t\tvec4 envMapColor = vec4( 0.0 );\n\t\t#endif\n\t\treturn PI * envMapColor.rgb * envMapIntensity;\n\t}\n\tfloat getSpecularMIPLevel( const in float roughness, const in int maxMIPLevel ) {\n\t\tfloat maxMIPLevelScalar = float( maxMIPLevel );\n\t\tfloat sigma = PI * roughness * roughness / ( 1.0 + roughness );\n\t\tfloat desiredMIPLevel = maxMIPLevelScalar + log2( sigma );\n\t\treturn clamp( desiredMIPLevel, 0.0, maxMIPLevelScalar );\n\t}\n\tvec3 getLightProbeIndirectRadiance( const in vec3 viewDir, const in vec3 normal, const in float roughness, const in int maxMIPLevel ) {\n\t\t#ifdef ENVMAP_MODE_REFLECTION\n\t\t  vec3 reflectVec = reflect( -viewDir, normal );\n\t\t  reflectVec = normalize( mix( reflectVec, normal, roughness * roughness) );\n\t\t#else\n\t\t  vec3 reflectVec = refract( -viewDir, normal, refractionRatio );\n\t\t#endif\n\t\treflectVec = inverseTransformDirection( reflectVec, viewMatrix );\n\t\tfloat specularMIPLevel = getSpecularMIPLevel( roughness, maxMIPLevel );\n\t\t#ifdef ENVMAP_TYPE_CUBE\n\t\t\tvec3 queryReflectVec = vec3( flipEnvMap * reflectVec.x, reflectVec.yz );\n\t\t\t#ifdef TEXTURE_LOD_EXT\n\t\t\t\tvec4 envMapColor = textureCubeLodEXT( envMap, queryReflectVec, specularMIPLevel );\n\t\t\t#else\n\t\t\t\tvec4 envMapColor = textureCube( envMap, queryReflectVec, specularMIPLevel );\n\t\t\t#endif\n\t\t\tenvMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;\n\t\t#elif defined( ENVMAP_TYPE_CUBE_UV )\n\t\t\tvec4 envMapColor = textureCubeUV( envMap, reflectVec, roughness );\n\t\t#elif defined( ENVMAP_TYPE_EQUIREC )\n\t\t\tvec2 sampleUV;\n\t\t\tsampleUV.y = asin( clamp( reflectVec.y, - 1.0, 1.0 ) ) * RECIPROCAL_PI + 0.5;\n\t\t\tsampleUV.x = atan( reflectVec.z, reflectVec.x ) * RECIPROCAL_PI2 + 0.5;\n\t\t\t#ifdef TEXTURE_LOD_EXT\n\t\t\t\tvec4 envMapColor = texture2DLodEXT( envMap, sampleUV, specularMIPLevel );\n\t\t\t#else\n\t\t\t\tvec4 envMapColor = texture2D( envMap, sampleUV, specularMIPLevel );\n\t\t\t#endif\n\t\t\tenvMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;\n\t\t#elif defined( ENVMAP_TYPE_SPHERE )\n\t\t\tvec3 reflectView = normalize( ( viewMatrix * vec4( reflectVec, 0.0 ) ).xyz + vec3( 0.0,0.0,1.0 ) );\n\t\t\t#ifdef TEXTURE_LOD_EXT\n\t\t\t\tvec4 envMapColor = texture2DLodEXT( envMap, reflectView.xy * 0.5 + 0.5, specularMIPLevel );\n\t\t\t#else\n\t\t\t\tvec4 envMapColor = texture2D( envMap, reflectView.xy * 0.5 + 0.5, specularMIPLevel );\n\t\t\t#endif\n\t\t\tenvMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;\n\t\t#endif\n\t\treturn envMapColor.rgb * envMapIntensity;\n\t}\n#endif";
+
+	var lights_toon_fragment = "ToonMaterial material;\nmaterial.diffuseColor = diffuseColor.rgb;\nmaterial.specularColor = specular;\nmaterial.specularShininess = shininess;\nmaterial.specularStrength = specularStrength;";
+
+	var lights_toon_pars_fragment = "varying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\nstruct ToonMaterial {\n\tvec3\tdiffuseColor;\n\tvec3\tspecularColor;\n\tfloat\tspecularShininess;\n\tfloat\tspecularStrength;\n};\nvoid RE_Direct_Toon( const in IncidentLight directLight, const in GeometricContext geometry, const in ToonMaterial material, inout ReflectedLight reflectedLight ) {\n\tvec3 irradiance = getGradientIrradiance( geometry.normal, directLight.direction ) * directLight.color;\n\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\tirradiance *= PI;\n\t#endif\n\treflectedLight.directDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );\n\treflectedLight.directSpecular += irradiance * BRDF_Specular_BlinnPhong( directLight, geometry, material.specularColor, material.specularShininess ) * material.specularStrength;\n}\nvoid RE_IndirectDiffuse_Toon( const in vec3 irradiance, const in GeometricContext geometry, const in ToonMaterial material, inout ReflectedLight reflectedLight ) {\n\treflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );\n}\n#define RE_Direct\t\t\t\tRE_Direct_Toon\n#define RE_IndirectDiffuse\t\tRE_IndirectDiffuse_Toon\n#define Material_LightProbeLOD( material )\t(0)";
+
+	var lights_phong_fragment = "BlinnPhongMaterial material;\nmaterial.diffuseColor = diffuseColor.rgb;\nmaterial.specularColor = specular;\nmaterial.specularShininess = shininess;\nmaterial.specularStrength = specularStrength;";
+
+	var lights_phong_pars_fragment = "varying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\nstruct BlinnPhongMaterial {\n\tvec3\tdiffuseColor;\n\tvec3\tspecularColor;\n\tfloat\tspecularShininess;\n\tfloat\tspecularStrength;\n};\nvoid RE_Direct_BlinnPhong( const in IncidentLight directLight, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {\n\tfloat dotNL = saturate( dot( geometry.normal, directLight.direction ) );\n\tvec3 irradiance = dotNL * directLight.color;\n\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\tirradiance *= PI;\n\t#endif\n\treflectedLight.directDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );\n\treflectedLight.directSpecular += irradiance * BRDF_Specular_BlinnPhong( directLight, geometry, material.specularColor, material.specularShininess ) * material.specularStrength;\n}\nvoid RE_IndirectDiffuse_BlinnPhong( const in vec3 irradiance, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {\n\treflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );\n}\n#define RE_Direct\t\t\t\tRE_Direct_BlinnPhong\n#define RE_IndirectDiffuse\t\tRE_IndirectDiffuse_BlinnPhong\n#define Material_LightProbeLOD( material )\t(0)";
+
+	var lights_physical_fragment = "PhysicalMaterial material;\nmaterial.diffuseColor = diffuseColor.rgb * ( 1.0 - metalnessFactor );\nvec3 dxy = max( abs( dFdx( geometryNormal ) ), abs( dFdy( geometryNormal ) ) );\nfloat geometryRoughness = max( max( dxy.x, dxy.y ), dxy.z );\nmaterial.specularRoughness = max( roughnessFactor, 0.0525 );material.specularRoughness += geometryRoughness;\nmaterial.specularRoughness = min( material.specularRoughness, 1.0 );\n#ifdef REFLECTIVITY\n\tmaterial.specularColor = mix( vec3( MAXIMUM_SPECULAR_COEFFICIENT * pow2( reflectivity ) ), diffuseColor.rgb, metalnessFactor );\n#else\n\tmaterial.specularColor = mix( vec3( DEFAULT_SPECULAR_COEFFICIENT ), diffuseColor.rgb, metalnessFactor );\n#endif\n#ifdef CLEARCOAT\n\tmaterial.clearcoat = clearcoat;\n\tmaterial.clearcoatRoughness = clearcoatRoughness;\n\t#ifdef USE_CLEARCOATMAP\n\t\tmaterial.clearcoat *= texture2D( clearcoatMap, vUv ).x;\n\t#endif\n\t#ifdef USE_CLEARCOAT_ROUGHNESSMAP\n\t\tmaterial.clearcoatRoughness *= texture2D( clearcoatRoughnessMap, vUv ).y;\n\t#endif\n\tmaterial.clearcoat = saturate( material.clearcoat );\tmaterial.clearcoatRoughness = max( material.clearcoatRoughness, 0.0525 );\n\tmaterial.clearcoatRoughness += geometryRoughness;\n\tmaterial.clearcoatRoughness = min( material.clearcoatRoughness, 1.0 );\n#endif\n#ifdef USE_SHEEN\n\tmaterial.sheenColor = sheen;\n#endif";
+
+	var lights_physical_pars_fragment = "struct PhysicalMaterial {\n\tvec3\tdiffuseColor;\n\tfloat\tspecularRoughness;\n\tvec3\tspecularColor;\n#ifdef CLEARCOAT\n\tfloat clearcoat;\n\tfloat clearcoatRoughness;\n#endif\n#ifdef USE_SHEEN\n\tvec3 sheenColor;\n#endif\n};\n#define MAXIMUM_SPECULAR_COEFFICIENT 0.16\n#define DEFAULT_SPECULAR_COEFFICIENT 0.04\nfloat clearcoatDHRApprox( const in float roughness, const in float dotNL ) {\n\treturn DEFAULT_SPECULAR_COEFFICIENT + ( 1.0 - DEFAULT_SPECULAR_COEFFICIENT ) * ( pow( 1.0 - dotNL, 5.0 ) * pow( 1.0 - roughness, 2.0 ) );\n}\n#if NUM_RECT_AREA_LIGHTS > 0\n\tvoid RE_Direct_RectArea_Physical( const in RectAreaLight rectAreaLight, const in GeometricContext geometry, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {\n\t\tvec3 normal = geometry.normal;\n\t\tvec3 viewDir = geometry.viewDir;\n\t\tvec3 position = geometry.position;\n\t\tvec3 lightPos = rectAreaLight.position;\n\t\tvec3 halfWidth = rectAreaLight.halfWidth;\n\t\tvec3 halfHeight = rectAreaLight.halfHeight;\n\t\tvec3 lightColor = rectAreaLight.color;\n\t\tfloat roughness = material.specularRoughness;\n\t\tvec3 rectCoords[ 4 ];\n\t\trectCoords[ 0 ] = lightPos + halfWidth - halfHeight;\t\trectCoords[ 1 ] = lightPos - halfWidth - halfHeight;\n\t\trectCoords[ 2 ] = lightPos - halfWidth + halfHeight;\n\t\trectCoords[ 3 ] = lightPos + halfWidth + halfHeight;\n\t\tvec2 uv = LTC_Uv( normal, viewDir, roughness );\n\t\tvec4 t1 = texture2D( ltc_1, uv );\n\t\tvec4 t2 = texture2D( ltc_2, uv );\n\t\tmat3 mInv = mat3(\n\t\t\tvec3( t1.x, 0, t1.y ),\n\t\t\tvec3(    0, 1,    0 ),\n\t\t\tvec3( t1.z, 0, t1.w )\n\t\t);\n\t\tvec3 fresnel = ( material.specularColor * t2.x + ( vec3( 1.0 ) - material.specularColor ) * t2.y );\n\t\treflectedLight.directSpecular += lightColor * fresnel * LTC_Evaluate( normal, viewDir, position, mInv, rectCoords );\n\t\treflectedLight.directDiffuse += lightColor * material.diffuseColor * LTC_Evaluate( normal, viewDir, position, mat3( 1.0 ), rectCoords );\n\t}\n#endif\nvoid RE_Direct_Physical( const in IncidentLight directLight, const in GeometricContext geometry, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {\n\tfloat dotNL = saturate( dot( geometry.normal, directLight.direction ) );\n\tvec3 irradiance = dotNL * directLight.color;\n\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\tirradiance *= PI;\n\t#endif\n\t#ifdef CLEARCOAT\n\t\tfloat ccDotNL = saturate( dot( geometry.clearcoatNormal, directLight.direction ) );\n\t\tvec3 ccIrradiance = ccDotNL * directLight.color;\n\t\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\t\tccIrradiance *= PI;\n\t\t#endif\n\t\tfloat clearcoatDHR = material.clearcoat * clearcoatDHRApprox( material.clearcoatRoughness, ccDotNL );\n\t\treflectedLight.directSpecular += ccIrradiance * material.clearcoat * BRDF_Specular_GGX( directLight, geometry.viewDir, geometry.clearcoatNormal, vec3( DEFAULT_SPECULAR_COEFFICIENT ), material.clearcoatRoughness );\n\t#else\n\t\tfloat clearcoatDHR = 0.0;\n\t#endif\n\t#ifdef USE_SHEEN\n\t\treflectedLight.directSpecular += ( 1.0 - clearcoatDHR ) * irradiance * BRDF_Specular_Sheen(\n\t\t\tmaterial.specularRoughness,\n\t\t\tdirectLight.direction,\n\t\t\tgeometry,\n\t\t\tmaterial.sheenColor\n\t\t);\n\t#else\n\t\treflectedLight.directSpecular += ( 1.0 - clearcoatDHR ) * irradiance * BRDF_Specular_GGX( directLight, geometry.viewDir, geometry.normal, material.specularColor, material.specularRoughness);\n\t#endif\n\treflectedLight.directDiffuse += ( 1.0 - clearcoatDHR ) * irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );\n}\nvoid RE_IndirectDiffuse_Physical( const in vec3 irradiance, const in GeometricContext geometry, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {\n\treflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );\n}\nvoid RE_IndirectSpecular_Physical( const in vec3 radiance, const in vec3 irradiance, const in vec3 clearcoatRadiance, const in GeometricContext geometry, const in PhysicalMaterial material, inout ReflectedLight reflectedLight) {\n\t#ifdef CLEARCOAT\n\t\tfloat ccDotNV = saturate( dot( geometry.clearcoatNormal, geometry.viewDir ) );\n\t\treflectedLight.indirectSpecular += clearcoatRadiance * material.clearcoat * BRDF_Specular_GGX_Environment( geometry.viewDir, geometry.clearcoatNormal, vec3( DEFAULT_SPECULAR_COEFFICIENT ), material.clearcoatRoughness );\n\t\tfloat ccDotNL = ccDotNV;\n\t\tfloat clearcoatDHR = material.clearcoat * clearcoatDHRApprox( material.clearcoatRoughness, ccDotNL );\n\t#else\n\t\tfloat clearcoatDHR = 0.0;\n\t#endif\n\tfloat clearcoatInv = 1.0 - clearcoatDHR;\n\tvec3 singleScattering = vec3( 0.0 );\n\tvec3 multiScattering = vec3( 0.0 );\n\tvec3 cosineWeightedIrradiance = irradiance * RECIPROCAL_PI;\n\tBRDF_Specular_Multiscattering_Environment( geometry, material.specularColor, material.specularRoughness, singleScattering, multiScattering );\n\tvec3 diffuse = material.diffuseColor * ( 1.0 - ( singleScattering + multiScattering ) );\n\treflectedLight.indirectSpecular += clearcoatInv * radiance * singleScattering;\n\treflectedLight.indirectSpecular += multiScattering * cosineWeightedIrradiance;\n\treflectedLight.indirectDiffuse += diffuse * cosineWeightedIrradiance;\n}\n#define RE_Direct\t\t\t\tRE_Direct_Physical\n#define RE_Direct_RectArea\t\tRE_Direct_RectArea_Physical\n#define RE_IndirectDiffuse\t\tRE_IndirectDiffuse_Physical\n#define RE_IndirectSpecular\t\tRE_IndirectSpecular_Physical\nfloat computeSpecularOcclusion( const in float dotNV, const in float ambientOcclusion, const in float roughness ) {\n\treturn saturate( pow( dotNV + ambientOcclusion, exp2( - 16.0 * roughness - 1.0 ) ) - 1.0 + ambientOcclusion );\n}";
+
+	var lights_fragment_begin = "\nGeometricContext geometry;\ngeometry.position = - vViewPosition;\ngeometry.normal = normal;\ngeometry.viewDir = ( isOrthographic ) ? vec3( 0, 0, 1 ) : normalize( vViewPosition );\n#ifdef CLEARCOAT\n\tgeometry.clearcoatNormal = clearcoatNormal;\n#endif\nIncidentLight directLight;\n#if ( NUM_POINT_LIGHTS > 0 ) && defined( RE_Direct )\n\tPointLight pointLight;\n\t#if defined( USE_SHADOWMAP ) && NUM_POINT_LIGHT_SHADOWS > 0\n\tPointLightShadow pointLightShadow;\n\t#endif\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {\n\t\tpointLight = pointLights[ i ];\n\t\tgetPointDirectLightIrradiance( pointLight, geometry, directLight );\n\t\t#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_POINT_LIGHT_SHADOWS )\n\t\tpointLightShadow = pointLightShadows[ i ];\n\t\tdirectLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getPointShadow( pointShadowMap[ i ], pointLightShadow.shadowMapSize, pointLightShadow.shadowBias, pointLightShadow.shadowRadius, vPointShadowCoord[ i ], pointLightShadow.shadowCameraNear, pointLightShadow.shadowCameraFar ) : 1.0;\n\t\t#endif\n\t\tRE_Direct( directLight, geometry, material, reflectedLight );\n\t}\n\t#pragma unroll_loop_end\n#endif\n#if ( NUM_SPOT_LIGHTS > 0 ) && defined( RE_Direct )\n\tSpotLight spotLight;\n\t#if defined( USE_SHADOWMAP ) && NUM_SPOT_LIGHT_SHADOWS > 0\n\tSpotLightShadow spotLightShadow;\n\t#endif\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {\n\t\tspotLight = spotLights[ i ];\n\t\tgetSpotDirectLightIrradiance( spotLight, geometry, directLight );\n\t\t#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_SPOT_LIGHT_SHADOWS )\n\t\tspotLightShadow = spotLightShadows[ i ];\n\t\tdirectLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;\n\t\t#endif\n\t\tRE_Direct( directLight, geometry, material, reflectedLight );\n\t}\n\t#pragma unroll_loop_end\n#endif\n#if ( NUM_DIR_LIGHTS > 0 ) && defined( RE_Direct )\n\tDirectionalLight directionalLight;\n\t#if defined( USE_SHADOWMAP ) && NUM_DIR_LIGHT_SHADOWS > 0\n\tDirectionalLightShadow directionalLightShadow;\n\t#endif\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {\n\t\tdirectionalLight = directionalLights[ i ];\n\t\tgetDirectionalDirectLightIrradiance( directionalLight, geometry, directLight );\n\t\t#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_DIR_LIGHT_SHADOWS )\n\t\tdirectionalLightShadow = directionalLightShadows[ i ];\n\t\tdirectLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;\n\t\t#endif\n\t\tRE_Direct( directLight, geometry, material, reflectedLight );\n\t}\n\t#pragma unroll_loop_end\n#endif\n#if ( NUM_RECT_AREA_LIGHTS > 0 ) && defined( RE_Direct_RectArea )\n\tRectAreaLight rectAreaLight;\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_RECT_AREA_LIGHTS; i ++ ) {\n\t\trectAreaLight = rectAreaLights[ i ];\n\t\tRE_Direct_RectArea( rectAreaLight, geometry, material, reflectedLight );\n\t}\n\t#pragma unroll_loop_end\n#endif\n#if defined( RE_IndirectDiffuse )\n\tvec3 iblIrradiance = vec3( 0.0 );\n\tvec3 irradiance = getAmbientLightIrradiance( ambientLightColor );\n\tirradiance += getLightProbeIrradiance( lightProbe, geometry );\n\t#if ( NUM_HEMI_LIGHTS > 0 )\n\t\t#pragma unroll_loop_start\n\t\tfor ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {\n\t\t\tirradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );\n\t\t}\n\t\t#pragma unroll_loop_end\n\t#endif\n#endif\n#if defined( RE_IndirectSpecular )\n\tvec3 radiance = vec3( 0.0 );\n\tvec3 clearcoatRadiance = vec3( 0.0 );\n#endif";
+
+	var lights_fragment_maps = "#if defined( RE_IndirectDiffuse )\n\t#ifdef USE_LIGHTMAP\n\t\tvec4 lightMapTexel= texture2D( lightMap, vUv2 );\n\t\tvec3 lightMapIrradiance = lightMapTexelToLinear( lightMapTexel ).rgb * lightMapIntensity;\n\t\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\t\tlightMapIrradiance *= PI;\n\t\t#endif\n\t\tirradiance += lightMapIrradiance;\n\t#endif\n\t#if defined( USE_ENVMAP ) && defined( STANDARD ) && defined( ENVMAP_TYPE_CUBE_UV )\n\t\tiblIrradiance += getLightProbeIndirectIrradiance( geometry, maxMipLevel );\n\t#endif\n#endif\n#if defined( USE_ENVMAP ) && defined( RE_IndirectSpecular )\n\tradiance += getLightProbeIndirectRadiance( geometry.viewDir, geometry.normal, material.specularRoughness, maxMipLevel );\n\t#ifdef CLEARCOAT\n\t\tclearcoatRadiance += getLightProbeIndirectRadiance( geometry.viewDir, geometry.clearcoatNormal, material.clearcoatRoughness, maxMipLevel );\n\t#endif\n#endif";
+
+	var lights_fragment_end = "#if defined( RE_IndirectDiffuse )\n\tRE_IndirectDiffuse( irradiance, geometry, material, reflectedLight );\n#endif\n#if defined( RE_IndirectSpecular )\n\tRE_IndirectSpecular( radiance, iblIrradiance, clearcoatRadiance, geometry, material, reflectedLight );\n#endif";
+
+	var logdepthbuf_fragment = "#if defined( USE_LOGDEPTHBUF ) && defined( USE_LOGDEPTHBUF_EXT )\n\tgl_FragDepthEXT = vIsPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;\n#endif";
+
+	var logdepthbuf_pars_fragment = "#if defined( USE_LOGDEPTHBUF ) && defined( USE_LOGDEPTHBUF_EXT )\n\tuniform float logDepthBufFC;\n\tvarying float vFragDepth;\n\tvarying float vIsPerspective;\n#endif";
+
+	var logdepthbuf_pars_vertex = "#ifdef USE_LOGDEPTHBUF\n\t#ifdef USE_LOGDEPTHBUF_EXT\n\t\tvarying float vFragDepth;\n\t\tvarying float vIsPerspective;\n\t#else\n\t\tuniform float logDepthBufFC;\n\t#endif\n#endif";
+
+	var logdepthbuf_vertex = "#ifdef USE_LOGDEPTHBUF\n\t#ifdef USE_LOGDEPTHBUF_EXT\n\t\tvFragDepth = 1.0 + gl_Position.w;\n\t\tvIsPerspective = float( isPerspectiveMatrix( projectionMatrix ) );\n\t#else\n\t\tif ( isPerspectiveMatrix( projectionMatrix ) ) {\n\t\t\tgl_Position.z = log2( max( EPSILON, gl_Position.w + 1.0 ) ) * logDepthBufFC - 1.0;\n\t\t\tgl_Position.z *= gl_Position.w;\n\t\t}\n\t#endif\n#endif";
+
+	var map_fragment = "#ifdef USE_MAP\n\tvec4 texelColor = texture2D( map, vUv );\n\ttexelColor = mapTexelToLinear( texelColor );\n\tdiffuseColor *= texelColor;\n#endif";
+
+	var map_pars_fragment = "#ifdef USE_MAP\n\tuniform sampler2D map;\n#endif";
+
+	var map_particle_fragment = "#if defined( USE_MAP ) || defined( USE_ALPHAMAP )\n\tvec2 uv = ( uvTransform * vec3( gl_PointCoord.x, 1.0 - gl_PointCoord.y, 1 ) ).xy;\n#endif\n#ifdef USE_MAP\n\tvec4 mapTexel = texture2D( map, uv );\n\tdiffuseColor *= mapTexelToLinear( mapTexel );\n#endif\n#ifdef USE_ALPHAMAP\n\tdiffuseColor.a *= texture2D( alphaMap, uv ).g;\n#endif";
+
+	var map_particle_pars_fragment = "#if defined( USE_MAP ) || defined( USE_ALPHAMAP )\n\tuniform mat3 uvTransform;\n#endif\n#ifdef USE_MAP\n\tuniform sampler2D map;\n#endif\n#ifdef USE_ALPHAMAP\n\tuniform sampler2D alphaMap;\n#endif";
+
+	var metalnessmap_fragment = "float metalnessFactor = metalness;\n#ifdef USE_METALNESSMAP\n\tvec4 texelMetalness = texture2D( metalnessMap, vUv );\n\tmetalnessFactor *= texelMetalness.b;\n#endif";
+
+	var metalnessmap_pars_fragment = "#ifdef USE_METALNESSMAP\n\tuniform sampler2D metalnessMap;\n#endif";
+
+	var morphnormal_vertex = "#ifdef USE_MORPHNORMALS\n\tobjectNormal *= morphTargetBaseInfluence;\n\tobjectNormal += morphNormal0 * morphTargetInfluences[ 0 ];\n\tobjectNormal += morphNormal1 * morphTargetInfluences[ 1 ];\n\tobjectNormal += morphNormal2 * morphTargetInfluences[ 2 ];\n\tobjectNormal += morphNormal3 * morphTargetInfluences[ 3 ];\n#endif";
+
+	var morphtarget_pars_vertex = "#ifdef USE_MORPHTARGETS\n\tuniform float morphTargetBaseInfluence;\n\t#ifndef USE_MORPHNORMALS\n\tuniform float morphTargetInfluences[ 8 ];\n\t#else\n\tuniform float morphTargetInfluences[ 4 ];\n\t#endif\n#endif";
+
+	var morphtarget_vertex = "#ifdef USE_MORPHTARGETS\n\ttransformed *= morphTargetBaseInfluence;\n\ttransformed += morphTarget0 * morphTargetInfluences[ 0 ];\n\ttransformed += morphTarget1 * morphTargetInfluences[ 1 ];\n\ttransformed += morphTarget2 * morphTargetInfluences[ 2 ];\n\ttransformed += morphTarget3 * morphTargetInfluences[ 3 ];\n\t#ifndef USE_MORPHNORMALS\n\ttransformed += morphTarget4 * morphTargetInfluences[ 4 ];\n\ttransformed += morphTarget5 * morphTargetInfluences[ 5 ];\n\ttransformed += morphTarget6 * morphTargetInfluences[ 6 ];\n\ttransformed += morphTarget7 * morphTargetInfluences[ 7 ];\n\t#endif\n#endif";
+
+	var normal_fragment_begin = "#ifdef FLAT_SHADED\n\tvec3 fdx = vec3( dFdx( vViewPosition.x ), dFdx( vViewPosition.y ), dFdx( vViewPosition.z ) );\n\tvec3 fdy = vec3( dFdy( vViewPosition.x ), dFdy( vViewPosition.y ), dFdy( vViewPosition.z ) );\n\tvec3 normal = normalize( cross( fdx, fdy ) );\n#else\n\tvec3 normal = normalize( vNormal );\n\t#ifdef DOUBLE_SIDED\n\t\tnormal = normal * ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t#endif\n\t#ifdef USE_TANGENT\n\t\tvec3 tangent = normalize( vTangent );\n\t\tvec3 bitangent = normalize( vBitangent );\n\t\t#ifdef DOUBLE_SIDED\n\t\t\ttangent = tangent * ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t\t\tbitangent = bitangent * ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t\t#endif\n\t\t#if defined( TANGENTSPACE_NORMALMAP ) || defined( USE_CLEARCOAT_NORMALMAP )\n\t\t\tmat3 vTBN = mat3( tangent, bitangent, normal );\n\t\t#endif\n\t#endif\n#endif\nvec3 geometryNormal = normal;";
+
+	var normal_fragment_maps = "#ifdef OBJECTSPACE_NORMALMAP\n\tnormal = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0;\n\t#ifdef FLIP_SIDED\n\t\tnormal = - normal;\n\t#endif\n\t#ifdef DOUBLE_SIDED\n\t\tnormal = normal * ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t#endif\n\tnormal = normalize( normalMatrix * normal );\n#elif defined( TANGENTSPACE_NORMALMAP )\n\tvec3 mapN = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0;\n\tmapN.xy *= normalScale;\n\t#ifdef USE_TANGENT\n\t\tnormal = normalize( vTBN * mapN );\n\t#else\n\t\tnormal = perturbNormal2Arb( -vViewPosition, normal, mapN );\n\t#endif\n#elif defined( USE_BUMPMAP )\n\tnormal = perturbNormalArb( -vViewPosition, normal, dHdxy_fwd() );\n#endif";
+
+	var normalmap_pars_fragment = "#ifdef USE_NORMALMAP\n\tuniform sampler2D normalMap;\n\tuniform vec2 normalScale;\n#endif\n#ifdef OBJECTSPACE_NORMALMAP\n\tuniform mat3 normalMatrix;\n#endif\n#if ! defined ( USE_TANGENT ) && ( defined ( TANGENTSPACE_NORMALMAP ) || defined ( USE_CLEARCOAT_NORMALMAP ) )\n\tvec3 perturbNormal2Arb( vec3 eye_pos, vec3 surf_norm, vec3 mapN ) {\n\t\tvec3 q0 = vec3( dFdx( eye_pos.x ), dFdx( eye_pos.y ), dFdx( eye_pos.z ) );\n\t\tvec3 q1 = vec3( dFdy( eye_pos.x ), dFdy( eye_pos.y ), dFdy( eye_pos.z ) );\n\t\tvec2 st0 = dFdx( vUv.st );\n\t\tvec2 st1 = dFdy( vUv.st );\n\t\tfloat scale = sign( st1.t * st0.s - st0.t * st1.s );\n\t\tvec3 S = normalize( ( q0 * st1.t - q1 * st0.t ) * scale );\n\t\tvec3 T = normalize( ( - q0 * st1.s + q1 * st0.s ) * scale );\n\t\tvec3 N = normalize( surf_norm );\n\t\tmat3 tsn = mat3( S, T, N );\n\t\tmapN.xy *= ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t\treturn normalize( tsn * mapN );\n\t}\n#endif";
+
+	var clearcoat_normal_fragment_begin = "#ifdef CLEARCOAT\n\tvec3 clearcoatNormal = geometryNormal;\n#endif";
+
+	var clearcoat_normal_fragment_maps = "#ifdef USE_CLEARCOAT_NORMALMAP\n\tvec3 clearcoatMapN = texture2D( clearcoatNormalMap, vUv ).xyz * 2.0 - 1.0;\n\tclearcoatMapN.xy *= clearcoatNormalScale;\n\t#ifdef USE_TANGENT\n\t\tclearcoatNormal = normalize( vTBN * clearcoatMapN );\n\t#else\n\t\tclearcoatNormal = perturbNormal2Arb( - vViewPosition, clearcoatNormal, clearcoatMapN );\n\t#endif\n#endif";
+
+	var clearcoat_pars_fragment = "#ifdef USE_CLEARCOATMAP\n\tuniform sampler2D clearcoatMap;\n#endif\n#ifdef USE_CLEARCOAT_ROUGHNESSMAP\n\tuniform sampler2D clearcoatRoughnessMap;\n#endif\n#ifdef USE_CLEARCOAT_NORMALMAP\n\tuniform sampler2D clearcoatNormalMap;\n\tuniform vec2 clearcoatNormalScale;\n#endif";
+
+	var packing = "vec3 packNormalToRGB( const in vec3 normal ) {\n\treturn normalize( normal ) * 0.5 + 0.5;\n}\nvec3 unpackRGBToNormal( const in vec3 rgb ) {\n\treturn 2.0 * rgb.xyz - 1.0;\n}\nconst float PackUpscale = 256. / 255.;const float UnpackDownscale = 255. / 256.;\nconst vec3 PackFactors = vec3( 256. * 256. * 256., 256. * 256.,  256. );\nconst vec4 UnpackFactors = UnpackDownscale / vec4( PackFactors, 1. );\nconst float ShiftRight8 = 1. / 256.;\nvec4 packDepthToRGBA( const in float v ) {\n\tvec4 r = vec4( fract( v * PackFactors ), v );\n\tr.yzw -= r.xyz * ShiftRight8;\treturn r * PackUpscale;\n}\nfloat unpackRGBAToDepth( const in vec4 v ) {\n\treturn dot( v, UnpackFactors );\n}\nvec4 pack2HalfToRGBA( vec2 v ) {\n\tvec4 r = vec4( v.x, fract( v.x * 255.0 ), v.y, fract( v.y * 255.0 ));\n\treturn vec4( r.x - r.y / 255.0, r.y, r.z - r.w / 255.0, r.w);\n}\nvec2 unpackRGBATo2Half( vec4 v ) {\n\treturn vec2( v.x + ( v.y / 255.0 ), v.z + ( v.w / 255.0 ) );\n}\nfloat viewZToOrthographicDepth( const in float viewZ, const in float near, const in float far ) {\n\treturn ( viewZ + near ) / ( near - far );\n}\nfloat orthographicDepthToViewZ( const in float linearClipZ, const in float near, const in float far ) {\n\treturn linearClipZ * ( near - far ) - near;\n}\nfloat viewZToPerspectiveDepth( const in float viewZ, const in float near, const in float far ) {\n\treturn (( near + viewZ ) * far ) / (( far - near ) * viewZ );\n}\nfloat perspectiveDepthToViewZ( const in float invClipZ, const in float near, const in float far ) {\n\treturn ( near * far ) / ( ( far - near ) * invClipZ - far );\n}";
+
+	var premultiplied_alpha_fragment = "#ifdef PREMULTIPLIED_ALPHA\n\tgl_FragColor.rgb *= gl_FragColor.a;\n#endif";
+
+	var project_vertex = "vec4 mvPosition = vec4( transformed, 1.0 );\n#ifdef USE_INSTANCING\n\tmvPosition = instanceMatrix * mvPosition;\n#endif\nmvPosition = modelViewMatrix * mvPosition;\ngl_Position = projectionMatrix * mvPosition;";
+
+	var dithering_fragment = "#ifdef DITHERING\n\tgl_FragColor.rgb = dithering( gl_FragColor.rgb );\n#endif";
+
+	var dithering_pars_fragment = "#ifdef DITHERING\n\tvec3 dithering( vec3 color ) {\n\t\tfloat grid_position = rand( gl_FragCoord.xy );\n\t\tvec3 dither_shift_RGB = vec3( 0.25 / 255.0, -0.25 / 255.0, 0.25 / 255.0 );\n\t\tdither_shift_RGB = mix( 2.0 * dither_shift_RGB, -2.0 * dither_shift_RGB, grid_position );\n\t\treturn color + dither_shift_RGB;\n\t}\n#endif";
+
+	var roughnessmap_fragment = "float roughnessFactor = roughness;\n#ifdef USE_ROUGHNESSMAP\n\tvec4 texelRoughness = texture2D( roughnessMap, vUv );\n\troughnessFactor *= texelRoughness.g;\n#endif";
+
+	var roughnessmap_pars_fragment = "#ifdef USE_ROUGHNESSMAP\n\tuniform sampler2D roughnessMap;\n#endif";
+
+	var shadowmap_pars_fragment = "#ifdef USE_SHADOWMAP\n\t#if NUM_DIR_LIGHT_SHADOWS > 0\n\t\tuniform sampler2D directionalShadowMap[ NUM_DIR_LIGHT_SHADOWS ];\n\t\tvarying vec4 vDirectionalShadowCoord[ NUM_DIR_LIGHT_SHADOWS ];\n\t#endif\n\t#if NUM_SPOT_LIGHT_SHADOWS > 0\n\t\tuniform sampler2D spotShadowMap[ NUM_SPOT_LIGHT_SHADOWS ];\n\t\tvarying vec4 vSpotShadowCoord[ NUM_SPOT_LIGHT_SHADOWS ];\n\t#endif\n\t#if NUM_POINT_LIGHT_SHADOWS > 0\n\t\tuniform sampler2D pointShadowMap[ NUM_POINT_LIGHT_SHADOWS ];\n\t\tvarying vec4 vPointShadowCoord[ NUM_POINT_LIGHT_SHADOWS ];\n\t#endif\n\tfloat texture2DCompare( sampler2D depths, vec2 uv, float compare ) {\n\t\treturn step( compare, unpackRGBAToDepth( texture2D( depths, uv ) ) );\n\t}\n\tvec2 texture2DDistribution( sampler2D shadow, vec2 uv ) {\n\t\treturn unpackRGBATo2Half( texture2D( shadow, uv ) );\n\t}\n\tfloat VSMShadow (sampler2D shadow, vec2 uv, float compare ){\n\t\tfloat occlusion = 1.0;\n\t\tvec2 distribution = texture2DDistribution( shadow, uv );\n\t\tfloat hard_shadow = step( compare , distribution.x );\n\t\tif (hard_shadow != 1.0 ) {\n\t\t\tfloat distance = compare - distribution.x ;\n\t\t\tfloat variance = max( 0.00000, distribution.y * distribution.y );\n\t\t\tfloat softness_probability = variance / (variance + distance * distance );\t\t\tsoftness_probability = clamp( ( softness_probability - 0.3 ) / ( 0.95 - 0.3 ), 0.0, 1.0 );\t\t\tocclusion = clamp( max( hard_shadow, softness_probability ), 0.0, 1.0 );\n\t\t}\n\t\treturn occlusion;\n\t}\n\tfloat getShadow( sampler2D shadowMap, vec2 shadowMapSize, float shadowBias, float shadowRadius, vec4 shadowCoord ) {\n\t\tfloat shadow = 1.0;\n\t\tshadowCoord.xyz /= shadowCoord.w;\n\t\tshadowCoord.z += shadowBias;\n\t\tbvec4 inFrustumVec = bvec4 ( shadowCoord.x >= 0.0, shadowCoord.x <= 1.0, shadowCoord.y >= 0.0, shadowCoord.y <= 1.0 );\n\t\tbool inFrustum = all( inFrustumVec );\n\t\tbvec2 frustumTestVec = bvec2( inFrustum, shadowCoord.z <= 1.0 );\n\t\tbool frustumTest = all( frustumTestVec );\n\t\tif ( frustumTest ) {\n\t\t#if defined( SHADOWMAP_TYPE_PCF )\n\t\t\tvec2 texelSize = vec2( 1.0 ) / shadowMapSize;\n\t\t\tfloat dx0 = - texelSize.x * shadowRadius;\n\t\t\tfloat dy0 = - texelSize.y * shadowRadius;\n\t\t\tfloat dx1 = + texelSize.x * shadowRadius;\n\t\t\tfloat dy1 = + texelSize.y * shadowRadius;\n\t\t\tfloat dx2 = dx0 / 2.0;\n\t\t\tfloat dy2 = dy0 / 2.0;\n\t\t\tfloat dx3 = dx1 / 2.0;\n\t\t\tfloat dy3 = dy1 / 2.0;\n\t\t\tshadow = (\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx0, dy0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( 0.0, dy0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx1, dy0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx2, dy2 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( 0.0, dy2 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx3, dy2 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx0, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx2, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy, shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx3, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx1, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx2, dy3 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( 0.0, dy3 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx3, dy3 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx0, dy1 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( 0.0, dy1 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx1, dy1 ), shadowCoord.z )\n\t\t\t) * ( 1.0 / 17.0 );\n\t\t#elif defined( SHADOWMAP_TYPE_PCF_SOFT )\n\t\t\tvec2 texelSize = vec2( 1.0 ) / shadowMapSize;\n\t\t\tfloat dx = texelSize.x;\n\t\t\tfloat dy = texelSize.y;\n\t\t\tvec2 uv = shadowCoord.xy;\n\t\t\tvec2 f = fract( uv * shadowMapSize + 0.5 );\n\t\t\tuv -= f * texelSize;\n\t\t\tshadow = (\n\t\t\t\ttexture2DCompare( shadowMap, uv, shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, uv + vec2( dx, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, uv + vec2( 0.0, dy ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, uv + texelSize, shadowCoord.z ) +\n\t\t\t\tmix( texture2DCompare( shadowMap, uv + vec2( -dx, 0.0 ), shadowCoord.z ), \n\t\t\t\t\t texture2DCompare( shadowMap, uv + vec2( 2.0 * dx, 0.0 ), shadowCoord.z ),\n\t\t\t\t\t f.x ) +\n\t\t\t\tmix( texture2DCompare( shadowMap, uv + vec2( -dx, dy ), shadowCoord.z ), \n\t\t\t\t\t texture2DCompare( shadowMap, uv + vec2( 2.0 * dx, dy ), shadowCoord.z ),\n\t\t\t\t\t f.x ) +\n\t\t\t\tmix( texture2DCompare( shadowMap, uv + vec2( 0.0, -dy ), shadowCoord.z ), \n\t\t\t\t\t texture2DCompare( shadowMap, uv + vec2( 0.0, 2.0 * dy ), shadowCoord.z ),\n\t\t\t\t\t f.y ) +\n\t\t\t\tmix( texture2DCompare( shadowMap, uv + vec2( dx, -dy ), shadowCoord.z ), \n\t\t\t\t\t texture2DCompare( shadowMap, uv + vec2( dx, 2.0 * dy ), shadowCoord.z ),\n\t\t\t\t\t f.y ) +\n\t\t\t\tmix( mix( texture2DCompare( shadowMap, uv + vec2( -dx, -dy ), shadowCoord.z ), \n\t\t\t\t\t\t  texture2DCompare( shadowMap, uv + vec2( 2.0 * dx, -dy ), shadowCoord.z ),\n\t\t\t\t\t\t  f.x ),\n\t\t\t\t\t mix( texture2DCompare( shadowMap, uv + vec2( -dx, 2.0 * dy ), shadowCoord.z ), \n\t\t\t\t\t\t  texture2DCompare( shadowMap, uv + vec2( 2.0 * dx, 2.0 * dy ), shadowCoord.z ),\n\t\t\t\t\t\t  f.x ),\n\t\t\t\t\t f.y )\n\t\t\t) * ( 1.0 / 9.0 );\n\t\t#elif defined( SHADOWMAP_TYPE_VSM )\n\t\t\tshadow = VSMShadow( shadowMap, shadowCoord.xy, shadowCoord.z );\n\t\t#else\n\t\t\tshadow = texture2DCompare( shadowMap, shadowCoord.xy, shadowCoord.z );\n\t\t#endif\n\t\t}\n\t\treturn shadow;\n\t}\n\tvec2 cubeToUV( vec3 v, float texelSizeY ) {\n\t\tvec3 absV = abs( v );\n\t\tfloat scaleToCube = 1.0 / max( absV.x, max( absV.y, absV.z ) );\n\t\tabsV *= scaleToCube;\n\t\tv *= scaleToCube * ( 1.0 - 2.0 * texelSizeY );\n\t\tvec2 planar = v.xy;\n\t\tfloat almostATexel = 1.5 * texelSizeY;\n\t\tfloat almostOne = 1.0 - almostATexel;\n\t\tif ( absV.z >= almostOne ) {\n\t\t\tif ( v.z > 0.0 )\n\t\t\t\tplanar.x = 4.0 - v.x;\n\t\t} else if ( absV.x >= almostOne ) {\n\t\t\tfloat signX = sign( v.x );\n\t\t\tplanar.x = v.z * signX + 2.0 * signX;\n\t\t} else if ( absV.y >= almostOne ) {\n\t\t\tfloat signY = sign( v.y );\n\t\t\tplanar.x = v.x + 2.0 * signY + 2.0;\n\t\t\tplanar.y = v.z * signY - 2.0;\n\t\t}\n\t\treturn vec2( 0.125, 0.25 ) * planar + vec2( 0.375, 0.75 );\n\t}\n\tfloat getPointShadow( sampler2D shadowMap, vec2 shadowMapSize, float shadowBias, float shadowRadius, vec4 shadowCoord, float shadowCameraNear, float shadowCameraFar ) {\n\t\tvec2 texelSize = vec2( 1.0 ) / ( shadowMapSize * vec2( 4.0, 2.0 ) );\n\t\tvec3 lightToPosition = shadowCoord.xyz;\n\t\tfloat dp = ( length( lightToPosition ) - shadowCameraNear ) / ( shadowCameraFar - shadowCameraNear );\t\tdp += shadowBias;\n\t\tvec3 bd3D = normalize( lightToPosition );\n\t\t#if defined( SHADOWMAP_TYPE_PCF ) || defined( SHADOWMAP_TYPE_PCF_SOFT ) || defined( SHADOWMAP_TYPE_VSM )\n\t\t\tvec2 offset = vec2( - 1, 1 ) * shadowRadius * texelSize.y;\n\t\t\treturn (\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.xyy, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.yyy, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.xyx, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.yyx, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.xxy, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.yxy, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.xxx, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.yxx, texelSize.y ), dp )\n\t\t\t) * ( 1.0 / 9.0 );\n\t\t#else\n\t\t\treturn texture2DCompare( shadowMap, cubeToUV( bd3D, texelSize.y ), dp );\n\t\t#endif\n\t}\n#endif";
+
+	var shadowmap_pars_vertex = "#ifdef USE_SHADOWMAP\n\t#if NUM_DIR_LIGHT_SHADOWS > 0\n\t\tuniform mat4 directionalShadowMatrix[ NUM_DIR_LIGHT_SHADOWS ];\n\t\tvarying vec4 vDirectionalShadowCoord[ NUM_DIR_LIGHT_SHADOWS ];\n\t#endif\n\t#if NUM_SPOT_LIGHT_SHADOWS > 0\n\t\tuniform mat4 spotShadowMatrix[ NUM_SPOT_LIGHT_SHADOWS ];\n\t\tvarying vec4 vSpotShadowCoord[ NUM_SPOT_LIGHT_SHADOWS ];\n\t#endif\n\t#if NUM_POINT_LIGHT_SHADOWS > 0\n\t\tuniform mat4 pointShadowMatrix[ NUM_POINT_LIGHT_SHADOWS ];\n\t\tvarying vec4 vPointShadowCoord[ NUM_POINT_LIGHT_SHADOWS ];\n\t#endif\n#endif";
+
+	var shadowmap_vertex = "#ifdef USE_SHADOWMAP\n\t#if NUM_DIR_LIGHT_SHADOWS > 0\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_DIR_LIGHT_SHADOWS; i ++ ) {\n\t\tvDirectionalShadowCoord[ i ] = directionalShadowMatrix[ i ] * worldPosition;\n\t}\n\t#pragma unroll_loop_end\n\t#endif\n\t#if NUM_SPOT_LIGHT_SHADOWS > 0\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_SPOT_LIGHT_SHADOWS; i ++ ) {\n\t\tvSpotShadowCoord[ i ] = spotShadowMatrix[ i ] * worldPosition;\n\t}\n\t#pragma unroll_loop_end\n\t#endif\n\t#if NUM_POINT_LIGHT_SHADOWS > 0\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_POINT_LIGHT_SHADOWS; i ++ ) {\n\t\tvPointShadowCoord[ i ] = pointShadowMatrix[ i ] * worldPosition;\n\t}\n\t#pragma unroll_loop_end\n\t#endif\n#endif";
+
+	var shadowmask_pars_fragment = "float getShadowMask() {\n\tfloat shadow = 1.0;\n\t#ifdef USE_SHADOWMAP\n\t#if NUM_DIR_LIGHT_SHADOWS > 0\n\tDirectionalLightShadow directionalLight;\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_DIR_LIGHT_SHADOWS; i ++ ) {\n\t\tdirectionalLight = directionalLightShadows[ i ];\n\t\tshadow *= receiveShadow ? getShadow( directionalShadowMap[ i ], directionalLight.shadowMapSize, directionalLight.shadowBias, directionalLight.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;\n\t}\n\t#pragma unroll_loop_end\n\t#endif\n\t#if NUM_SPOT_LIGHT_SHADOWS > 0\n\tSpotLightShadow spotLight;\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_SPOT_LIGHT_SHADOWS; i ++ ) {\n\t\tspotLight = spotLightShadows[ i ];\n\t\tshadow *= receiveShadow ? getShadow( spotShadowMap[ i ], spotLight.shadowMapSize, spotLight.shadowBias, spotLight.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;\n\t}\n\t#pragma unroll_loop_end\n\t#endif\n\t#if NUM_POINT_LIGHT_SHADOWS > 0\n\tPointLightShadow pointLight;\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_POINT_LIGHT_SHADOWS; i ++ ) {\n\t\tpointLight = pointLightShadows[ i ];\n\t\tshadow *= receiveShadow ? getPointShadow( pointShadowMap[ i ], pointLight.shadowMapSize, pointLight.shadowBias, pointLight.shadowRadius, vPointShadowCoord[ i ], pointLight.shadowCameraNear, pointLight.shadowCameraFar ) : 1.0;\n\t}\n\t#pragma unroll_loop_end\n\t#endif\n\t#endif\n\treturn shadow;\n}";
+
+	var skinbase_vertex = "#ifdef USE_SKINNING\n\tmat4 boneMatX = getBoneMatrix( skinIndex.x );\n\tmat4 boneMatY = getBoneMatrix( skinIndex.y );\n\tmat4 boneMatZ = getBoneMatrix( skinIndex.z );\n\tmat4 boneMatW = getBoneMatrix( skinIndex.w );\n#endif";
+
+	var skinning_pars_vertex = "#ifdef USE_SKINNING\n\tuniform mat4 bindMatrix;\n\tuniform mat4 bindMatrixInverse;\n\t#ifdef BONE_TEXTURE\n\t\tuniform highp sampler2D boneTexture;\n\t\tuniform int boneTextureSize;\n\t\tmat4 getBoneMatrix( const in float i ) {\n\t\t\tfloat j = i * 4.0;\n\t\t\tfloat x = mod( j, float( boneTextureSize ) );\n\t\t\tfloat y = floor( j / float( boneTextureSize ) );\n\t\t\tfloat dx = 1.0 / float( boneTextureSize );\n\t\t\tfloat dy = 1.0 / float( boneTextureSize );\n\t\t\ty = dy * ( y + 0.5 );\n\t\t\tvec4 v1 = texture2D( boneTexture, vec2( dx * ( x + 0.5 ), y ) );\n\t\t\tvec4 v2 = texture2D( boneTexture, vec2( dx * ( x + 1.5 ), y ) );\n\t\t\tvec4 v3 = texture2D( boneTexture, vec2( dx * ( x + 2.5 ), y ) );\n\t\t\tvec4 v4 = texture2D( boneTexture, vec2( dx * ( x + 3.5 ), y ) );\n\t\t\tmat4 bone = mat4( v1, v2, v3, v4 );\n\t\t\treturn bone;\n\t\t}\n\t#else\n\t\tuniform mat4 boneMatrices[ MAX_BONES ];\n\t\tmat4 getBoneMatrix( const in float i ) {\n\t\t\tmat4 bone = boneMatrices[ int(i) ];\n\t\t\treturn bone;\n\t\t}\n\t#endif\n#endif";
+
+	var skinning_vertex = "#ifdef USE_SKINNING\n\tvec4 skinVertex = bindMatrix * vec4( transformed, 1.0 );\n\tvec4 skinned = vec4( 0.0 );\n\tskinned += boneMatX * skinVertex * skinWeight.x;\n\tskinned += boneMatY * skinVertex * skinWeight.y;\n\tskinned += boneMatZ * skinVertex * skinWeight.z;\n\tskinned += boneMatW * skinVertex * skinWeight.w;\n\ttransformed = ( bindMatrixInverse * skinned ).xyz;\n#endif";
+
+	var skinnormal_vertex = "#ifdef USE_SKINNING\n\tmat4 skinMatrix = mat4( 0.0 );\n\tskinMatrix += skinWeight.x * boneMatX;\n\tskinMatrix += skinWeight.y * boneMatY;\n\tskinMatrix += skinWeight.z * boneMatZ;\n\tskinMatrix += skinWeight.w * boneMatW;\n\tskinMatrix  = bindMatrixInverse * skinMatrix * bindMatrix;\n\tobjectNormal = vec4( skinMatrix * vec4( objectNormal, 0.0 ) ).xyz;\n\t#ifdef USE_TANGENT\n\t\tobjectTangent = vec4( skinMatrix * vec4( objectTangent, 0.0 ) ).xyz;\n\t#endif\n#endif";
+
+	var specularmap_fragment = "float specularStrength;\n#ifdef USE_SPECULARMAP\n\tvec4 texelSpecular = texture2D( specularMap, vUv );\n\tspecularStrength = texelSpecular.r;\n#else\n\tspecularStrength = 1.0;\n#endif";
+
+	var specularmap_pars_fragment = "#ifdef USE_SPECULARMAP\n\tuniform sampler2D specularMap;\n#endif";
+
+	var tonemapping_fragment = "#if defined( TONE_MAPPING )\n\tgl_FragColor.rgb = toneMapping( gl_FragColor.rgb );\n#endif";
+
+	var tonemapping_pars_fragment = "#ifndef saturate\n#define saturate(a) clamp( a, 0.0, 1.0 )\n#endif\nuniform float toneMappingExposure;\nuniform float toneMappingWhitePoint;\nvec3 LinearToneMapping( vec3 color ) {\n\treturn toneMappingExposure * color;\n}\nvec3 ReinhardToneMapping( vec3 color ) {\n\tcolor *= toneMappingExposure;\n\treturn saturate( color / ( vec3( 1.0 ) + color ) );\n}\n#define Uncharted2Helper( x ) max( ( ( x * ( 0.15 * x + 0.10 * 0.50 ) + 0.20 * 0.02 ) / ( x * ( 0.15 * x + 0.50 ) + 0.20 * 0.30 ) ) - 0.02 / 0.30, vec3( 0.0 ) )\nvec3 Uncharted2ToneMapping( vec3 color ) {\n\tcolor *= toneMappingExposure;\n\treturn saturate( Uncharted2Helper( color ) / Uncharted2Helper( vec3( toneMappingWhitePoint ) ) );\n}\nvec3 OptimizedCineonToneMapping( vec3 color ) {\n\tcolor *= toneMappingExposure;\n\tcolor = max( vec3( 0.0 ), color - 0.004 );\n\treturn pow( ( color * ( 6.2 * color + 0.5 ) ) / ( color * ( 6.2 * color + 1.7 ) + 0.06 ), vec3( 2.2 ) );\n}\nvec3 ACESFilmicToneMapping( vec3 color ) {\n\tcolor *= toneMappingExposure;\n\treturn saturate( ( color * ( 2.51 * color + 0.03 ) ) / ( color * ( 2.43 * color + 0.59 ) + 0.14 ) );\n}";
+
+	var uv_pars_fragment = "#if ( defined( USE_UV ) && ! defined( UVS_VERTEX_ONLY ) )\n\tvarying vec2 vUv;\n#endif";
+
+	var uv_pars_vertex = "#ifdef USE_UV\n\t#ifdef UVS_VERTEX_ONLY\n\t\tvec2 vUv;\n\t#else\n\t\tvarying vec2 vUv;\n\t#endif\n\tuniform mat3 uvTransform;\n#endif";
+
+	var uv_vertex = "#ifdef USE_UV\n\tvUv = ( uvTransform * vec3( uv, 1 ) ).xy;\n#endif";
+
+	var uv2_pars_fragment = "#if defined( USE_LIGHTMAP ) || defined( USE_AOMAP )\n\tvarying vec2 vUv2;\n#endif";
+
+	var uv2_pars_vertex = "#if defined( USE_LIGHTMAP ) || defined( USE_AOMAP )\n\tattribute vec2 uv2;\n\tvarying vec2 vUv2;\n\tuniform mat3 uv2Transform;\n#endif";
+
+	var uv2_vertex = "#if defined( USE_LIGHTMAP ) || defined( USE_AOMAP )\n\tvUv2 = ( uv2Transform * vec3( uv2, 1 ) ).xy;\n#endif";
+
+	var worldpos_vertex = "#if defined( USE_ENVMAP ) || defined( DISTANCE ) || defined ( USE_SHADOWMAP )\n\tvec4 worldPosition = vec4( transformed, 1.0 );\n\t#ifdef USE_INSTANCING\n\t\tworldPosition = instanceMatrix * worldPosition;\n\t#endif\n\tworldPosition = modelMatrix * worldPosition;\n#endif";
+
+	var background_frag = "uniform sampler2D t2D;\nvarying vec2 vUv;\nvoid main() {\n\tvec4 texColor = texture2D( t2D, vUv );\n\tgl_FragColor = mapTexelToLinear( texColor );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n}";
+
+	var background_vert = "varying vec2 vUv;\nuniform mat3 uvTransform;\nvoid main() {\n\tvUv = ( uvTransform * vec3( uv, 1 ) ).xy;\n\tgl_Position = vec4( position.xy, 1.0, 1.0 );\n}";
+
+	var cube_frag = "#include <envmap_common_pars_fragment>\nuniform float opacity;\nvarying vec3 vWorldDirection;\n#include <cube_uv_reflection_fragment>\nvoid main() {\n\tvec3 vReflect = vWorldDirection;\n\t#include <envmap_fragment>\n\tgl_FragColor = envColor;\n\tgl_FragColor.a *= opacity;\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n}";
+
+	var cube_vert = "varying vec3 vWorldDirection;\n#include <common>\nvoid main() {\n\tvWorldDirection = transformDirection( position, modelMatrix );\n\t#include <begin_vertex>\n\t#include <project_vertex>\n\tgl_Position.z = gl_Position.w;\n}";
+
+	var depth_frag = "#if DEPTH_PACKING == 3200\n\tuniform float opacity;\n#endif\n#include <common>\n#include <packing>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvarying vec2 vHighPrecisionZW;\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( 1.0 );\n\t#if DEPTH_PACKING == 3200\n\t\tdiffuseColor.a = opacity;\n\t#endif\n\t#include <map_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <logdepthbuf_fragment>\n\tfloat fragCoordZ = 0.5 * vHighPrecisionZW[0] / vHighPrecisionZW[1] + 0.5;\n\t#if DEPTH_PACKING == 3200\n\t\tgl_FragColor = vec4( vec3( 1.0 - fragCoordZ ), opacity );\n\t#elif DEPTH_PACKING == 3201\n\t\tgl_FragColor = packDepthToRGBA( fragCoordZ );\n\t#endif\n}";
+
+	var depth_vert = "#include <common>\n#include <uv_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvarying vec2 vHighPrecisionZW;\nvoid main() {\n\t#include <uv_vertex>\n\t#include <skinbase_vertex>\n\t#ifdef USE_DISPLACEMENTMAP\n\t\t#include <beginnormal_vertex>\n\t\t#include <morphnormal_vertex>\n\t\t#include <skinnormal_vertex>\n\t#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\tvHighPrecisionZW = gl_Position.zw;\n}";
+
+	var distanceRGBA_frag = "#define DISTANCE\nuniform vec3 referencePosition;\nuniform float nearDistance;\nuniform float farDistance;\nvarying vec3 vWorldPosition;\n#include <common>\n#include <packing>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main () {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( 1.0 );\n\t#include <map_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\tfloat dist = length( vWorldPosition - referencePosition );\n\tdist = ( dist - nearDistance ) / ( farDistance - nearDistance );\n\tdist = saturate( dist );\n\tgl_FragColor = packDepthToRGBA( dist );\n}";
+
+	var distanceRGBA_vert = "#define DISTANCE\nvarying vec3 vWorldPosition;\n#include <common>\n#include <uv_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <skinbase_vertex>\n\t#ifdef USE_DISPLACEMENTMAP\n\t\t#include <beginnormal_vertex>\n\t\t#include <morphnormal_vertex>\n\t\t#include <skinnormal_vertex>\n\t#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <worldpos_vertex>\n\t#include <clipping_planes_vertex>\n\tvWorldPosition = worldPosition.xyz;\n}";
+
+	var equirect_frag = "uniform sampler2D tEquirect;\nvarying vec3 vWorldDirection;\n#include <common>\nvoid main() {\n\tvec3 direction = normalize( vWorldDirection );\n\tvec2 sampleUV;\n\tsampleUV.y = asin( clamp( direction.y, - 1.0, 1.0 ) ) * RECIPROCAL_PI + 0.5;\n\tsampleUV.x = atan( direction.z, direction.x ) * RECIPROCAL_PI2 + 0.5;\n\tvec4 texColor = texture2D( tEquirect, sampleUV );\n\tgl_FragColor = mapTexelToLinear( texColor );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n}";
+
+	var equirect_vert = "varying vec3 vWorldDirection;\n#include <common>\nvoid main() {\n\tvWorldDirection = transformDirection( position, modelMatrix );\n\t#include <begin_vertex>\n\t#include <project_vertex>\n}";
+
+	var linedashed_frag = "uniform vec3 diffuse;\nuniform float opacity;\nuniform float dashSize;\nuniform float totalSize;\nvarying float vLineDistance;\n#include <common>\n#include <color_pars_fragment>\n#include <fog_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tif ( mod( vLineDistance, totalSize ) > dashSize ) {\n\t\tdiscard;\n\t}\n\tvec3 outgoingLight = vec3( 0.0 );\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\t#include <logdepthbuf_fragment>\n\t#include <color_fragment>\n\toutgoingLight = diffuseColor.rgb;\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n}";
+
+	var linedashed_vert = "uniform float scale;\nattribute float lineDistance;\nvarying float vLineDistance;\n#include <common>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\tvLineDistance = scale * lineDistance;\n\t#include <color_vertex>\n\t#include <begin_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <fog_vertex>\n}";
+
+	var meshbasic_frag = "uniform vec3 diffuse;\nuniform float opacity;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\n#include <common>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <uv2_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <envmap_common_pars_fragment>\n#include <envmap_pars_fragment>\n#include <cube_uv_reflection_fragment>\n#include <fog_pars_fragment>\n#include <specularmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <color_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <specularmap_fragment>\n\tReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n\t#ifdef USE_LIGHTMAP\n\t\n\t\tvec4 lightMapTexel= texture2D( lightMap, vUv2 );\n\t\treflectedLight.indirectDiffuse += lightMapTexelToLinear( lightMapTexel ).rgb * lightMapIntensity;\n\t#else\n\t\treflectedLight.indirectDiffuse += vec3( 1.0 );\n\t#endif\n\t#include <aomap_fragment>\n\treflectedLight.indirectDiffuse *= diffuseColor.rgb;\n\tvec3 outgoingLight = reflectedLight.indirectDiffuse;\n\t#include <envmap_fragment>\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n\t#include <dithering_fragment>\n}";
+
+	var meshbasic_vert = "#include <common>\n#include <uv_pars_vertex>\n#include <uv2_pars_vertex>\n#include <envmap_pars_vertex>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <uv2_vertex>\n\t#include <color_vertex>\n\t#include <skinbase_vertex>\n\t#ifdef USE_ENVMAP\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n\t#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <worldpos_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <envmap_vertex>\n\t#include <fog_vertex>\n}";
+
+	var meshlambert_frag = "uniform vec3 diffuse;\nuniform vec3 emissive;\nuniform float opacity;\nvarying vec3 vLightFront;\nvarying vec3 vIndirectFront;\n#ifdef DOUBLE_SIDED\n\tvarying vec3 vLightBack;\n\tvarying vec3 vIndirectBack;\n#endif\n#include <common>\n#include <packing>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <uv2_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <emissivemap_pars_fragment>\n#include <envmap_common_pars_fragment>\n#include <envmap_pars_fragment>\n#include <cube_uv_reflection_fragment>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <fog_pars_fragment>\n#include <shadowmap_pars_fragment>\n#include <shadowmask_pars_fragment>\n#include <specularmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\tReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n\tvec3 totalEmissiveRadiance = emissive;\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <color_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <specularmap_fragment>\n\t#include <emissivemap_fragment>\n\t#ifdef DOUBLE_SIDED\n\t\treflectedLight.indirectDiffuse += ( gl_FrontFacing ) ? vIndirectFront : vIndirectBack;\n\t#else\n\t\treflectedLight.indirectDiffuse += vIndirectFront;\n\t#endif\n\t#include <lightmap_fragment>\n\treflectedLight.indirectDiffuse *= BRDF_Diffuse_Lambert( diffuseColor.rgb );\n\t#ifdef DOUBLE_SIDED\n\t\treflectedLight.directDiffuse = ( gl_FrontFacing ) ? vLightFront : vLightBack;\n\t#else\n\t\treflectedLight.directDiffuse = vLightFront;\n\t#endif\n\treflectedLight.directDiffuse *= BRDF_Diffuse_Lambert( diffuseColor.rgb ) * getShadowMask();\n\t#include <aomap_fragment>\n\tvec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + totalEmissiveRadiance;\n\t#include <envmap_fragment>\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n\t#include <dithering_fragment>\n}";
+
+	var meshlambert_vert = "#define LAMBERT\nvarying vec3 vLightFront;\nvarying vec3 vIndirectFront;\n#ifdef DOUBLE_SIDED\n\tvarying vec3 vLightBack;\n\tvarying vec3 vIndirectBack;\n#endif\n#include <common>\n#include <uv_pars_vertex>\n#include <uv2_pars_vertex>\n#include <envmap_pars_vertex>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <shadowmap_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <uv2_vertex>\n\t#include <color_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <worldpos_vertex>\n\t#include <envmap_vertex>\n\t#include <lights_lambert_vertex>\n\t#include <shadowmap_vertex>\n\t#include <fog_vertex>\n}";
+
+	var meshmatcap_frag = "#define MATCAP\nuniform vec3 diffuse;\nuniform float opacity;\nuniform sampler2D matcap;\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\n#include <common>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <fog_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <color_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <normal_fragment_begin>\n\t#include <normal_fragment_maps>\n\tvec3 viewDir = normalize( vViewPosition );\n\tvec3 x = normalize( vec3( viewDir.z, 0.0, - viewDir.x ) );\n\tvec3 y = cross( viewDir, x );\n\tvec2 uv = vec2( dot( x, normal ), dot( y, normal ) ) * 0.495 + 0.5;\n\t#ifdef USE_MATCAP\n\t\tvec4 matcapColor = texture2D( matcap, uv );\n\t\tmatcapColor = matcapTexelToLinear( matcapColor );\n\t#else\n\t\tvec4 matcapColor = vec4( 1.0 );\n\t#endif\n\tvec3 outgoingLight = diffuseColor.rgb * matcapColor.rgb;\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n\t#include <dithering_fragment>\n}";
+
+	var meshmatcap_vert = "#define MATCAP\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\n#include <common>\n#include <uv_pars_vertex>\n#include <color_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <color_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n\t#ifndef FLAT_SHADED\n\t\tvNormal = normalize( transformedNormal );\n\t#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <fog_vertex>\n\tvViewPosition = - mvPosition.xyz;\n}";
+
+	var meshtoon_frag = "#define TOON\nuniform vec3 diffuse;\nuniform vec3 emissive;\nuniform vec3 specular;\nuniform float shininess;\nuniform float opacity;\n#include <common>\n#include <packing>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <uv2_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <emissivemap_pars_fragment>\n#include <gradientmap_pars_fragment>\n#include <fog_pars_fragment>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <lights_toon_pars_fragment>\n#include <shadowmap_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <specularmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\tReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n\tvec3 totalEmissiveRadiance = emissive;\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <color_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <specularmap_fragment>\n\t#include <normal_fragment_begin>\n\t#include <normal_fragment_maps>\n\t#include <emissivemap_fragment>\n\t#include <lights_toon_fragment>\n\t#include <lights_fragment_begin>\n\t#include <lights_fragment_maps>\n\t#include <lights_fragment_end>\n\t#include <aomap_fragment>\n\tvec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n\t#include <dithering_fragment>\n}";
+
+	var meshtoon_vert = "#define TOON\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\n#include <common>\n#include <uv_pars_vertex>\n#include <uv2_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <shadowmap_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <uv2_vertex>\n\t#include <color_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n#ifndef FLAT_SHADED\n\tvNormal = normalize( transformedNormal );\n#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\tvViewPosition = - mvPosition.xyz;\n\t#include <worldpos_vertex>\n\t#include <shadowmap_vertex>\n\t#include <fog_vertex>\n}";
+
+	var meshphong_frag = "#define PHONG\nuniform vec3 diffuse;\nuniform vec3 emissive;\nuniform vec3 specular;\nuniform float shininess;\nuniform float opacity;\n#include <common>\n#include <packing>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <uv2_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <emissivemap_pars_fragment>\n#include <envmap_common_pars_fragment>\n#include <envmap_pars_fragment>\n#include <cube_uv_reflection_fragment>\n#include <fog_pars_fragment>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <lights_phong_pars_fragment>\n#include <shadowmap_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <specularmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\tReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n\tvec3 totalEmissiveRadiance = emissive;\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <color_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <specularmap_fragment>\n\t#include <normal_fragment_begin>\n\t#include <normal_fragment_maps>\n\t#include <emissivemap_fragment>\n\t#include <lights_phong_fragment>\n\t#include <lights_fragment_begin>\n\t#include <lights_fragment_maps>\n\t#include <lights_fragment_end>\n\t#include <aomap_fragment>\n\tvec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;\n\t#include <envmap_fragment>\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n\t#include <dithering_fragment>\n}";
+
+	var meshphong_vert = "#define PHONG\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\n#include <common>\n#include <uv_pars_vertex>\n#include <uv2_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <envmap_pars_vertex>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <shadowmap_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <uv2_vertex>\n\t#include <color_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n#ifndef FLAT_SHADED\n\tvNormal = normalize( transformedNormal );\n#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\tvViewPosition = - mvPosition.xyz;\n\t#include <worldpos_vertex>\n\t#include <envmap_vertex>\n\t#include <shadowmap_vertex>\n\t#include <fog_vertex>\n}";
+
+	var meshphysical_frag = "#define STANDARD\n#ifdef PHYSICAL\n\t#define REFLECTIVITY\n\t#define CLEARCOAT\n\t#define TRANSPARENCY\n#endif\nuniform vec3 diffuse;\nuniform vec3 emissive;\nuniform float roughness;\nuniform float metalness;\nuniform float opacity;\n#ifdef TRANSPARENCY\n\tuniform float transparency;\n#endif\n#ifdef REFLECTIVITY\n\tuniform float reflectivity;\n#endif\n#ifdef CLEARCOAT\n\tuniform float clearcoat;\n\tuniform float clearcoatRoughness;\n#endif\n#ifdef USE_SHEEN\n\tuniform vec3 sheen;\n#endif\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n\t#ifdef USE_TANGENT\n\t\tvarying vec3 vTangent;\n\t\tvarying vec3 vBitangent;\n\t#endif\n#endif\n#include <common>\n#include <packing>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <uv2_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <emissivemap_pars_fragment>\n#include <bsdfs>\n#include <cube_uv_reflection_fragment>\n#include <envmap_common_pars_fragment>\n#include <envmap_physical_pars_fragment>\n#include <fog_pars_fragment>\n#include <lights_pars_begin>\n#include <lights_physical_pars_fragment>\n#include <shadowmap_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <clearcoat_pars_fragment>\n#include <roughnessmap_pars_fragment>\n#include <metalnessmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\tReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n\tvec3 totalEmissiveRadiance = emissive;\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <color_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <roughnessmap_fragment>\n\t#include <metalnessmap_fragment>\n\t#include <normal_fragment_begin>\n\t#include <normal_fragment_maps>\n\t#include <clearcoat_normal_fragment_begin>\n\t#include <clearcoat_normal_fragment_maps>\n\t#include <emissivemap_fragment>\n\t#include <lights_physical_fragment>\n\t#include <lights_fragment_begin>\n\t#include <lights_fragment_maps>\n\t#include <lights_fragment_end>\n\t#include <aomap_fragment>\n\tvec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;\n\t#ifdef TRANSPARENCY\n\t\tdiffuseColor.a *= saturate( 1. - transparency + linearToRelativeLuminance( reflectedLight.directSpecular + reflectedLight.indirectSpecular ) );\n\t#endif\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n\t#include <dithering_fragment>\n}";
+
+	var meshphysical_vert = "#define STANDARD\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n\t#ifdef USE_TANGENT\n\t\tvarying vec3 vTangent;\n\t\tvarying vec3 vBitangent;\n\t#endif\n#endif\n#include <common>\n#include <uv_pars_vertex>\n#include <uv2_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <shadowmap_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <uv2_vertex>\n\t#include <color_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n#ifndef FLAT_SHADED\n\tvNormal = normalize( transformedNormal );\n\t#ifdef USE_TANGENT\n\t\tvTangent = normalize( transformedTangent );\n\t\tvBitangent = normalize( cross( vNormal, vTangent ) * tangent.w );\n\t#endif\n#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\tvViewPosition = - mvPosition.xyz;\n\t#include <worldpos_vertex>\n\t#include <shadowmap_vertex>\n\t#include <fog_vertex>\n}";
+
+	var normal_frag = "#define NORMAL\nuniform float opacity;\n#if defined( FLAT_SHADED ) || defined( USE_BUMPMAP ) || defined( TANGENTSPACE_NORMALMAP )\n\tvarying vec3 vViewPosition;\n#endif\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n\t#ifdef USE_TANGENT\n\t\tvarying vec3 vTangent;\n\t\tvarying vec3 vBitangent;\n\t#endif\n#endif\n#include <packing>\n#include <uv_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\t#include <logdepthbuf_fragment>\n\t#include <normal_fragment_begin>\n\t#include <normal_fragment_maps>\n\tgl_FragColor = vec4( packNormalToRGB( normal ), opacity );\n}";
+
+	var normal_vert = "#define NORMAL\n#if defined( FLAT_SHADED ) || defined( USE_BUMPMAP ) || defined( TANGENTSPACE_NORMALMAP )\n\tvarying vec3 vViewPosition;\n#endif\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n\t#ifdef USE_TANGENT\n\t\tvarying vec3 vTangent;\n\t\tvarying vec3 vBitangent;\n\t#endif\n#endif\n#include <common>\n#include <uv_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n#ifndef FLAT_SHADED\n\tvNormal = normalize( transformedNormal );\n\t#ifdef USE_TANGENT\n\t\tvTangent = normalize( transformedTangent );\n\t\tvBitangent = normalize( cross( vNormal, vTangent ) * tangent.w );\n\t#endif\n#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n#if defined( FLAT_SHADED ) || defined( USE_BUMPMAP ) || defined( TANGENTSPACE_NORMALMAP )\n\tvViewPosition = - mvPosition.xyz;\n#endif\n}";
+
+	var points_frag = "uniform vec3 diffuse;\nuniform float opacity;\n#include <common>\n#include <color_pars_fragment>\n#include <map_particle_pars_fragment>\n#include <fog_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec3 outgoingLight = vec3( 0.0 );\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\t#include <logdepthbuf_fragment>\n\t#include <map_particle_fragment>\n\t#include <color_fragment>\n\t#include <alphatest_fragment>\n\toutgoingLight = diffuseColor.rgb;\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n}";
+
+	var points_vert = "uniform float size;\nuniform float scale;\n#include <common>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <color_vertex>\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <project_vertex>\n\tgl_PointSize = size;\n\t#ifdef USE_SIZEATTENUATION\n\t\tbool isPerspective = isPerspectiveMatrix( projectionMatrix );\n\t\tif ( isPerspective ) gl_PointSize *= ( scale / - mvPosition.z );\n\t#endif\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <worldpos_vertex>\n\t#include <fog_vertex>\n}";
+
+	var shadow_frag = "uniform vec3 color;\nuniform float opacity;\n#include <common>\n#include <packing>\n#include <fog_pars_fragment>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <shadowmap_pars_fragment>\n#include <shadowmask_pars_fragment>\nvoid main() {\n\tgl_FragColor = vec4( color, opacity * ( 1.0 - getShadowMask() ) );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n}";
+
+	var shadow_vert = "#include <fog_pars_vertex>\n#include <shadowmap_pars_vertex>\nvoid main() {\n\t#include <begin_vertex>\n\t#include <project_vertex>\n\t#include <worldpos_vertex>\n\t#include <shadowmap_vertex>\n\t#include <fog_vertex>\n}";
+
+	var sprite_frag = "uniform vec3 diffuse;\nuniform float opacity;\n#include <common>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <fog_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec3 outgoingLight = vec3( 0.0 );\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\toutgoingLight = diffuseColor.rgb;\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n}";
+
+	var sprite_vert = "uniform float rotation;\nuniform vec2 center;\n#include <common>\n#include <uv_pars_vertex>\n#include <fog_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\tvec4 mvPosition = modelViewMatrix * vec4( 0.0, 0.0, 0.0, 1.0 );\n\tvec2 scale;\n\tscale.x = length( vec3( modelMatrix[ 0 ].x, modelMatrix[ 0 ].y, modelMatrix[ 0 ].z ) );\n\tscale.y = length( vec3( modelMatrix[ 1 ].x, modelMatrix[ 1 ].y, modelMatrix[ 1 ].z ) );\n\t#ifndef USE_SIZEATTENUATION\n\t\tbool isPerspective = isPerspectiveMatrix( projectionMatrix );\n\t\tif ( isPerspective ) scale *= - mvPosition.z;\n\t#endif\n\tvec2 alignedPosition = ( position.xy - ( center - vec2( 0.5 ) ) ) * scale;\n\tvec2 rotatedPosition;\n\trotatedPosition.x = cos( rotation ) * alignedPosition.x - sin( rotation ) * alignedPosition.y;\n\trotatedPosition.y = sin( rotation ) * alignedPosition.x + cos( rotation ) * alignedPosition.y;\n\tmvPosition.xy += rotatedPosition;\n\tgl_Position = projectionMatrix * mvPosition;\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <fog_vertex>\n}";
+
+	var ShaderChunk = {
+		alphamap_fragment: alphamap_fragment,
+		alphamap_pars_fragment: alphamap_pars_fragment,
+		alphatest_fragment: alphatest_fragment,
+		aomap_fragment: aomap_fragment,
+		aomap_pars_fragment: aomap_pars_fragment,
+		begin_vertex: begin_vertex,
+		beginnormal_vertex: beginnormal_vertex,
+		bsdfs: bsdfs,
+		bumpmap_pars_fragment: bumpmap_pars_fragment,
+		clipping_planes_fragment: clipping_planes_fragment,
+		clipping_planes_pars_fragment: clipping_planes_pars_fragment,
+		clipping_planes_pars_vertex: clipping_planes_pars_vertex,
+		clipping_planes_vertex: clipping_planes_vertex,
+		color_fragment: color_fragment,
+		color_pars_fragment: color_pars_fragment,
+		color_pars_vertex: color_pars_vertex,
+		color_vertex: color_vertex,
+		common: common,
+		cube_uv_reflection_fragment: cube_uv_reflection_fragment,
+		defaultnormal_vertex: defaultnormal_vertex,
+		displacementmap_pars_vertex: displacementmap_pars_vertex,
+		displacementmap_vertex: displacementmap_vertex,
+		emissivemap_fragment: emissivemap_fragment,
+		emissivemap_pars_fragment: emissivemap_pars_fragment,
+		encodings_fragment: encodings_fragment,
+		encodings_pars_fragment: encodings_pars_fragment,
+		envmap_fragment: envmap_fragment,
+		envmap_common_pars_fragment: envmap_common_pars_fragment,
+		envmap_pars_fragment: envmap_pars_fragment,
+		envmap_pars_vertex: envmap_pars_vertex,
+		envmap_physical_pars_fragment: envmap_physical_pars_fragment,
+		envmap_vertex: envmap_vertex,
+		fog_vertex: fog_vertex,
+		fog_pars_vertex: fog_pars_vertex,
+		fog_fragment: fog_fragment,
+		fog_pars_fragment: fog_pars_fragment,
+		gradientmap_pars_fragment: gradientmap_pars_fragment,
+		lightmap_fragment: lightmap_fragment,
+		lightmap_pars_fragment: lightmap_pars_fragment,
+		lights_lambert_vertex: lights_lambert_vertex,
+		lights_pars_begin: lights_pars_begin,
+		lights_toon_fragment: lights_toon_fragment,
+		lights_toon_pars_fragment: lights_toon_pars_fragment,
+		lights_phong_fragment: lights_phong_fragment,
+		lights_phong_pars_fragment: lights_phong_pars_fragment,
+		lights_physical_fragment: lights_physical_fragment,
+		lights_physical_pars_fragment: lights_physical_pars_fragment,
+		lights_fragment_begin: lights_fragment_begin,
+		lights_fragment_maps: lights_fragment_maps,
+		lights_fragment_end: lights_fragment_end,
+		logdepthbuf_fragment: logdepthbuf_fragment,
+		logdepthbuf_pars_fragment: logdepthbuf_pars_fragment,
+		logdepthbuf_pars_vertex: logdepthbuf_pars_vertex,
+		logdepthbuf_vertex: logdepthbuf_vertex,
+		map_fragment: map_fragment,
+		map_pars_fragment: map_pars_fragment,
+		map_particle_fragment: map_particle_fragment,
+		map_particle_pars_fragment: map_particle_pars_fragment,
+		metalnessmap_fragment: metalnessmap_fragment,
+		metalnessmap_pars_fragment: metalnessmap_pars_fragment,
+		morphnormal_vertex: morphnormal_vertex,
+		morphtarget_pars_vertex: morphtarget_pars_vertex,
+		morphtarget_vertex: morphtarget_vertex,
+		normal_fragment_begin: normal_fragment_begin,
+		normal_fragment_maps: normal_fragment_maps,
+		normalmap_pars_fragment: normalmap_pars_fragment,
+		clearcoat_normal_fragment_begin: clearcoat_normal_fragment_begin,
+		clearcoat_normal_fragment_maps: clearcoat_normal_fragment_maps,
+		clearcoat_pars_fragment: clearcoat_pars_fragment,
+		packing: packing,
+		premultiplied_alpha_fragment: premultiplied_alpha_fragment,
+		project_vertex: project_vertex,
+		dithering_fragment: dithering_fragment,
+		dithering_pars_fragment: dithering_pars_fragment,
+		roughnessmap_fragment: roughnessmap_fragment,
+		roughnessmap_pars_fragment: roughnessmap_pars_fragment,
+		shadowmap_pars_fragment: shadowmap_pars_fragment,
+		shadowmap_pars_vertex: shadowmap_pars_vertex,
+		shadowmap_vertex: shadowmap_vertex,
+		shadowmask_pars_fragment: shadowmask_pars_fragment,
+		skinbase_vertex: skinbase_vertex,
+		skinning_pars_vertex: skinning_pars_vertex,
+		skinning_vertex: skinning_vertex,
+		skinnormal_vertex: skinnormal_vertex,
+		specularmap_fragment: specularmap_fragment,
+		specularmap_pars_fragment: specularmap_pars_fragment,
+		tonemapping_fragment: tonemapping_fragment,
+		tonemapping_pars_fragment: tonemapping_pars_fragment,
+		uv_pars_fragment: uv_pars_fragment,
+		uv_pars_vertex: uv_pars_vertex,
+		uv_vertex: uv_vertex,
+		uv2_pars_fragment: uv2_pars_fragment,
+		uv2_pars_vertex: uv2_pars_vertex,
+		uv2_vertex: uv2_vertex,
+		worldpos_vertex: worldpos_vertex,
+
+		background_frag: background_frag,
+		background_vert: background_vert,
+		cube_frag: cube_frag,
+		cube_vert: cube_vert,
+		depth_frag: depth_frag,
+		depth_vert: depth_vert,
+		distanceRGBA_frag: distanceRGBA_frag,
+		distanceRGBA_vert: distanceRGBA_vert,
+		equirect_frag: equirect_frag,
+		equirect_vert: equirect_vert,
+		linedashed_frag: linedashed_frag,
+		linedashed_vert: linedashed_vert,
+		meshbasic_frag: meshbasic_frag,
+		meshbasic_vert: meshbasic_vert,
+		meshlambert_frag: meshlambert_frag,
+		meshlambert_vert: meshlambert_vert,
+		meshmatcap_frag: meshmatcap_frag,
+		meshmatcap_vert: meshmatcap_vert,
+		meshtoon_frag: meshtoon_frag,
+		meshtoon_vert: meshtoon_vert,
+		meshphong_frag: meshphong_frag,
+		meshphong_vert: meshphong_vert,
+		meshphysical_frag: meshphysical_frag,
+		meshphysical_vert: meshphysical_vert,
+		normal_frag: normal_frag,
+		normal_vert: normal_vert,
+		points_frag: points_frag,
+		points_vert: points_vert,
+		shadow_frag: shadow_frag,
+		shadow_vert: shadow_vert,
+		sprite_frag: sprite_frag,
+		sprite_vert: sprite_vert
+	};
+
+	/**
+	 * @author alteredq / http://alteredqualia.com/
+	 * @author mrdoob / http://mrdoob.com/
+	 * @author mikael emtinger / http://gomo.se/
+	 */
+
+	var ShaderLib = {
+
+		basic: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.common,
+				UniformsLib.specularmap,
+				UniformsLib.envmap,
+				UniformsLib.aomap,
+				UniformsLib.lightmap,
+				UniformsLib.fog
+			] ),
+
+			vertexShader: ShaderChunk.meshbasic_vert,
+			fragmentShader: ShaderChunk.meshbasic_frag
+
+		},
+
+		lambert: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.common,
+				UniformsLib.specularmap,
+				UniformsLib.envmap,
+				UniformsLib.aomap,
+				UniformsLib.lightmap,
+				UniformsLib.emissivemap,
+				UniformsLib.fog,
+				UniformsLib.lights,
+				{
+					emissive: { value: new Color( 0x000000 ) }
+				}
+			] ),
+
+			vertexShader: ShaderChunk.meshlambert_vert,
+			fragmentShader: ShaderChunk.meshlambert_frag
+
+		},
+
+		phong: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.common,
+				UniformsLib.specularmap,
+				UniformsLib.envmap,
+				UniformsLib.aomap,
+				UniformsLib.lightmap,
+				UniformsLib.emissivemap,
+				UniformsLib.bumpmap,
+				UniformsLib.normalmap,
+				UniformsLib.displacementmap,
+				UniformsLib.fog,
+				UniformsLib.lights,
+				{
+					emissive: { value: new Color( 0x000000 ) },
+					specular: { value: new Color( 0x111111 ) },
+					shininess: { value: 30 }
+				}
+			] ),
+
+			vertexShader: ShaderChunk.meshphong_vert,
+			fragmentShader: ShaderChunk.meshphong_frag
+
+		},
+
+		standard: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.common,
+				UniformsLib.envmap,
+				UniformsLib.aomap,
+				UniformsLib.lightmap,
+				UniformsLib.emissivemap,
+				UniformsLib.bumpmap,
+				UniformsLib.normalmap,
+				UniformsLib.displacementmap,
+				UniformsLib.roughnessmap,
+				UniformsLib.metalnessmap,
+				UniformsLib.fog,
+				UniformsLib.lights,
+				{
+					emissive: { value: new Color( 0x000000 ) },
+					roughness: { value: 1.0 },
+					metalness: { value: 0.0 },
+					envMapIntensity: { value: 1 } // temporary
+				}
+			] ),
+
+			vertexShader: ShaderChunk.meshphysical_vert,
+			fragmentShader: ShaderChunk.meshphysical_frag
+
+		},
+
+		toon: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.common,
+				UniformsLib.specularmap,
+				UniformsLib.aomap,
+				UniformsLib.lightmap,
+				UniformsLib.emissivemap,
+				UniformsLib.bumpmap,
+				UniformsLib.normalmap,
+				UniformsLib.displacementmap,
+				UniformsLib.gradientmap,
+				UniformsLib.fog,
+				UniformsLib.lights,
+				{
+					emissive: { value: new Color( 0x000000 ) },
+					specular: { value: new Color( 0x111111 ) },
+					shininess: { value: 30 }
+				}
+			] ),
+
+			vertexShader: ShaderChunk.meshtoon_vert,
+			fragmentShader: ShaderChunk.meshtoon_frag
+
+		},
+
+		matcap: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.common,
+				UniformsLib.bumpmap,
+				UniformsLib.normalmap,
+				UniformsLib.displacementmap,
+				UniformsLib.fog,
+				{
+					matcap: { value: null }
+				}
+			] ),
+
+			vertexShader: ShaderChunk.meshmatcap_vert,
+			fragmentShader: ShaderChunk.meshmatcap_frag
+
+		},
+
+		points: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.points,
+				UniformsLib.fog
+			] ),
+
+			vertexShader: ShaderChunk.points_vert,
+			fragmentShader: ShaderChunk.points_frag
+
+		},
+
+		dashed: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.common,
+				UniformsLib.fog,
+				{
+					scale: { value: 1 },
+					dashSize: { value: 1 },
+					totalSize: { value: 2 }
+				}
+			] ),
+
+			vertexShader: ShaderChunk.linedashed_vert,
+			fragmentShader: ShaderChunk.linedashed_frag
+
+		},
+
+		depth: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.common,
+				UniformsLib.displacementmap
+			] ),
+
+			vertexShader: ShaderChunk.depth_vert,
+			fragmentShader: ShaderChunk.depth_frag
+
+		},
+
+		normal: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.common,
+				UniformsLib.bumpmap,
+				UniformsLib.normalmap,
+				UniformsLib.displacementmap,
+				{
+					opacity: { value: 1.0 }
+				}
+			] ),
+
+			vertexShader: ShaderChunk.normal_vert,
+			fragmentShader: ShaderChunk.normal_frag
+
+		},
+
+		sprite: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.sprite,
+				UniformsLib.fog
+			] ),
+
+			vertexShader: ShaderChunk.sprite_vert,
+			fragmentShader: ShaderChunk.sprite_frag
+
+		},
+
+		background: {
+
+			uniforms: {
+				uvTransform: { value: new Matrix3() },
+				t2D: { value: null },
+			},
+
+			vertexShader: ShaderChunk.background_vert,
+			fragmentShader: ShaderChunk.background_frag
+
+		},
+		/* -------------------------------------------------------------------------
+		//	Cube map shader
+		 ------------------------------------------------------------------------- */
+
+		cube: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.envmap,
+				{
+					opacity: { value: 1.0 }
+				}
+			] ),
+
+			vertexShader: ShaderChunk.cube_vert,
+			fragmentShader: ShaderChunk.cube_frag
+
+		},
+
+		equirect: {
+
+			uniforms: {
+				tEquirect: { value: null },
+			},
+
+			vertexShader: ShaderChunk.equirect_vert,
+			fragmentShader: ShaderChunk.equirect_frag
+
+		},
+
+		distanceRGBA: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.common,
+				UniformsLib.displacementmap,
+				{
+					referencePosition: { value: new Vector3() },
+					nearDistance: { value: 1 },
+					farDistance: { value: 1000 }
+				}
+			] ),
+
+			vertexShader: ShaderChunk.distanceRGBA_vert,
+			fragmentShader: ShaderChunk.distanceRGBA_frag
+
+		},
+
+		shadow: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.lights,
+				UniformsLib.fog,
+				{
+					color: { value: new Color( 0x00000 ) },
+					opacity: { value: 1.0 }
+				},
+			] ),
+
+			vertexShader: ShaderChunk.shadow_vert,
+			fragmentShader: ShaderChunk.shadow_frag
+
+		}
+
+	};
+
+	ShaderLib.physical = {
+
+		uniforms: mergeUniforms( [
+			ShaderLib.standard.uniforms,
+			{
+				clearcoat: { value: 0 },
+				clearcoatMap: { value: null },
+				clearcoatRoughness: { value: 0 },
+				clearcoatRoughnessMap: { value: null },
+				clearcoatNormalScale: { value: new Vector2( 1, 1 ) },
+				clearcoatNormalMap: { value: null },
+				sheen: { value: new Color( 0x000000 ) },
+				transparency: { value: 0 },
+			}
+		] ),
+
+		vertexShader: ShaderChunk.meshphysical_vert,
+		fragmentShader: ShaderChunk.meshphysical_frag
+
+	};
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -15515,10 +15533,10 @@ var Spacekit = (function (exports) {
 
 		var planeMesh;
 		var boxMesh;
-		// Store the current background texture and its `version`
-		// so we can recompile the material accordingly.
+
 		var currentBackground = null;
 		var currentBackgroundVersion = 0;
+		var currentTonemapping = null;
 
 		function render( renderList, scene, camera, forceClear ) {
 
@@ -15527,8 +15545,8 @@ var Spacekit = (function (exports) {
 			// Ignore background in AR
 			// TODO: Reconsider this.
 
-			var vr = renderer.vr;
-			var session = vr.getSession && vr.getSession();
+			var xr = renderer.xr;
+			var session = xr.getSession && xr.getSession();
 
 			if ( session && session.environmentBlendMode === 'additive' ) {
 
@@ -15539,15 +15557,11 @@ var Spacekit = (function (exports) {
 			if ( background === null ) {
 
 				setClear( clearColor, clearAlpha );
-				currentBackground = null;
-				currentBackgroundVersion = 0;
 
 			} else if ( background && background.isColor ) {
 
 				setClear( background, 1 );
 				forceClear = true;
-				currentBackground = null;
-				currentBackgroundVersion = 0;
 
 			}
 
@@ -15557,7 +15571,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			if ( background && ( background.isCubeTexture || background.isWebGLRenderTargetCube ) ) {
+			if ( background && ( background.isCubeTexture || background.isWebGLCubeRenderTarget || background.mapping === CubeUVReflectionMapping ) ) {
 
 				if ( boxMesh === undefined ) {
 
@@ -15575,8 +15589,8 @@ var Spacekit = (function (exports) {
 						} )
 					);
 
-					boxMesh.geometry.removeAttribute( 'normal' );
-					boxMesh.geometry.removeAttribute( 'uv' );
+					boxMesh.geometry.deleteAttribute( 'normal' );
+					boxMesh.geometry.deleteAttribute( 'uv' );
 
 					boxMesh.onBeforeRender = function ( renderer, scene, camera ) {
 
@@ -15585,11 +15599,11 @@ var Spacekit = (function (exports) {
 					};
 
 					// enable code injection for non-built-in material
-					Object.defineProperty( boxMesh.material, 'map', {
+					Object.defineProperty( boxMesh.material, 'envMap', {
 
 						get: function () {
 
-							return this.uniforms.tCube.value;
+							return this.uniforms.envMap.value;
 
 						}
 
@@ -15599,17 +15613,20 @@ var Spacekit = (function (exports) {
 
 				}
 
-				var texture = background.isWebGLRenderTargetCube ? background.texture : background;
-				boxMesh.material.uniforms.tCube.value = texture;
-				boxMesh.material.uniforms.tFlip.value = ( background.isWebGLRenderTargetCube ) ? 1 : - 1;
+				var texture = background.isWebGLCubeRenderTarget ? background.texture : background;
+
+				boxMesh.material.uniforms.envMap.value = texture;
+				boxMesh.material.uniforms.flipEnvMap.value = texture.isCubeTexture ? - 1 : 1;
 
 				if ( currentBackground !== background ||
-				     currentBackgroundVersion !== texture.version ) {
+					currentBackgroundVersion !== texture.version ||
+					currentTonemapping !== renderer.toneMapping ) {
 
 					boxMesh.material.needsUpdate = true;
 
 					currentBackground = background;
 					currentBackgroundVersion = texture.version;
+					currentTonemapping = renderer.toneMapping;
 
 				}
 
@@ -15634,7 +15651,7 @@ var Spacekit = (function (exports) {
 						} )
 					);
 
-					planeMesh.geometry.removeAttribute( 'normal' );
+					planeMesh.geometry.deleteAttribute( 'normal' );
 
 					// enable code injection for non-built-in material
 					Object.defineProperty( planeMesh.material, 'map', {
@@ -15662,12 +15679,14 @@ var Spacekit = (function (exports) {
 				planeMesh.material.uniforms.uvTransform.value.copy( background.matrix );
 
 				if ( currentBackground !== background ||
-					   currentBackgroundVersion !== background.version ) {
+					currentBackgroundVersion !== background.version ||
+					currentTonemapping !== renderer.toneMapping ) {
 
 					planeMesh.material.needsUpdate = true;
 
 					currentBackground = background;
 					currentBackgroundVersion = background.version;
+					currentTonemapping = renderer.toneMapping;
 
 				}
 
@@ -15722,6 +15741,8 @@ var Spacekit = (function (exports) {
 
 	function WebGLBufferRenderer( gl, extensions, info, capabilities ) {
 
+		var isWebGL2 = capabilities.isWebGL2;
+
 		var mode;
 
 		function setMode( value ) {
@@ -15738,17 +15759,21 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function renderInstances( geometry, start, count ) {
+		function renderInstances( geometry, start, count, primcount ) {
 
-			var extension;
+			if ( primcount === 0 ) return;
 
-			if ( capabilities.isWebGL2 ) {
+			var extension, methodName;
+
+			if ( isWebGL2 ) {
 
 				extension = gl;
+				methodName = 'drawArraysInstanced';
 
 			} else {
 
 				extension = extensions.get( 'ANGLE_instanced_arrays' );
+				methodName = 'drawArraysInstancedANGLE';
 
 				if ( extension === null ) {
 
@@ -15759,9 +15784,9 @@ var Spacekit = (function (exports) {
 
 			}
 
-			extension[ capabilities.isWebGL2 ? 'drawArraysInstanced' : 'drawArraysInstancedANGLE' ]( mode, start, count, geometry.maxInstancedCount );
+			extension[ methodName ]( mode, start, count, primcount );
 
-			info.update( count, mode, geometry.maxInstancedCount );
+			info.update( count, mode, primcount );
 
 		}
 
@@ -15806,7 +15831,7 @@ var Spacekit = (function (exports) {
 			if ( precision === 'highp' ) {
 
 				if ( gl.getShaderPrecisionFormat( 35633, 36338 ).precision > 0 &&
-				     gl.getShaderPrecisionFormat( 35632, 36338 ).precision > 0 ) {
+					gl.getShaderPrecisionFormat( 35632, 36338 ).precision > 0 ) {
 
 					return 'highp';
 
@@ -15819,7 +15844,7 @@ var Spacekit = (function (exports) {
 			if ( precision === 'mediump' ) {
 
 				if ( gl.getShaderPrecisionFormat( 35633, 36337 ).precision > 0 &&
-				     gl.getShaderPrecisionFormat( 35632, 36337 ).precision > 0 ) {
+					gl.getShaderPrecisionFormat( 35632, 36337 ).precision > 0 ) {
 
 					return 'mediump';
 
@@ -15831,7 +15856,10 @@ var Spacekit = (function (exports) {
 
 		}
 
-		var isWebGL2 = typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext;
+		/* eslint-disable no-undef */
+		var isWebGL2 = ( typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext ) ||
+			( typeof WebGL2ComputeRenderingContext !== 'undefined' && gl instanceof WebGL2ComputeRenderingContext );
+		/* eslint-enable no-undef */
 
 		var precision = parameters.precision !== undefined ? parameters.precision : 'highp';
 		var maxPrecision = getMaxPrecision( precision );
@@ -16043,6 +16071,7 @@ var Spacekit = (function (exports) {
 			}
 
 			scope.numPlanes = nPlanes;
+			scope.numIntersection = 0;
 
 			return dstArray;
 
@@ -16115,13 +16144,13 @@ var Spacekit = (function (exports) {
 
 	function WebGLGeometries( gl, attributes, info ) {
 
-		var geometries = {};
-		var wireframeAttributes = {};
+		var geometries = new WeakMap();
+		var wireframeAttributes = new WeakMap();
 
 		function onGeometryDispose( event ) {
 
 			var geometry = event.target;
-			var buffergeometry = geometries[ geometry.id ];
+			var buffergeometry = geometries.get( geometry );
 
 			if ( buffergeometry.index !== null ) {
 
@@ -16137,14 +16166,14 @@ var Spacekit = (function (exports) {
 
 			geometry.removeEventListener( 'dispose', onGeometryDispose );
 
-			delete geometries[ geometry.id ];
+			geometries.delete( geometry );
 
-			var attribute = wireframeAttributes[ buffergeometry.id ];
+			var attribute = wireframeAttributes.get( buffergeometry );
 
 			if ( attribute ) {
 
 				attributes.remove( attribute );
-				delete wireframeAttributes[ buffergeometry.id ];
+				wireframeAttributes.delete( buffergeometry );
 
 			}
 
@@ -16156,7 +16185,7 @@ var Spacekit = (function (exports) {
 
 		function get( object, geometry ) {
 
-			var buffergeometry = geometries[ geometry.id ];
+			var buffergeometry = geometries.get( geometry );
 
 			if ( buffergeometry ) return buffergeometry;
 
@@ -16178,7 +16207,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			geometries[ geometry.id ] = buffergeometry;
+			geometries.set( geometry, buffergeometry );
 
 			info.memory.geometries ++;
 
@@ -16268,19 +16297,19 @@ var Spacekit = (function (exports) {
 
 			//
 
-			var previousAttribute = wireframeAttributes[ geometry.id ];
+			var previousAttribute = wireframeAttributes.get( geometry );
 
 			if ( previousAttribute ) attributes.remove( previousAttribute );
 
 			//
 
-			wireframeAttributes[ geometry.id ] = attribute;
+			wireframeAttributes.set( geometry, attribute );
 
 		}
 
 		function getWireframeAttribute( geometry ) {
 
-			var currentAttribute = wireframeAttributes[ geometry.id ];
+			var currentAttribute = wireframeAttributes.get( geometry );
 
 			if ( currentAttribute ) {
 
@@ -16304,7 +16333,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			return wireframeAttributes[ geometry.id ];
+			return wireframeAttributes.get( geometry );
 
 		}
 
@@ -16324,6 +16353,8 @@ var Spacekit = (function (exports) {
 	 */
 
 	function WebGLIndexedBufferRenderer( gl, extensions, info, capabilities ) {
+
+		var isWebGL2 = capabilities.isWebGL2;
 
 		var mode;
 
@@ -16350,17 +16381,21 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function renderInstances( geometry, start, count ) {
+		function renderInstances( geometry, start, count, primcount ) {
 
-			var extension;
+			if ( primcount === 0 ) return;
 
-			if ( capabilities.isWebGL2 ) {
+			var extension, methodName;
+
+			if ( isWebGL2 ) {
 
 				extension = gl;
+				methodName = 'drawElementsInstanced';
 
 			} else {
 
-				var extension = extensions.get( 'ANGLE_instanced_arrays' );
+				extension = extensions.get( 'ANGLE_instanced_arrays' );
+				methodName = 'drawElementsInstancedANGLE';
 
 				if ( extension === null ) {
 
@@ -16371,9 +16406,9 @@ var Spacekit = (function (exports) {
 
 			}
 
-			extension[ capabilities.isWebGL2 ? 'drawElementsInstanced' : 'drawElementsInstancedANGLE' ]( mode, count, type, start * bytesPerElement, geometry.maxInstancedCount );
+			extension[ methodName ]( mode, count, type, start * bytesPerElement, primcount );
 
-			info.update( count, mode, geometry.maxInstancedCount );
+			info.update( count, mode, primcount );
 
 		}
 
@@ -16415,11 +16450,6 @@ var Spacekit = (function (exports) {
 
 				case 4:
 					render.triangles += instanceCount * ( count / 3 );
-					break;
-
-				case 5:
-				case 6:
-					render.triangles += instanceCount * ( count - 2 );
 					break;
 
 				case 1:
@@ -16486,7 +16516,10 @@ var Spacekit = (function (exports) {
 
 			var objectInfluences = object.morphTargetInfluences;
 
-			var length = objectInfluences.length;
+			// When object doesn't have morph target influences defined, we treat it as a 0-length array
+			// This is important to make sure we set up morphTargetBaseInfluence / morphTargetInfluences
+
+			var length = objectInfluences === undefined ? 0 : objectInfluences.length;
 
 			var influences = influencesList[ geometry.id ];
 
@@ -16517,8 +16550,8 @@ var Spacekit = (function (exports) {
 
 				if ( influence[ 1 ] !== 0 ) {
 
-					if ( morphTargets ) geometry.removeAttribute( 'morphTarget' + i );
-					if ( morphNormals ) geometry.removeAttribute( 'morphNormal' + i );
+					if ( morphTargets ) geometry.deleteAttribute( 'morphTarget' + i );
+					if ( morphNormals ) geometry.deleteAttribute( 'morphNormal' + i );
 
 				}
 
@@ -16539,6 +16572,8 @@ var Spacekit = (function (exports) {
 
 			// Add morphAttributes
 
+			var morphInfluencesSum = 0;
+
 			for ( var i = 0; i < 8; i ++ ) {
 
 				var influence = influences[ i ];
@@ -16550,10 +16585,11 @@ var Spacekit = (function (exports) {
 
 					if ( value ) {
 
-						if ( morphTargets ) geometry.addAttribute( 'morphTarget' + i, morphTargets[ index ] );
-						if ( morphNormals ) geometry.addAttribute( 'morphNormal' + i, morphNormals[ index ] );
+						if ( morphTargets ) geometry.setAttribute( 'morphTarget' + i, morphTargets[ index ] );
+						if ( morphNormals ) geometry.setAttribute( 'morphNormal' + i, morphNormals[ index ] );
 
 						morphInfluences[ i ] = value;
+						morphInfluencesSum += value;
 						continue;
 
 					}
@@ -16564,6 +16600,12 @@ var Spacekit = (function (exports) {
 
 			}
 
+			// GLSL shader uses formula baseinfluence * base + sum(target * influence)
+			// This allows us to switch between absolute morphs and relative morphs without changing shader code
+			// When baseinfluence = 1 - sum(influence), the above is equivalent to sum((target - base) * influence)
+			var morphBaseInfluence = geometry.morphTargetsRelative ? 1 : 1 - morphInfluencesSum;
+
+			program.getUniforms().setValue( gl, 'morphTargetBaseInfluence', morphBaseInfluence );
 			program.getUniforms().setValue( gl, 'morphTargetInfluences', morphInfluences );
 
 		}
@@ -16580,9 +16622,9 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-	function WebGLObjects( geometries, info ) {
+	function WebGLObjects( gl, geometries, attributes, info ) {
 
-		var updateList = {};
+		var updateMap = new WeakMap();
 
 		function update( object ) {
 
@@ -16593,7 +16635,7 @@ var Spacekit = (function (exports) {
 
 			// Update once per frame
 
-			if ( updateList[ buffergeometry.id ] !== frame ) {
+			if ( updateMap.get( buffergeometry ) !== frame ) {
 
 				if ( geometry.isGeometry ) {
 
@@ -16603,7 +16645,13 @@ var Spacekit = (function (exports) {
 
 				geometries.update( buffergeometry );
 
-				updateList[ buffergeometry.id ] = frame;
+				updateMap.set( buffergeometry, frame );
+
+			}
+
+			if ( object.isInstancedMesh ) {
+
+				attributes.update( object.instanceMatrix, 34962 );
 
 			}
 
@@ -16613,7 +16661,7 @@ var Spacekit = (function (exports) {
 
 		function dispose() {
 
-			updateList = {};
+			updateMap = new WeakMap();
 
 		}
 
@@ -16671,7 +16719,7 @@ var Spacekit = (function (exports) {
 
 		Texture.call( this, null );
 
-		this.image = { data: data, width: width, height: height, depth: depth };
+		this.image = { data: data || null, width: width || 1, height: height || 1, depth: depth || 1 };
 
 		this.magFilter = NearestFilter;
 		this.minFilter = NearestFilter;
@@ -16680,6 +16728,8 @@ var Spacekit = (function (exports) {
 
 		this.generateMipmaps = false;
 		this.flipY = false;
+
+		this.needsUpdate = true;
 
 	}
 
@@ -16703,7 +16753,7 @@ var Spacekit = (function (exports) {
 
 		Texture.call( this, null );
 
-		this.image = { data: data, width: width, height: height, depth: depth };
+		this.image = { data: data || null, width: width || 1, height: height || 1, depth: depth || 1 };
 
 		this.magFilter = NearestFilter;
 		this.minFilter = NearestFilter;
@@ -16712,6 +16762,9 @@ var Spacekit = (function (exports) {
 
 		this.generateMipmaps = false;
 		this.flipY = false;
+
+		this.needsUpdate = true;
+
 
 	}
 
@@ -17181,6 +17234,20 @@ var Spacekit = (function (exports) {
 
 	}
 
+	// uint
+
+	function setValueV1ui( gl, v ) {
+
+		var cache = this.cache;
+
+		if ( cache[ 0 ] === v ) return;
+
+		gl.uniform1ui( this.addr, v );
+
+		cache[ 0 ] = v;
+
+	}
+
 	// Helper to pick the right setter for the singular case
 
 	function getSingularSetter( type ) {
@@ -17196,15 +17263,36 @@ var Spacekit = (function (exports) {
 			case 0x8b5b: return setValueM3; // _MAT3
 			case 0x8b5c: return setValueM4; // _MAT4
 
-			case 0x8b5e: case 0x8d66: return setValueT1; // SAMPLER_2D, SAMPLER_EXTERNAL_OES
-			case 0x8b5f: return setValueT3D1; // SAMPLER_3D
-			case 0x8b60: return setValueT6; // SAMPLER_CUBE
-			case 0x8DC1: return setValueT2DArray1; // SAMPLER_2D_ARRAY
-
 			case 0x1404: case 0x8b56: return setValueV1i; // INT, BOOL
 			case 0x8b53: case 0x8b57: return setValueV2i; // _VEC2
 			case 0x8b54: case 0x8b58: return setValueV3i; // _VEC3
 			case 0x8b55: case 0x8b59: return setValueV4i; // _VEC4
+
+			case 0x1405: return setValueV1ui; // UINT
+
+			case 0x8b5e: // SAMPLER_2D
+			case 0x8d66: // SAMPLER_EXTERNAL_OES
+			case 0x8dca: // INT_SAMPLER_2D
+			case 0x8dd2: // UNSIGNED_INT_SAMPLER_2D
+			case 0x8b62: // SAMPLER_2D_SHADOW
+				return setValueT1;
+
+			case 0x8b5f: // SAMPLER_3D
+			case 0x8dcb: // INT_SAMPLER_3D
+			case 0x8dd3: // UNSIGNED_INT_SAMPLER_3D
+				return setValueT3D1;
+
+			case 0x8b60: // SAMPLER_CUBE
+			case 0x8dcc: // INT_SAMPLER_CUBE
+			case 0x8dd4: // UNSIGNED_INT_SAMPLER_CUBE
+			case 0x8dc5: // SAMPLER_CUBE_SHADOW
+				return setValueT6;
+
+			case 0x8dc1: // SAMPLER_2D_ARRAY
+			case 0x8dcf: // INT_SAMPLER_2D_ARRAY
+			case 0x8dd7: // UNSIGNED_INT_SAMPLER_2D_ARRAY
+			case 0x8dc4: // SAMPLER_2D_ARRAY_SHADOW
+				return setValueT2DArray1;
 
 		}
 
@@ -17344,13 +17432,23 @@ var Spacekit = (function (exports) {
 			case 0x8b5b: return setValueM3Array; // _MAT3
 			case 0x8b5c: return setValueM4Array; // _MAT4
 
-			case 0x8b5e: return setValueT1Array; // SAMPLER_2D
-			case 0x8b60: return setValueT6Array; // SAMPLER_CUBE
-
 			case 0x1404: case 0x8b56: return setValueV1iArray; // INT, BOOL
 			case 0x8b53: case 0x8b57: return setValueV2iArray; // _VEC2
 			case 0x8b54: case 0x8b58: return setValueV3iArray; // _VEC3
 			case 0x8b55: case 0x8b59: return setValueV4iArray; // _VEC4
+
+			case 0x8b5e: // SAMPLER_2D
+			case 0x8d66: // SAMPLER_EXTERNAL_OES
+			case 0x8dca: // INT_SAMPLER_2D
+			case 0x8dd2: // UNSIGNED_INT_SAMPLER_2D
+			case 0x8b62: // SAMPLER_2D_SHADOW
+				return setValueT1Array;
+
+			case 0x8b60: // SAMPLER_CUBE
+			case 0x8dcc: // INT_SAMPLER_CUBE
+			case 0x8dd4: // UNSIGNED_INT_SAMPLER_CUBE
+			case 0x8dc5: // SAMPLER_CUBE_SHADOW
+				return setValueT6Array;
 
 		}
 
@@ -17614,6 +17712,8 @@ var Spacekit = (function (exports) {
 				return [ 'RGBD', '( value, 256.0 )' ];
 			case GammaEncoding:
 				return [ 'Gamma', '( value, float( GAMMA_FACTOR ) )' ];
+			case LogLuvEncoding:
+				return [ 'LogLuv', '( value )' ];
 			default:
 				throw new Error( 'unsupported encoding: ' + encoding );
 
@@ -17686,15 +17786,13 @@ var Spacekit = (function (exports) {
 
 	}
 
-	function generateExtensions( extensions, parameters, rendererExtensions ) {
-
-		extensions = extensions || {};
+	function generateExtensions( parameters ) {
 
 		var chunks = [
-			( extensions.derivatives || parameters.envMapCubeUV || parameters.bumpMap || ( parameters.normalMap && ! parameters.objectSpaceNormalMap ) || parameters.flatShading ) ? '#extension GL_OES_standard_derivatives : enable' : '',
-			( extensions.fragDepth || parameters.logarithmicDepthBuffer ) && rendererExtensions.get( 'EXT_frag_depth' ) ? '#extension GL_EXT_frag_depth : enable' : '',
-			( extensions.drawBuffers ) && rendererExtensions.get( 'WEBGL_draw_buffers' ) ? '#extension GL_EXT_draw_buffers : require' : '',
-			( extensions.shaderTextureLOD || parameters.envMap ) && rendererExtensions.get( 'EXT_shader_texture_lod' ) ? '#extension GL_EXT_shader_texture_lod : enable' : ''
+			( parameters.extensionDerivatives || parameters.envMapCubeUV || parameters.bumpMap || parameters.tangentSpaceNormalMap || parameters.clearcoatNormalMap || parameters.flatShading || parameters.shaderID === 'physical' ) ? '#extension GL_OES_standard_derivatives : enable' : '',
+			( parameters.extensionFragDepth || parameters.logarithmicDepthBuffer ) && parameters.rendererExtensionFragDepth ? '#extension GL_EXT_frag_depth : enable' : '',
+			( parameters.extensionDrawBuffers && parameters.rendererExtensionDrawBuffers ) ? '#extension GL_EXT_draw_buffers : require' : '',
+			( parameters.extensionShaderTextureLOD || parameters.envMap ) && parameters.rendererExtensionShaderTextureLod ? '#extension GL_EXT_shader_texture_lod : enable' : ''
 		];
 
 		return chunks.filter( filterEmptyLine ).join( '\n' );
@@ -17753,7 +17851,10 @@ var Spacekit = (function (exports) {
 			.replace( /NUM_SPOT_LIGHTS/g, parameters.numSpotLights )
 			.replace( /NUM_RECT_AREA_LIGHTS/g, parameters.numRectAreaLights )
 			.replace( /NUM_POINT_LIGHTS/g, parameters.numPointLights )
-			.replace( /NUM_HEMI_LIGHTS/g, parameters.numHemiLights );
+			.replace( /NUM_HEMI_LIGHTS/g, parameters.numHemiLights )
+			.replace( /NUM_DIR_LIGHT_SHADOWS/g, parameters.numDirLightShadows )
+			.replace( /NUM_SPOT_LIGHT_SHADOWS/g, parameters.numSpotLightShadows )
+			.replace( /NUM_POINT_LIGHT_SHADOWS/g, parameters.numPointLightShadows );
 
 	}
 
@@ -17765,58 +17866,91 @@ var Spacekit = (function (exports) {
 
 	}
 
-	function parseIncludes( string ) {
+	// Resolve Includes
 
-		var pattern = /^[ \t]*#include +<([\w\d./]+)>/gm;
+	var includePattern = /^[ \t]*#include +<([\w\d./]+)>/gm;
 
-		function replace( match, include ) {
+	function resolveIncludes( string ) {
 
-			var replace = ShaderChunk[ include ];
+		return string.replace( includePattern, includeReplacer );
 
-			if ( replace === undefined ) {
+	}
 
-				throw new Error( 'Can not resolve #include <' + include + '>' );
+	function includeReplacer( match, include ) {
 
-			}
+		var string = ShaderChunk[ include ];
 
-			return parseIncludes( replace );
+		if ( string === undefined ) {
+
+			throw new Error( 'Can not resolve #include <' + include + '>' );
 
 		}
 
-		return string.replace( pattern, replace );
+		return resolveIncludes( string );
 
 	}
+
+	// Unroll Loops
+
+	var deprecatedUnrollLoopPattern = /#pragma unroll_loop[\s]+?for \( int i \= (\d+)\; i < (\d+)\; i \+\+ \) \{([\s\S]+?)(?=\})\}/g;
+	var unrollLoopPattern = /#pragma unroll_loop_start[\s]+?for \( int i \= (\d+)\; i < (\d+)\; i \+\+ \) \{([\s\S]+?)(?=\})\}[\s]+?#pragma unroll_loop_end/g;
 
 	function unrollLoops( string ) {
 
-		var pattern = /#pragma unroll_loop[\s]+?for \( int i \= (\d+)\; i < (\d+)\; i \+\+ \) \{([\s\S]+?)(?=\})\}/g;
-
-		function replace( match, start, end, snippet ) {
-
-			var unroll = '';
-
-			for ( var i = parseInt( start ); i < parseInt( end ); i ++ ) {
-
-				unroll += snippet.replace( /\[ i \]/g, '[ ' + i + ' ]' );
-
-			}
-
-			return unroll;
-
-		}
-
-		return string.replace( pattern, replace );
+		return string
+			.replace( unrollLoopPattern, loopReplacer )
+			.replace( deprecatedUnrollLoopPattern, deprecatedLoopReplacer );
 
 	}
 
-	function WebGLProgram( renderer, extensions, code, material, shader, parameters, capabilities ) {
+	function deprecatedLoopReplacer( match, start, end, snippet ) {
 
-		var gl = renderer.getContext();
+		console.warn( 'WebGLProgram: #pragma unroll_loop shader syntax is deprecated. Please use #pragma unroll_loop_start syntax instead.' );
+		return loopReplacer( match, start, end, snippet );
 
-		var defines = material.defines;
+	}
 
-		var vertexShader = shader.vertexShader;
-		var fragmentShader = shader.fragmentShader;
+	function loopReplacer( match, start, end, snippet ) {
+
+		var string = '';
+
+		for ( var i = parseInt( start ); i < parseInt( end ); i ++ ) {
+
+			string += snippet
+				.replace( /\[ i \]/g, '[ ' + i + ' ]' )
+				.replace( /UNROLLED_LOOP_INDEX/g, i );
+
+		}
+
+		return string;
+
+	}
+
+	//
+
+	function generatePrecision( parameters ) {
+
+		var precisionstring = "precision " + parameters.precision + " float;\nprecision " + parameters.precision + " int;";
+
+		if ( parameters.precision === "highp" ) {
+
+			precisionstring += "\n#define HIGH_PRECISION";
+
+		} else if ( parameters.precision === "mediump" ) {
+
+			precisionstring += "\n#define MEDIUM_PRECISION";
+
+		} else if ( parameters.precision === "lowp" ) {
+
+			precisionstring += "\n#define LOW_PRECISION";
+
+		}
+
+		return precisionstring;
+
+	}
+
+	function generateShadowMapTypeDefine( parameters ) {
 
 		var shadowMapTypeDefine = 'SHADOWMAP_TYPE_BASIC';
 
@@ -17828,15 +17962,23 @@ var Spacekit = (function (exports) {
 
 			shadowMapTypeDefine = 'SHADOWMAP_TYPE_PCF_SOFT';
 
+		} else if ( parameters.shadowMapType === VSMShadowMap ) {
+
+			shadowMapTypeDefine = 'SHADOWMAP_TYPE_VSM';
+
 		}
 
+		return shadowMapTypeDefine;
+
+	}
+
+	function generateEnvMapTypeDefine( parameters ) {
+
 		var envMapTypeDefine = 'ENVMAP_TYPE_CUBE';
-		var envMapModeDefine = 'ENVMAP_MODE_REFLECTION';
-		var envMapBlendingDefine = 'ENVMAP_BLENDING_MULTIPLY';
 
 		if ( parameters.envMap ) {
 
-			switch ( material.envMap.mapping ) {
+			switch ( parameters.envMapMode ) {
 
 				case CubeReflectionMapping:
 				case CubeRefractionMapping:
@@ -17859,7 +18001,19 @@ var Spacekit = (function (exports) {
 
 			}
 
-			switch ( material.envMap.mapping ) {
+		}
+
+		return envMapTypeDefine;
+
+	}
+
+	function generateEnvMapModeDefine( parameters ) {
+
+		var envMapModeDefine = 'ENVMAP_MODE_REFLECTION';
+
+		if ( parameters.envMap ) {
+
+			switch ( parameters.envMapMode ) {
 
 				case CubeRefractionMapping:
 				case EquirectangularRefractionMapping:
@@ -17868,7 +18022,19 @@ var Spacekit = (function (exports) {
 
 			}
 
-			switch ( material.combine ) {
+		}
+
+		return envMapModeDefine;
+
+	}
+
+	function generateEnvMapBlendingDefine( parameters ) {
+
+		var envMapBlendingDefine = 'ENVMAP_BLENDING_NONE';
+
+		if ( parameters.envMap ) {
+
+			switch ( parameters.combine ) {
 
 				case MultiplyOperation:
 					envMapBlendingDefine = 'ENVMAP_BLENDING_MULTIPLY';
@@ -17886,23 +18052,35 @@ var Spacekit = (function (exports) {
 
 		}
 
+		return envMapBlendingDefine;
+
+	}
+
+	function WebGLProgram( renderer, cacheKey, parameters ) {
+
+		var gl = renderer.getContext();
+
+		var defines = parameters.defines;
+
+		var vertexShader = parameters.vertexShader;
+		var fragmentShader = parameters.fragmentShader;
+		var shadowMapTypeDefine = generateShadowMapTypeDefine( parameters );
+		var envMapTypeDefine = generateEnvMapTypeDefine( parameters );
+		var envMapModeDefine = generateEnvMapModeDefine( parameters );
+		var envMapBlendingDefine = generateEnvMapBlendingDefine( parameters );
+
+
 		var gammaFactorDefine = ( renderer.gammaFactor > 0 ) ? renderer.gammaFactor : 1.0;
 
-		// console.log( 'building new program ' );
-
-		//
-
-		var customExtensions = capabilities.isWebGL2 ? '' : generateExtensions( material.extensions, parameters, extensions );
+		var customExtensions = parameters.isWebGL2 ? '' : generateExtensions( parameters );
 
 		var customDefines = generateDefines( defines );
-
-		//
 
 		var program = gl.createProgram();
 
 		var prefixVertex, prefixFragment;
 
-		if ( material.isRawShaderMaterial ) {
+		if ( parameters.isRawShaderMaterial ) {
 
 			prefixVertex = [
 
@@ -17933,20 +18111,20 @@ var Spacekit = (function (exports) {
 
 			prefixVertex = [
 
-				'precision ' + parameters.precision + ' float;',
-				'precision ' + parameters.precision + ' int;',
+				generatePrecision( parameters ),
 
-				'#define SHADER_NAME ' + shader.name,
+				'#define SHADER_NAME ' + parameters.shaderName,
 
 				customDefines,
 
+				parameters.instancing ? '#define USE_INSTANCING' : '',
 				parameters.supportsVertexTextures ? '#define VERTEX_TEXTURES' : '',
 
 				'#define GAMMA_FACTOR ' + gammaFactorDefine,
 
 				'#define MAX_BONES ' + parameters.maxBones,
 				( parameters.useFog && parameters.fog ) ? '#define USE_FOG' : '',
-				( parameters.useFog && parameters.fogExp ) ? '#define FOG_EXP2' : '',
+				( parameters.useFog && parameters.fogExp2 ) ? '#define FOG_EXP2' : '',
 
 				parameters.map ? '#define USE_MAP' : '',
 				parameters.envMap ? '#define USE_ENVMAP' : '',
@@ -17957,6 +18135,11 @@ var Spacekit = (function (exports) {
 				parameters.bumpMap ? '#define USE_BUMPMAP' : '',
 				parameters.normalMap ? '#define USE_NORMALMAP' : '',
 				( parameters.normalMap && parameters.objectSpaceNormalMap ) ? '#define OBJECTSPACE_NORMALMAP' : '',
+				( parameters.normalMap && parameters.tangentSpaceNormalMap ) ? '#define TANGENTSPACE_NORMALMAP' : '',
+
+				parameters.clearcoatMap ? '#define USE_CLEARCOATMAP' : '',
+				parameters.clearcoatRoughnessMap ? '#define USE_CLEARCOAT_ROUGHNESSMAP' : '',
+				parameters.clearcoatNormalMap ? '#define USE_CLEARCOAT_NORMALMAP' : '',
 				parameters.displacementMap && parameters.supportsVertexTextures ? '#define USE_DISPLACEMENTMAP' : '',
 				parameters.specularMap ? '#define USE_SPECULARMAP' : '',
 				parameters.roughnessMap ? '#define USE_ROUGHNESSMAP' : '',
@@ -17965,6 +18148,8 @@ var Spacekit = (function (exports) {
 
 				parameters.vertexTangents ? '#define USE_TANGENT' : '',
 				parameters.vertexColors ? '#define USE_COLOR' : '',
+				parameters.vertexUvs ? '#define USE_UV' : '',
+				parameters.uvsVertexOnly ? '#define UVS_VERTEX_ONLY' : '',
 
 				parameters.flatShading ? '#define FLAT_SHADED' : '',
 
@@ -17982,7 +18167,7 @@ var Spacekit = (function (exports) {
 				parameters.sizeAttenuation ? '#define USE_SIZEATTENUATION' : '',
 
 				parameters.logarithmicDepthBuffer ? '#define USE_LOGDEPTHBUF' : '',
-				parameters.logarithmicDepthBuffer && ( capabilities.isWebGL2 || extensions.get( 'EXT_frag_depth' ) ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
+				( parameters.logarithmicDepthBuffer && parameters.rendererExtensionFragDepth ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
 
 				'uniform mat4 modelMatrix;',
 				'uniform mat4 modelViewMatrix;',
@@ -17990,6 +18175,13 @@ var Spacekit = (function (exports) {
 				'uniform mat4 viewMatrix;',
 				'uniform mat3 normalMatrix;',
 				'uniform vec3 cameraPosition;',
+				'uniform bool isOrthographic;',
+
+				'#ifdef USE_INSTANCING',
+
+				' attribute mat4 instanceMatrix;',
+
+				'#endif',
 
 				'attribute vec3 position;',
 				'attribute vec3 normal;',
@@ -18047,10 +18239,9 @@ var Spacekit = (function (exports) {
 
 				customExtensions,
 
-				'precision ' + parameters.precision + ' float;',
-				'precision ' + parameters.precision + ' int;',
+				generatePrecision( parameters ),
 
-				'#define SHADER_NAME ' + shader.name,
+				'#define SHADER_NAME ' + parameters.shaderName,
 
 				customDefines,
 
@@ -18059,7 +18250,7 @@ var Spacekit = (function (exports) {
 				'#define GAMMA_FACTOR ' + gammaFactorDefine,
 
 				( parameters.useFog && parameters.fog ) ? '#define USE_FOG' : '',
-				( parameters.useFog && parameters.fogExp ) ? '#define FOG_EXP2' : '',
+				( parameters.useFog && parameters.fogExp2 ) ? '#define FOG_EXP2' : '',
 
 				parameters.map ? '#define USE_MAP' : '',
 				parameters.matcap ? '#define USE_MATCAP' : '',
@@ -18073,13 +18264,21 @@ var Spacekit = (function (exports) {
 				parameters.bumpMap ? '#define USE_BUMPMAP' : '',
 				parameters.normalMap ? '#define USE_NORMALMAP' : '',
 				( parameters.normalMap && parameters.objectSpaceNormalMap ) ? '#define OBJECTSPACE_NORMALMAP' : '',
+				( parameters.normalMap && parameters.tangentSpaceNormalMap ) ? '#define TANGENTSPACE_NORMALMAP' : '',
+				parameters.clearcoatMap ? '#define USE_CLEARCOATMAP' : '',
+				parameters.clearcoatRoughnessMap ? '#define USE_CLEARCOAT_ROUGHNESSMAP' : '',
+				parameters.clearcoatNormalMap ? '#define USE_CLEARCOAT_NORMALMAP' : '',
 				parameters.specularMap ? '#define USE_SPECULARMAP' : '',
 				parameters.roughnessMap ? '#define USE_ROUGHNESSMAP' : '',
 				parameters.metalnessMap ? '#define USE_METALNESSMAP' : '',
 				parameters.alphaMap ? '#define USE_ALPHAMAP' : '',
 
+				parameters.sheen ? '#define USE_SHEEN' : '',
+
 				parameters.vertexTangents ? '#define USE_TANGENT' : '',
 				parameters.vertexColors ? '#define USE_COLOR' : '',
+				parameters.vertexUvs ? '#define USE_UV' : '',
+				parameters.uvsVertexOnly ? '#define UVS_VERTEX_ONLY' : '',
 
 				parameters.gradientMap ? '#define USE_GRADIENTMAP' : '',
 
@@ -18096,12 +18295,13 @@ var Spacekit = (function (exports) {
 				parameters.physicallyCorrectLights ? '#define PHYSICALLY_CORRECT_LIGHTS' : '',
 
 				parameters.logarithmicDepthBuffer ? '#define USE_LOGDEPTHBUF' : '',
-				parameters.logarithmicDepthBuffer && ( capabilities.isWebGL2 || extensions.get( 'EXT_frag_depth' ) ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
+				( parameters.logarithmicDepthBuffer && parameters.rendererExtensionFragDepth ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
 
-				parameters.envMap && ( capabilities.isWebGL2 || extensions.get( 'EXT_shader_texture_lod' ) ) ? '#define TEXTURE_LOD_EXT' : '',
+				( ( parameters.extensionShaderTextureLOD || parameters.envMap ) && parameters.rendererExtensionShaderTextureLod ) ? '#define TEXTURE_LOD_EXT' : '',
 
 				'uniform mat4 viewMatrix;',
 				'uniform vec3 cameraPosition;',
+				'uniform bool isOrthographic;',
 
 				( parameters.toneMapping !== NoToneMapping ) ? '#define TONE_MAPPING' : '',
 				( parameters.toneMapping !== NoToneMapping ) ? ShaderChunk[ 'tonemapping_pars_fragment' ] : '', // this code is required here because it is used by the toneMapping() function defined below
@@ -18109,15 +18309,16 @@ var Spacekit = (function (exports) {
 
 				parameters.dithering ? '#define DITHERING' : '',
 
-				( parameters.outputEncoding || parameters.mapEncoding || parameters.matcapEncoding || parameters.envMapEncoding || parameters.emissiveMapEncoding ) ?
+				( parameters.outputEncoding || parameters.mapEncoding || parameters.matcapEncoding || parameters.envMapEncoding || parameters.emissiveMapEncoding || parameters.lightMapEncoding ) ?
 					ShaderChunk[ 'encodings_pars_fragment' ] : '', // this code is required here because it is used by the various encoding/decoding function defined below
 				parameters.mapEncoding ? getTexelDecodingFunction( 'mapTexelToLinear', parameters.mapEncoding ) : '',
 				parameters.matcapEncoding ? getTexelDecodingFunction( 'matcapTexelToLinear', parameters.matcapEncoding ) : '',
 				parameters.envMapEncoding ? getTexelDecodingFunction( 'envMapTexelToLinear', parameters.envMapEncoding ) : '',
 				parameters.emissiveMapEncoding ? getTexelDecodingFunction( 'emissiveMapTexelToLinear', parameters.emissiveMapEncoding ) : '',
+				parameters.lightMapEncoding ? getTexelDecodingFunction( 'lightMapTexelToLinear', parameters.lightMapEncoding ) : '',
 				parameters.outputEncoding ? getTexelEncodingFunction( 'linearToOutputTexel', parameters.outputEncoding ) : '',
 
-				parameters.depthPacking ? '#define DEPTH_PACKING ' + material.depthPacking : '',
+				parameters.depthPacking ? '#define DEPTH_PACKING ' + parameters.depthPacking : '',
 
 				'\n'
 
@@ -18125,24 +18326,24 @@ var Spacekit = (function (exports) {
 
 		}
 
-		vertexShader = parseIncludes( vertexShader );
+		vertexShader = resolveIncludes( vertexShader );
 		vertexShader = replaceLightNums( vertexShader, parameters );
 		vertexShader = replaceClippingPlaneNums( vertexShader, parameters );
 
-		fragmentShader = parseIncludes( fragmentShader );
+		fragmentShader = resolveIncludes( fragmentShader );
 		fragmentShader = replaceLightNums( fragmentShader, parameters );
 		fragmentShader = replaceClippingPlaneNums( fragmentShader, parameters );
 
 		vertexShader = unrollLoops( vertexShader );
 		fragmentShader = unrollLoops( fragmentShader );
 
-		if ( capabilities.isWebGL2 && ! material.isRawShaderMaterial ) {
+		if ( parameters.isWebGL2 && ! parameters.isRawShaderMaterial ) {
 
 			var isGLSL3ShaderMaterial = false;
 
 			var versionRegex = /^\s*#version\s+300\s+es\s*\n/;
 
-			if ( material.isShaderMaterial &&
+			if ( parameters.isShaderMaterial &&
 				vertexShader.match( versionRegex ) !== null &&
 				fragmentShader.match( versionRegex ) !== null ) {
 
@@ -18154,6 +18355,7 @@ var Spacekit = (function (exports) {
 			}
 
 			// GLSL 3.0 conversion
+
 			prefixVertex = [
 				'#version 300 es\n',
 				'#define attribute in',
@@ -18194,9 +18396,9 @@ var Spacekit = (function (exports) {
 
 		// Force a particular attribute to index 0.
 
-		if ( material.index0AttributeName !== undefined ) {
+		if ( parameters.index0AttributeName !== undefined ) {
 
-			gl.bindAttribLocation( program, 0, material.index0AttributeName );
+			gl.bindAttribLocation( program, 0, parameters.index0AttributeName );
 
 		} else if ( parameters.morphTargets === true ) {
 
@@ -18241,7 +18443,6 @@ var Spacekit = (function (exports) {
 				this.diagnostics = {
 
 					runnable: runnable,
-					material: material,
 
 					programLog: programLog,
 
@@ -18265,7 +18466,11 @@ var Spacekit = (function (exports) {
 
 		}
 
-		// clean up
+		// Clean up
+
+		// Crashes in iOS9 and iOS10. #18402
+		// gl.detachShader( program, glVertexShader );
+		// gl.detachShader( program, glFragmentShader );
 
 		gl.deleteShader( glVertexShader );
 		gl.deleteShader( glFragmentShader );
@@ -18313,9 +18518,9 @@ var Spacekit = (function (exports) {
 
 		//
 
-		this.name = shader.name;
+		this.name = parameters.shaderName;
 		this.id = programIdCount ++;
-		this.code = code;
+		this.cacheKey = cacheKey;
 		this.usedTimes = 1;
 		this.program = program;
 		this.vertexShader = glVertexShader;
@@ -18333,6 +18538,13 @@ var Spacekit = (function (exports) {
 
 		var programs = [];
 
+		var isWebGL2 = capabilities.isWebGL2;
+		var logarithmicDepthBuffer = capabilities.logarithmicDepthBuffer;
+		var floatVertexTextures = capabilities.floatVertexTextures;
+		var precision = capabilities.precision;
+		var maxVertexUniforms = capabilities.maxVertexUniforms;
+		var vertexTextures = capabilities.vertexTextures;
+
 		var shaderIDs = {
 			MeshDepthMaterial: 'depth',
 			MeshDistanceMaterial: 'distanceRGBA',
@@ -18340,7 +18552,7 @@ var Spacekit = (function (exports) {
 			MeshBasicMaterial: 'basic',
 			MeshLambertMaterial: 'lambert',
 			MeshPhongMaterial: 'phong',
-			MeshToonMaterial: 'phong',
+			MeshToonMaterial: 'toon',
 			MeshStandardMaterial: 'physical',
 			MeshPhysicalMaterial: 'physical',
 			MeshMatcapMaterial: 'matcap',
@@ -18352,25 +18564,57 @@ var Spacekit = (function (exports) {
 		};
 
 		var parameterNames = [
-			"precision", "supportsVertexTextures", "map", "mapEncoding", "matcap", "matcapEncoding", "envMap", "envMapMode", "envMapEncoding",
-			"lightMap", "aoMap", "emissiveMap", "emissiveMapEncoding", "bumpMap", "normalMap", "objectSpaceNormalMap", "displacementMap", "specularMap",
+			"precision", "isWebGL2", "supportsVertexTextures", "outputEncoding", "instancing",
+			"map", "mapEncoding", "matcap", "matcapEncoding", "envMap", "envMapMode", "envMapEncoding", "envMapCubeUV",
+			"lightMap", "lightMapEncoding", "aoMap", "emissiveMap", "emissiveMapEncoding", "bumpMap", "normalMap", "objectSpaceNormalMap", "tangentSpaceNormalMap", "clearcoatMap", "clearcoatRoughnessMap", "clearcoatNormalMap", "displacementMap", "specularMap",
 			"roughnessMap", "metalnessMap", "gradientMap",
-			"alphaMap", "combine", "vertexColors", "vertexTangents", "fog", "useFog", "fogExp",
+			"alphaMap", "combine", "vertexColors", "vertexTangents", "vertexUvs", "uvsVertexOnly", "fog", "useFog", "fogExp2",
 			"flatShading", "sizeAttenuation", "logarithmicDepthBuffer", "skinning",
 			"maxBones", "useVertexTexture", "morphTargets", "morphNormals",
 			"maxMorphTargets", "maxMorphNormals", "premultipliedAlpha",
 			"numDirLights", "numPointLights", "numSpotLights", "numHemiLights", "numRectAreaLights",
+			"numDirLightShadows", "numPointLightShadows", "numSpotLightShadows",
 			"shadowMapEnabled", "shadowMapType", "toneMapping", 'physicallyCorrectLights',
-			"alphaTest", "doubleSided", "flipSided", "numClippingPlanes", "numClipIntersection", "depthPacking", "dithering"
+			"alphaTest", "doubleSided", "flipSided", "numClippingPlanes", "numClipIntersection", "depthPacking", "dithering",
+			"sheen"
 		];
 
+		function getShaderObject( material, shaderID ) {
+
+			var shaderobject;
+
+			if ( shaderID ) {
+
+				var shader = ShaderLib[ shaderID ];
+
+				shaderobject = {
+					name: material.type,
+					uniforms: UniformsUtils.clone( shader.uniforms ),
+					vertexShader: shader.vertexShader,
+					fragmentShader: shader.fragmentShader
+				};
+
+			} else {
+
+				shaderobject = {
+					name: material.type,
+					uniforms: material.uniforms,
+					vertexShader: material.vertexShader,
+					fragmentShader: material.fragmentShader
+				};
+
+			}
+
+			return shaderobject;
+
+		}
 
 		function allocateBones( object ) {
 
 			var skeleton = object.skeleton;
 			var bones = skeleton.bones;
 
-			if ( capabilities.floatVertexTextures ) {
+			if ( floatVertexTextures ) {
 
 				return 1024;
 
@@ -18383,7 +18627,7 @@ var Spacekit = (function (exports) {
 				//  - limit here is ANGLE's 254 max uniform vectors
 				//    (up to 54 should be safe)
 
-				var nVertexUniforms = capabilities.maxVertexUniforms;
+				var nVertexUniforms = maxVertexUniforms;
 				var nVertexMatrices = Math.floor( ( nVertexUniforms - 20 ) / 4 );
 
 				var maxBones = Math.min( nVertexMatrices, bones.length );
@@ -18401,7 +18645,7 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function getTextureEncodingFromMap( map, gammaOverrideLinear ) {
+		function getTextureEncodingFromMap( map ) {
 
 			var encoding;
 
@@ -18420,18 +18664,16 @@ var Spacekit = (function (exports) {
 
 			}
 
-			// add backwards compatibility for WebGLRenderer.gammaInput/gammaOutput parameter, should probably be removed at some point.
-			if ( encoding === LinearEncoding && gammaOverrideLinear ) {
-
-				encoding = GammaEncoding;
-
-			}
-
 			return encoding;
 
 		}
 
-		this.getParameters = function ( material, lights, shadows, fog, nClipPlanes, nClipIntersection, object ) {
+		this.getParameters = function ( material, lights, shadows, scene, nClipPlanes, nClipIntersection, object ) {
+
+			var fog = scene.fog;
+			var environment = material.isMeshStandardMaterial ? scene.environment : null;
+
+			var envMap = material.envMap || environment;
 
 			var shaderID = shaderIDs[ material.type ];
 
@@ -18439,7 +18681,6 @@ var Spacekit = (function (exports) {
 			// (not to blow over maxLights budget)
 
 			var maxBones = object.isSkinnedMesh ? allocateBones( object ) : 0;
-			var precision = capabilities.precision;
 
 			if ( material.precision !== null ) {
 
@@ -18453,30 +18694,52 @@ var Spacekit = (function (exports) {
 
 			}
 
+			var shaderobject = getShaderObject( material, shaderID );
+			material.onBeforeCompile( shaderobject, renderer );
+
 			var currentRenderTarget = renderer.getRenderTarget();
 
 			var parameters = {
 
+				isWebGL2: isWebGL2,
+
 				shaderID: shaderID,
+				shaderName: shaderobject.name,
+
+				uniforms: shaderobject.uniforms,
+				vertexShader: shaderobject.vertexShader,
+				fragmentShader: shaderobject.fragmentShader,
+				defines: material.defines,
+
+				isRawShaderMaterial: material.isRawShaderMaterial,
+				isShaderMaterial: material.isShaderMaterial,
 
 				precision: precision,
-				supportsVertexTextures: capabilities.vertexTextures,
-				outputEncoding: getTextureEncodingFromMap( ( ! currentRenderTarget ) ? null : currentRenderTarget.texture, renderer.gammaOutput ),
+
+				instancing: object.isInstancedMesh === true,
+
+				supportsVertexTextures: vertexTextures,
+				outputEncoding: ( currentRenderTarget !== null ) ? getTextureEncodingFromMap( currentRenderTarget.texture ) : renderer.outputEncoding,
 				map: !! material.map,
-				mapEncoding: getTextureEncodingFromMap( material.map, renderer.gammaInput ),
+				mapEncoding: getTextureEncodingFromMap( material.map ),
 				matcap: !! material.matcap,
-				matcapEncoding: getTextureEncodingFromMap( material.matcap, renderer.gammaInput ),
-				envMap: !! material.envMap,
-				envMapMode: material.envMap && material.envMap.mapping,
-				envMapEncoding: getTextureEncodingFromMap( material.envMap, renderer.gammaInput ),
-				envMapCubeUV: ( !! material.envMap ) && ( ( material.envMap.mapping === CubeUVReflectionMapping ) || ( material.envMap.mapping === CubeUVRefractionMapping ) ),
+				matcapEncoding: getTextureEncodingFromMap( material.matcap ),
+				envMap: !! envMap,
+				envMapMode: envMap && envMap.mapping,
+				envMapEncoding: getTextureEncodingFromMap( envMap ),
+				envMapCubeUV: ( !! envMap ) && ( ( envMap.mapping === CubeUVReflectionMapping ) || ( envMap.mapping === CubeUVRefractionMapping ) ),
 				lightMap: !! material.lightMap,
+				lightMapEncoding: getTextureEncodingFromMap( material.lightMap ),
 				aoMap: !! material.aoMap,
 				emissiveMap: !! material.emissiveMap,
-				emissiveMapEncoding: getTextureEncodingFromMap( material.emissiveMap, renderer.gammaInput ),
+				emissiveMapEncoding: getTextureEncodingFromMap( material.emissiveMap ),
 				bumpMap: !! material.bumpMap,
 				normalMap: !! material.normalMap,
 				objectSpaceNormalMap: material.normalMapType === ObjectSpaceNormalMap,
+				tangentSpaceNormalMap: material.normalMapType === TangentSpaceNormalMap,
+				clearcoatMap: !! material.clearcoatMap,
+				clearcoatRoughnessMap: !! material.clearcoatRoughnessMap,
+				clearcoatNormalMap: !! material.clearcoatNormalMap,
 				displacementMap: !! material.displacementMap,
 				roughnessMap: !! material.roughnessMap,
 				metalnessMap: !! material.metalnessMap,
@@ -18485,23 +18748,27 @@ var Spacekit = (function (exports) {
 
 				gradientMap: !! material.gradientMap,
 
+				sheen: !! material.sheen,
+
 				combine: material.combine,
 
 				vertexTangents: ( material.normalMap && material.vertexTangents ),
 				vertexColors: material.vertexColors,
+				vertexUvs: !! material.map || !! material.bumpMap || !! material.normalMap || !! material.specularMap || !! material.alphaMap || !! material.emissiveMap || !! material.roughnessMap || !! material.metalnessMap || !! material.clearcoatMap || !! material.clearcoatRoughnessMap || !! material.clearcoatNormalMap || !! material.displacementMap,
+				uvsVertexOnly: ! ( !! material.map || !! material.bumpMap || !! material.normalMap || !! material.specularMap || !! material.alphaMap || !! material.emissiveMap || !! material.roughnessMap || !! material.metalnessMap || !! material.clearcoatNormalMap ) && !! material.displacementMap,
 
 				fog: !! fog,
 				useFog: material.fog,
-				fogExp: ( fog && fog.isFogExp2 ),
+				fogExp2: ( fog && fog.isFogExp2 ),
 
 				flatShading: material.flatShading,
 
 				sizeAttenuation: material.sizeAttenuation,
-				logarithmicDepthBuffer: capabilities.logarithmicDepthBuffer,
+				logarithmicDepthBuffer: logarithmicDepthBuffer,
 
 				skinning: material.skinning && maxBones > 0,
 				maxBones: maxBones,
-				useVertexTexture: capabilities.floatVertexTextures,
+				useVertexTexture: floatVertexTextures,
 
 				morphTargets: material.morphTargets,
 				morphNormals: material.morphNormals,
@@ -18514,15 +18781,19 @@ var Spacekit = (function (exports) {
 				numRectAreaLights: lights.rectArea.length,
 				numHemiLights: lights.hemi.length,
 
+				numDirLightShadows: lights.directionalShadowMap.length,
+				numPointLightShadows: lights.pointShadowMap.length,
+				numSpotLightShadows: lights.spotShadowMap.length,
+
 				numClippingPlanes: nClipPlanes,
 				numClipIntersection: nClipIntersection,
 
 				dithering: material.dithering,
 
-				shadowMapEnabled: renderer.shadowMap.enabled && object.receiveShadow && shadows.length > 0,
+				shadowMapEnabled: renderer.shadowMap.enabled && shadows.length > 0,
 				shadowMapType: renderer.shadowMap.type,
 
-				toneMapping: renderer.toneMapping,
+				toneMapping: material.toneMapped ? renderer.toneMapping : NoToneMapping,
 				physicallyCorrectLights: renderer.physicallyCorrectLights,
 
 				premultipliedAlpha: material.premultipliedAlpha,
@@ -18531,7 +18802,20 @@ var Spacekit = (function (exports) {
 				doubleSided: material.side === DoubleSide,
 				flipSided: material.side === BackSide,
 
-				depthPacking: ( material.depthPacking !== undefined ) ? material.depthPacking : false
+				depthPacking: ( material.depthPacking !== undefined ) ? material.depthPacking : false,
+
+				index0AttributeName: material.index0AttributeName,
+
+				extensionDerivatives: material.extensions && material.extensions.derivatives,
+				extensionFragDepth: material.extensions && material.extensions.fragDepth,
+				extensionDrawBuffers: material.extensions && material.extensions.drawBuffers,
+				extensionShaderTextureLOD: material.extensions && material.extensions.shaderTextureLOD,
+
+				rendererExtensionFragDepth: isWebGL2 || extensions.get( 'EXT_frag_depth' ) !== null,
+				rendererExtensionDrawBuffers: isWebGL2 || extensions.get( 'WEBGL_draw_buffers' ) !== null,
+				rendererExtensionShaderTextureLod: isWebGL2 || extensions.get( 'EXT_shader_texture_lod' ) !== null,
+
+				onBeforeCompile: material.onBeforeCompile
 
 			};
 
@@ -18539,7 +18823,7 @@ var Spacekit = (function (exports) {
 
 		};
 
-		this.getProgramCode = function ( material, parameters ) {
+		this.getProgramCacheKey = function ( parameters ) {
 
 			var array = [];
 
@@ -18549,50 +18833,53 @@ var Spacekit = (function (exports) {
 
 			} else {
 
-				array.push( material.fragmentShader );
-				array.push( material.vertexShader );
+				array.push( parameters.fragmentShader );
+				array.push( parameters.vertexShader );
 
 			}
 
-			if ( material.defines !== undefined ) {
+			if ( parameters.defines !== undefined ) {
 
-				for ( var name in material.defines ) {
+				for ( var name in parameters.defines ) {
 
 					array.push( name );
-					array.push( material.defines[ name ] );
+					array.push( parameters.defines[ name ] );
 
 				}
 
 			}
 
-			for ( var i = 0; i < parameterNames.length; i ++ ) {
+			if ( parameters.isRawShaderMaterial === undefined ) {
 
-				array.push( parameters[ parameterNames[ i ] ] );
+				for ( var i = 0; i < parameterNames.length; i ++ ) {
+
+					array.push( parameters[ parameterNames[ i ] ] );
+
+				}
+
+				array.push( renderer.outputEncoding );
+				array.push( renderer.gammaFactor );
 
 			}
 
-			array.push( material.onBeforeCompile.toString() );
-
-			array.push( renderer.gammaOutput );
-
-			array.push( renderer.gammaFactor );
+			array.push( parameters.onBeforeCompile.toString() );
 
 			return array.join();
 
 		};
 
-		this.acquireProgram = function ( material, shader, parameters, code ) {
+		this.acquireProgram = function ( parameters, cacheKey ) {
 
 			var program;
 
 			// Check if code has been already compiled
 			for ( var p = 0, pl = programs.length; p < pl; p ++ ) {
 
-				var programInfo = programs[ p ];
+				var preexistingProgram = programs[ p ];
 
-				if ( programInfo.code === code ) {
+				if ( preexistingProgram.cacheKey === cacheKey ) {
 
-					program = programInfo;
+					program = preexistingProgram;
 					++ program.usedTimes;
 
 					break;
@@ -18603,7 +18890,7 @@ var Spacekit = (function (exports) {
 
 			if ( program === undefined ) {
 
-				program = new WebGLProgram( renderer, extensions, code, material, shader, parameters, capabilities );
+				program = new WebGLProgram( renderer, cacheKey, parameters );
 				programs.push( program );
 
 			}
@@ -18815,10 +19102,31 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function sort() {
+		function sort( customOpaqueSort, customTransparentSort ) {
 
-			if ( opaque.length > 1 ) opaque.sort( painterSortStable );
-			if ( transparent.length > 1 ) transparent.sort( reversePainterSortStable );
+			if ( opaque.length > 1 ) opaque.sort( customOpaqueSort || painterSortStable );
+			if ( transparent.length > 1 ) transparent.sort( customTransparentSort || reversePainterSortStable );
+
+		}
+
+		function finish() {
+
+			// Clear references from inactive renderItems in the list
+
+			for ( var i = renderItemsIndex, il = renderItems.length; i < il; i ++ ) {
+
+				var renderItem = renderItems[ i ];
+
+				if ( renderItem.id === null ) break;
+
+				renderItem.id = null;
+				renderItem.object = null;
+				renderItem.geometry = null;
+				renderItem.material = null;
+				renderItem.program = null;
+				renderItem.group = null;
+
+			}
 
 		}
 
@@ -18829,6 +19137,7 @@ var Spacekit = (function (exports) {
 			init: init,
 			push: push,
 			unshift: unshift,
+			finish: finish,
 
 			sort: sort
 		};
@@ -18837,7 +19146,7 @@ var Spacekit = (function (exports) {
 
 	function WebGLRenderLists() {
 
-		var lists = {};
+		var lists = new WeakMap();
 
 		function onSceneDispose( event ) {
 
@@ -18845,29 +19154,29 @@ var Spacekit = (function (exports) {
 
 			scene.removeEventListener( 'dispose', onSceneDispose );
 
-			delete lists[ scene.id ];
+			lists.delete( scene );
 
 		}
 
 		function get( scene, camera ) {
 
-			var cameras = lists[ scene.id ];
+			var cameras = lists.get( scene );
 			var list;
 			if ( cameras === undefined ) {
 
 				list = new WebGLRenderList();
-				lists[ scene.id ] = {};
-				lists[ scene.id ][ camera.id ] = list;
+				lists.set( scene, new WeakMap() );
+				lists.get( scene ).set( camera, list );
 
 				scene.addEventListener( 'dispose', onSceneDispose );
 
 			} else {
 
-				list = cameras[ camera.id ];
+				list = cameras.get( camera );
 				if ( list === undefined ) {
 
 					list = new WebGLRenderList();
-					cameras[ camera.id ] = list;
+					cameras.set( camera, list );
 
 				}
 
@@ -18879,7 +19188,7 @@ var Spacekit = (function (exports) {
 
 		function dispose() {
 
-			lists = {};
+			lists = new WeakMap();
 
 		}
 
@@ -18915,12 +19224,7 @@ var Spacekit = (function (exports) {
 					case 'DirectionalLight':
 						uniforms = {
 							direction: new Vector3(),
-							color: new Color(),
-
-							shadow: false,
-							shadowBias: 0,
-							shadowRadius: 1,
-							shadowMapSize: new Vector2()
+							color: new Color()
 						};
 						break;
 
@@ -18932,12 +19236,7 @@ var Spacekit = (function (exports) {
 							distance: 0,
 							coneCos: 0,
 							penumbraCos: 0,
-							decay: 0,
-
-							shadow: false,
-							shadowBias: 0,
-							shadowRadius: 1,
-							shadowMapSize: new Vector2()
+							decay: 0
 						};
 						break;
 
@@ -18946,14 +19245,7 @@ var Spacekit = (function (exports) {
 							position: new Vector3(),
 							color: new Color(),
 							distance: 0,
-							decay: 0,
-
-							shadow: false,
-							shadowBias: 0,
-							shadowRadius: 1,
-							shadowMapSize: new Vector2(),
-							shadowCameraNear: 1,
-							shadowCameraFar: 1000
+							decay: 0
 						};
 						break;
 
@@ -18971,7 +19263,6 @@ var Spacekit = (function (exports) {
 							position: new Vector3(),
 							halfWidth: new Vector3(),
 							halfHeight: new Vector3()
-							// TODO (abelnation): set RectAreaLight shadow uniforms
 						};
 						break;
 
@@ -18987,11 +19278,79 @@ var Spacekit = (function (exports) {
 
 	}
 
+	function ShadowUniformsCache() {
+
+		var lights = {};
+
+		return {
+
+			get: function ( light ) {
+
+				if ( lights[ light.id ] !== undefined ) {
+
+					return lights[ light.id ];
+
+				}
+
+				var uniforms;
+
+				switch ( light.type ) {
+
+					case 'DirectionalLight':
+						uniforms = {
+							shadowBias: 0,
+							shadowRadius: 1,
+							shadowMapSize: new Vector2()
+						};
+						break;
+
+					case 'SpotLight':
+						uniforms = {
+							shadowBias: 0,
+							shadowRadius: 1,
+							shadowMapSize: new Vector2()
+						};
+						break;
+
+					case 'PointLight':
+						uniforms = {
+							shadowBias: 0,
+							shadowRadius: 1,
+							shadowMapSize: new Vector2(),
+							shadowCameraNear: 1,
+							shadowCameraFar: 1000
+						};
+						break;
+
+					// TODO (abelnation): set RectAreaLight shadow uniforms
+
+				}
+
+				lights[ light.id ] = uniforms;
+
+				return uniforms;
+
+			}
+
+		};
+
+	}
+
+
+
 	var nextVersion = 0;
+
+	function shadowCastingLightsFirst( lightA, lightB ) {
+
+		return ( lightB.castShadow ? 1 : 0 ) - ( lightA.castShadow ? 1 : 0 );
+
+	}
 
 	function WebGLLights() {
 
 		var cache = new UniformsCache();
+
+		var shadowCache = ShadowUniformsCache();
 
 		var state = {
 
@@ -19003,19 +19362,25 @@ var Spacekit = (function (exports) {
 				spotLength: - 1,
 				rectAreaLength: - 1,
 				hemiLength: - 1,
-				shadowsLength: - 1,
+
+				numDirectionalShadows: - 1,
+				numPointShadows: - 1,
+				numSpotShadows: - 1
 			},
 
 			ambient: [ 0, 0, 0 ],
 			probe: [],
 			directional: [],
+			directionalShadow: [],
 			directionalShadowMap: [],
 			directionalShadowMatrix: [],
 			spot: [],
+			spotShadow: [],
 			spotShadowMap: [],
 			spotShadowMatrix: [],
 			rectArea: [],
 			point: [],
+			pointShadow: [],
 			pointShadowMap: [],
 			pointShadowMatrix: [],
 			hemi: []
@@ -19040,7 +19405,13 @@ var Spacekit = (function (exports) {
 			var rectAreaLength = 0;
 			var hemiLength = 0;
 
+			var numDirectionalShadows = 0;
+			var numPointShadows = 0;
+			var numSpotShadows = 0;
+
 			var viewMatrix = camera.matrixWorldInverse;
+
+			lights.sort( shadowCastingLightsFirst );
 
 			for ( var i = 0, l = lights.length; i < l; i ++ ) {
 
@@ -19076,20 +19447,24 @@ var Spacekit = (function (exports) {
 					uniforms.direction.sub( vector3 );
 					uniforms.direction.transformDirection( viewMatrix );
 
-					uniforms.shadow = light.castShadow;
-
 					if ( light.castShadow ) {
 
 						var shadow = light.shadow;
 
-						uniforms.shadowBias = shadow.bias;
-						uniforms.shadowRadius = shadow.radius;
-						uniforms.shadowMapSize = shadow.mapSize;
+						var shadowUniforms = shadowCache.get( light );
+
+						shadowUniforms.shadowBias = shadow.bias;
+						shadowUniforms.shadowRadius = shadow.radius;
+						shadowUniforms.shadowMapSize = shadow.mapSize;
+
+						state.directionalShadow[ directionalLength ] = shadowUniforms;
+						state.directionalShadowMap[ directionalLength ] = shadowMap;
+						state.directionalShadowMatrix[ directionalLength ] = light.shadow.matrix;
+
+						numDirectionalShadows ++;
 
 					}
 
-					state.directionalShadowMap[ directionalLength ] = shadowMap;
-					state.directionalShadowMatrix[ directionalLength ] = light.shadow.matrix;
 					state.directional[ directionalLength ] = uniforms;
 
 					directionalLength ++;
@@ -19113,20 +19488,24 @@ var Spacekit = (function (exports) {
 					uniforms.penumbraCos = Math.cos( light.angle * ( 1 - light.penumbra ) );
 					uniforms.decay = light.decay;
 
-					uniforms.shadow = light.castShadow;
-
 					if ( light.castShadow ) {
 
 						var shadow = light.shadow;
 
-						uniforms.shadowBias = shadow.bias;
-						uniforms.shadowRadius = shadow.radius;
-						uniforms.shadowMapSize = shadow.mapSize;
+						var shadowUniforms = shadowCache.get( light );
+
+						shadowUniforms.shadowBias = shadow.bias;
+						shadowUniforms.shadowRadius = shadow.radius;
+						shadowUniforms.shadowMapSize = shadow.mapSize;
+
+						state.spotShadow[ spotLength ] = shadowUniforms;
+						state.spotShadowMap[ spotLength ] = shadowMap;
+						state.spotShadowMatrix[ spotLength ] = light.shadow.matrix;
+
+						numSpotShadows ++;
 
 					}
 
-					state.spotShadowMap[ spotLength ] = shadowMap;
-					state.spotShadowMatrix[ spotLength ] = light.shadow.matrix;
 					state.spot[ spotLength ] = uniforms;
 
 					spotLength ++;
@@ -19174,22 +19553,26 @@ var Spacekit = (function (exports) {
 					uniforms.distance = light.distance;
 					uniforms.decay = light.decay;
 
-					uniforms.shadow = light.castShadow;
-
 					if ( light.castShadow ) {
 
 						var shadow = light.shadow;
 
-						uniforms.shadowBias = shadow.bias;
-						uniforms.shadowRadius = shadow.radius;
-						uniforms.shadowMapSize = shadow.mapSize;
-						uniforms.shadowCameraNear = shadow.camera.near;
-						uniforms.shadowCameraFar = shadow.camera.far;
+						var shadowUniforms = shadowCache.get( light );
+
+						shadowUniforms.shadowBias = shadow.bias;
+						shadowUniforms.shadowRadius = shadow.radius;
+						shadowUniforms.shadowMapSize = shadow.mapSize;
+						shadowUniforms.shadowCameraNear = shadow.camera.near;
+						shadowUniforms.shadowCameraFar = shadow.camera.far;
+
+						state.pointShadow[ pointLength ] = shadowUniforms;
+						state.pointShadowMap[ pointLength ] = shadowMap;
+						state.pointShadowMatrix[ pointLength ] = light.shadow.matrix;
+
+						numPointShadows ++;
 
 					}
 
-					state.pointShadowMap[ pointLength ] = shadowMap;
-					state.pointShadowMatrix[ pointLength ] = light.shadow.matrix;
 					state.point[ pointLength ] = uniforms;
 
 					pointLength ++;
@@ -19224,7 +19607,9 @@ var Spacekit = (function (exports) {
 				hash.spotLength !== spotLength ||
 				hash.rectAreaLength !== rectAreaLength ||
 				hash.hemiLength !== hemiLength ||
-				hash.shadowsLength !== shadows.length ) {
+				hash.numDirectionalShadows !== numDirectionalShadows ||
+				hash.numPointShadows !== numPointShadows ||
+				hash.numSpotShadows !== numSpotShadows ) {
 
 				state.directional.length = directionalLength;
 				state.spot.length = spotLength;
@@ -19232,12 +19617,25 @@ var Spacekit = (function (exports) {
 				state.point.length = pointLength;
 				state.hemi.length = hemiLength;
 
+				state.directionalShadow.length = numDirectionalShadows;
+				state.directionalShadowMap.length = numDirectionalShadows;
+				state.pointShadow.length = numPointShadows;
+				state.pointShadowMap.length = numPointShadows;
+				state.spotShadow.length = numSpotShadows;
+				state.spotShadowMap.length = numSpotShadows;
+				state.directionalShadowMatrix.length = numDirectionalShadows;
+				state.pointShadowMatrix.length = numPointShadows;
+				state.spotShadowMatrix.length = numSpotShadows;
+
 				hash.directionalLength = directionalLength;
 				hash.pointLength = pointLength;
 				hash.spotLength = spotLength;
 				hash.rectAreaLength = rectAreaLength;
 				hash.hemiLength = hemiLength;
-				hash.shadowsLength = shadows.length;
+
+				hash.numDirectionalShadows = numDirectionalShadows;
+				hash.numPointShadows = numPointShadows;
+				hash.numSpotShadows = numSpotShadows;
 
 				state.version = nextVersion ++;
 
@@ -19308,7 +19706,7 @@ var Spacekit = (function (exports) {
 
 	function WebGLRenderStates() {
 
-		var renderStates = {};
+		var renderStates = new WeakMap();
 
 		function onSceneDispose( event ) {
 
@@ -19316,7 +19714,7 @@ var Spacekit = (function (exports) {
 
 			scene.removeEventListener( 'dispose', onSceneDispose );
 
-			delete renderStates[ scene.id ];
+			renderStates.delete( scene );
 
 		}
 
@@ -19324,24 +19722,24 @@ var Spacekit = (function (exports) {
 
 			var renderState;
 
-			if ( renderStates[ scene.id ] === undefined ) {
+			if ( renderStates.has( scene ) === false ) {
 
 				renderState = new WebGLRenderState();
-				renderStates[ scene.id ] = {};
-				renderStates[ scene.id ][ camera.id ] = renderState;
+				renderStates.set( scene, new WeakMap() );
+				renderStates.get( scene ).set( camera, renderState );
 
 				scene.addEventListener( 'dispose', onSceneDispose );
 
 			} else {
 
-				if ( renderStates[ scene.id ][ camera.id ] === undefined ) {
+				if ( renderStates.get( scene ).has( camera ) === false ) {
 
 					renderState = new WebGLRenderState();
-					renderStates[ scene.id ][ camera.id ] = renderState;
+					renderStates.get( scene ).set( camera, renderState );
 
 				} else {
 
-					renderState = renderStates[ scene.id ][ camera.id ];
+					renderState = renderStates.get( scene ).get( camera );
 
 				}
 
@@ -19353,7 +19751,7 @@ var Spacekit = (function (exports) {
 
 		function dispose() {
 
-			renderStates = {};
+			renderStates = new WeakMap();
 
 		}
 
@@ -19410,7 +19808,6 @@ var Spacekit = (function (exports) {
 		this.wireframeLinewidth = 1;
 
 		this.fog = false;
-		this.lights = false;
 
 		this.setValues( parameters );
 
@@ -19490,7 +19887,6 @@ var Spacekit = (function (exports) {
 		this.displacementBias = 0;
 
 		this.fog = false;
-		this.lights = false;
 
 		this.setValues( parameters );
 
@@ -19524,6 +19920,10 @@ var Spacekit = (function (exports) {
 
 	};
 
+	var vsm_frag = "uniform sampler2D shadow_pass;\nuniform vec2 resolution;\nuniform float radius;\n#include <packing>\nvoid main() {\n  float mean = 0.0;\n  float squared_mean = 0.0;\n\tfloat depth = unpackRGBAToDepth( texture2D( shadow_pass, ( gl_FragCoord.xy  ) / resolution ) );\n  for ( float i = -1.0; i < 1.0 ; i += SAMPLE_RATE) {\n    #ifdef HORIZONAL_PASS\n      vec2 distribution = unpackRGBATo2Half( texture2D( shadow_pass, ( gl_FragCoord.xy + vec2( i, 0.0 ) * radius ) / resolution ) );\n      mean += distribution.x;\n      squared_mean += distribution.y * distribution.y + distribution.x * distribution.x;\n    #else\n      float depth = unpackRGBAToDepth( texture2D( shadow_pass, ( gl_FragCoord.xy + vec2( 0.0,  i )  * radius ) / resolution ) );\n      mean += depth;\n      squared_mean += depth * depth;\n    #endif\n  }\n  mean = mean * HALF_SAMPLE_RATE;\n  squared_mean = squared_mean * HALF_SAMPLE_RATE;\n  float std_dev = sqrt( squared_mean - mean * mean );\n  gl_FragColor = pack2HalfToRGBA( vec2( mean, std_dev ) );\n}";
+
+	var vsm_vert = "void main() {\n\tgl_Position = vec4( position, 1.0 );\n}";
+
 	/**
 	 * @author alteredq / http://alteredqualia.com/
 	 * @author mrdoob / http://mrdoob.com/
@@ -19532,73 +19932,51 @@ var Spacekit = (function (exports) {
 	function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 		var _frustum = new Frustum(),
-			_projScreenMatrix = new Matrix4(),
 
 			_shadowMapSize = new Vector2(),
-			_maxShadowMapSize = new Vector2( maxTextureSize, maxTextureSize ),
+			_viewportSize = new Vector2(),
 
-			_lookTarget = new Vector3(),
-			_lightPositionWorld = new Vector3(),
+			_viewport = new Vector4(),
 
-			_MorphingFlag = 1,
-			_SkinningFlag = 2,
-
-			_NumberOfMaterialVariants = ( _MorphingFlag | _SkinningFlag ) + 1,
-
-			_depthMaterials = new Array( _NumberOfMaterialVariants ),
-			_distanceMaterials = new Array( _NumberOfMaterialVariants ),
+			_depthMaterials = [],
+			_distanceMaterials = [],
 
 			_materialCache = {};
 
 		var shadowSide = { 0: BackSide, 1: FrontSide, 2: DoubleSide };
 
-		var cubeDirections = [
-			new Vector3( 1, 0, 0 ), new Vector3( - 1, 0, 0 ), new Vector3( 0, 0, 1 ),
-			new Vector3( 0, 0, - 1 ), new Vector3( 0, 1, 0 ), new Vector3( 0, - 1, 0 )
-		];
+		var shadowMaterialVertical = new ShaderMaterial( {
 
-		var cubeUps = [
-			new Vector3( 0, 1, 0 ), new Vector3( 0, 1, 0 ), new Vector3( 0, 1, 0 ),
-			new Vector3( 0, 1, 0 ), new Vector3( 0, 0, 1 ),	new Vector3( 0, 0, - 1 )
-		];
+			defines: {
+				SAMPLE_RATE: 2.0 / 8.0,
+				HALF_SAMPLE_RATE: 1.0 / 8.0
+			},
 
-		var cube2DViewPorts = [
-			new Vector4(), new Vector4(), new Vector4(),
-			new Vector4(), new Vector4(), new Vector4()
-		];
+			uniforms: {
+				shadow_pass: { value: null },
+				resolution: { value: new Vector2() },
+				radius: { value: 4.0 }
+			},
 
-		// init
+			vertexShader: vsm_vert,
 
-		for ( var i = 0; i !== _NumberOfMaterialVariants; ++ i ) {
+			fragmentShader: vsm_frag
 
-			var useMorphing = ( i & _MorphingFlag ) !== 0;
-			var useSkinning = ( i & _SkinningFlag ) !== 0;
+		} );
 
-			var depthMaterial = new MeshDepthMaterial( {
+		var shadowMaterialHorizonal = shadowMaterialVertical.clone();
+		shadowMaterialHorizonal.defines.HORIZONAL_PASS = 1;
 
-				depthPacking: RGBADepthPacking,
+		var fullScreenTri = new BufferGeometry();
+		fullScreenTri.setAttribute(
+			"position",
+			new BufferAttribute(
+				new Float32Array( [ - 1, - 1, 0.5, 3, - 1, 0.5, - 1, 3, 0.5 ] ),
+				3
+			)
+		);
 
-				morphTargets: useMorphing,
-				skinning: useSkinning
-
-			} );
-
-			_depthMaterials[ i ] = depthMaterial;
-
-			//
-
-			var distanceMaterial = new MeshDistanceMaterial( {
-
-				morphTargets: useMorphing,
-				skinning: useSkinning
-
-			} );
-
-			_distanceMaterials[ i ] = distanceMaterial;
-
-		}
-
-		//
+		var fullScreenMesh = new Mesh( fullScreenTri, shadowMaterialVertical );
 
 		var scope = this;
 
@@ -19630,13 +20008,10 @@ var Spacekit = (function (exports) {
 
 			// render depth map
 
-			var faceCount;
-
 			for ( var i = 0, il = lights.length; i < il; i ++ ) {
 
 				var light = lights[ i ];
 				var shadow = light.shadow;
-				var isPointLight = light && light.isPointLight;
 
 				if ( shadow === undefined ) {
 
@@ -19645,44 +20020,44 @@ var Spacekit = (function (exports) {
 
 				}
 
-				var shadowCamera = shadow.camera;
-
 				_shadowMapSize.copy( shadow.mapSize );
-				_shadowMapSize.min( _maxShadowMapSize );
 
-				if ( isPointLight ) {
+				var shadowFrameExtents = shadow.getFrameExtents();
 
-					var vpWidth = _shadowMapSize.x;
-					var vpHeight = _shadowMapSize.y;
+				_shadowMapSize.multiply( shadowFrameExtents );
 
-					// These viewports map a cube-map onto a 2D texture with the
-					// following orientation:
-					//
-					//  xzXZ
-					//   y Y
-					//
-					// X - Positive x direction
-					// x - Negative x direction
-					// Y - Positive y direction
-					// y - Negative y direction
-					// Z - Positive z direction
-					// z - Negative z direction
+				_viewportSize.copy( shadow.mapSize );
 
-					// positive X
-					cube2DViewPorts[ 0 ].set( vpWidth * 2, vpHeight, vpWidth, vpHeight );
-					// negative X
-					cube2DViewPorts[ 1 ].set( 0, vpHeight, vpWidth, vpHeight );
-					// positive Z
-					cube2DViewPorts[ 2 ].set( vpWidth * 3, vpHeight, vpWidth, vpHeight );
-					// negative Z
-					cube2DViewPorts[ 3 ].set( vpWidth, vpHeight, vpWidth, vpHeight );
-					// positive Y
-					cube2DViewPorts[ 4 ].set( vpWidth * 3, 0, vpWidth, vpHeight );
-					// negative Y
-					cube2DViewPorts[ 5 ].set( vpWidth, 0, vpWidth, vpHeight );
+				if ( _shadowMapSize.x > maxTextureSize || _shadowMapSize.y > maxTextureSize ) {
 
-					_shadowMapSize.x *= 4.0;
-					_shadowMapSize.y *= 2.0;
+					if ( _shadowMapSize.x > maxTextureSize ) {
+
+						_viewportSize.x = Math.floor( maxTextureSize / shadowFrameExtents.x );
+						_shadowMapSize.x = _viewportSize.x * shadowFrameExtents.x;
+						shadow.mapSize.x = _viewportSize.x;
+
+					}
+
+					if ( _shadowMapSize.y > maxTextureSize ) {
+
+						_viewportSize.y = Math.floor( maxTextureSize / shadowFrameExtents.y );
+						_shadowMapSize.y = _viewportSize.y * shadowFrameExtents.y;
+						shadow.mapSize.y = _viewportSize.y;
+
+					}
+
+				}
+
+				if ( shadow.map === null && ! shadow.isPointLightShadow && this.type === VSMShadowMap ) {
+
+					var pars = { minFilter: LinearFilter, magFilter: LinearFilter, format: RGBAFormat };
+
+					shadow.map = new WebGLRenderTarget( _shadowMapSize.x, _shadowMapSize.y, pars );
+					shadow.map.texture.name = light.name + ".shadowMap";
+
+					shadow.mapPass = new WebGLRenderTarget( _shadowMapSize.x, _shadowMapSize.y, pars );
+
+					shadow.camera.updateProjectionMatrix();
 
 				}
 
@@ -19693,82 +20068,41 @@ var Spacekit = (function (exports) {
 					shadow.map = new WebGLRenderTarget( _shadowMapSize.x, _shadowMapSize.y, pars );
 					shadow.map.texture.name = light.name + ".shadowMap";
 
-					shadowCamera.updateProjectionMatrix();
+					shadow.camera.updateProjectionMatrix();
 
 				}
 
-				if ( shadow.isSpotLightShadow ) {
-
-					shadow.update( light );
-
-				}
-
-				var shadowMap = shadow.map;
-				var shadowMatrix = shadow.matrix;
-
-				_lightPositionWorld.setFromMatrixPosition( light.matrixWorld );
-				shadowCamera.position.copy( _lightPositionWorld );
-
-				if ( isPointLight ) {
-
-					faceCount = 6;
-
-					// for point lights we set the shadow matrix to be a translation-only matrix
-					// equal to inverse of the light's position
-
-					shadowMatrix.makeTranslation( - _lightPositionWorld.x, - _lightPositionWorld.y, - _lightPositionWorld.z );
-
-				} else {
-
-					faceCount = 1;
-
-					_lookTarget.setFromMatrixPosition( light.target.matrixWorld );
-					shadowCamera.lookAt( _lookTarget );
-					shadowCamera.updateMatrixWorld();
-
-					// compute shadow matrix
-
-					shadowMatrix.set(
-						0.5, 0.0, 0.0, 0.5,
-						0.0, 0.5, 0.0, 0.5,
-						0.0, 0.0, 0.5, 0.5,
-						0.0, 0.0, 0.0, 1.0
-					);
-
-					shadowMatrix.multiply( shadowCamera.projectionMatrix );
-					shadowMatrix.multiply( shadowCamera.matrixWorldInverse );
-
-				}
-
-				_renderer.setRenderTarget( shadowMap );
+				_renderer.setRenderTarget( shadow.map );
 				_renderer.clear();
 
-				// render shadow map for each cube face (if omni-directional) or
-				// run a single pass if not
+				var viewportCount = shadow.getViewportCount();
 
-				for ( var face = 0; face < faceCount; face ++ ) {
+				for ( var vp = 0; vp < viewportCount; vp ++ ) {
 
-					if ( isPointLight ) {
+					var viewport = shadow.getViewport( vp );
 
-						_lookTarget.copy( shadowCamera.position );
-						_lookTarget.add( cubeDirections[ face ] );
-						shadowCamera.up.copy( cubeUps[ face ] );
-						shadowCamera.lookAt( _lookTarget );
-						shadowCamera.updateMatrixWorld();
+					_viewport.set(
+						_viewportSize.x * viewport.x,
+						_viewportSize.y * viewport.y,
+						_viewportSize.x * viewport.z,
+						_viewportSize.y * viewport.w
+					);
 
-						var vpDimensions = cube2DViewPorts[ face ];
-						_state.viewport( vpDimensions );
+					_state.viewport( _viewport );
 
-					}
+					shadow.updateMatrices( light, vp );
 
-					// update camera matrices and frustum
+					_frustum = shadow.getFrustum();
 
-					_projScreenMatrix.multiplyMatrices( shadowCamera.projectionMatrix, shadowCamera.matrixWorldInverse );
-					_frustum.setFromMatrix( _projScreenMatrix );
+					renderObject( scene, camera, shadow.camera, light, this.type );
 
-					// set object matrices & frustum culling
+				}
 
-					renderObject( scene, camera, shadowCamera, isPointLight );
+				// do blur pass for VSM
+
+				if ( ! shadow.isPointLightShadow && this.type === VSMShadowMap ) {
+
+					VSMPass( shadow, camera );
 
 				}
 
@@ -19780,54 +20114,121 @@ var Spacekit = (function (exports) {
 
 		};
 
-		function getDepthMaterial( object, material, isPointLight, lightPositionWorld, shadowCameraNear, shadowCameraFar ) {
+		function VSMPass( shadow, camera ) {
 
-			var geometry = object.geometry;
+			var geometry = _objects.update( fullScreenMesh );
+
+			// vertical pass
+
+			shadowMaterialVertical.uniforms.shadow_pass.value = shadow.map.texture;
+			shadowMaterialVertical.uniforms.resolution.value = shadow.mapSize;
+			shadowMaterialVertical.uniforms.radius.value = shadow.radius;
+			_renderer.setRenderTarget( shadow.mapPass );
+			_renderer.clear();
+			_renderer.renderBufferDirect( camera, null, geometry, shadowMaterialVertical, fullScreenMesh, null );
+
+			// horizonal pass
+
+			shadowMaterialHorizonal.uniforms.shadow_pass.value = shadow.mapPass.texture;
+			shadowMaterialHorizonal.uniforms.resolution.value = shadow.mapSize;
+			shadowMaterialHorizonal.uniforms.radius.value = shadow.radius;
+			_renderer.setRenderTarget( shadow.map );
+			_renderer.clear();
+			_renderer.renderBufferDirect( camera, null, geometry, shadowMaterialHorizonal, fullScreenMesh, null );
+
+		}
+
+		function getDepthMaterialVariant( useMorphing, useSkinning, useInstancing ) {
+
+			var index = useMorphing << 0 | useSkinning << 1 | useInstancing << 2;
+
+			var material = _depthMaterials[ index ];
+
+			if ( material === undefined ) {
+
+				material = new MeshDepthMaterial( {
+
+					depthPacking: RGBADepthPacking,
+
+					morphTargets: useMorphing,
+					skinning: useSkinning
+
+				} );
+
+				_depthMaterials[ index ] = material;
+
+			}
+
+			return material;
+
+		}
+
+		function getDistanceMaterialVariant( useMorphing, useSkinning, useInstancing ) {
+
+			var index = useMorphing << 0 | useSkinning << 1 | useInstancing << 2;
+
+			var material = _distanceMaterials[ index ];
+
+			if ( material === undefined ) {
+
+				material = new MeshDistanceMaterial( {
+
+					morphTargets: useMorphing,
+					skinning: useSkinning
+
+				} );
+
+				_distanceMaterials[ index ] = material;
+
+			}
+
+			return material;
+
+		}
+
+		function getDepthMaterial( object, geometry, material, light, shadowCameraNear, shadowCameraFar, type ) {
 
 			var result = null;
 
-			var materialVariants = _depthMaterials;
+			var getMaterialVariant = getDepthMaterialVariant;
 			var customMaterial = object.customDepthMaterial;
 
-			if ( isPointLight ) {
+			if ( light.isPointLight === true ) {
 
-				materialVariants = _distanceMaterials;
+				getMaterialVariant = getDistanceMaterialVariant;
 				customMaterial = object.customDistanceMaterial;
 
 			}
 
-			if ( ! customMaterial ) {
+			if ( customMaterial === undefined ) {
 
 				var useMorphing = false;
 
-				if ( material.morphTargets ) {
+				if ( material.morphTargets === true ) {
 
-					if ( geometry && geometry.isBufferGeometry ) {
+					useMorphing = geometry.morphAttributes && geometry.morphAttributes.position && geometry.morphAttributes.position.length > 0;
 
-						useMorphing = geometry.morphAttributes && geometry.morphAttributes.position && geometry.morphAttributes.position.length > 0;
+				}
 
-					} else if ( geometry && geometry.isGeometry ) {
+				var useSkinning = false;
 
-						useMorphing = geometry.morphTargets && geometry.morphTargets.length > 0;
+				if ( object.isSkinnedMesh === true ) {
+
+					if ( material.skinning === true ) {
+
+						useSkinning = true;
+
+					} else {
+
+						console.warn( 'THREE.WebGLShadowMap: THREE.SkinnedMesh with material.skinning set to false:', object );
 
 					}
 
 				}
 
-				if ( object.isSkinnedMesh && material.skinning === false ) {
+				var useInstancing = object.isInstancedMesh === true;
 
-					console.warn( 'THREE.WebGLShadowMap: THREE.SkinnedMesh with material.skinning set to false:', object );
-
-				}
-
-				var useSkinning = object.isSkinnedMesh && material.skinning;
-
-				var variantIndex = 0;
-
-				if ( useMorphing ) variantIndex |= _MorphingFlag;
-				if ( useSkinning ) variantIndex |= _SkinningFlag;
-
-				result = materialVariants[ variantIndex ];
+				result = getMaterialVariant( useMorphing, useSkinning, useInstancing );
 
 			} else {
 
@@ -19869,7 +20270,15 @@ var Spacekit = (function (exports) {
 			result.visible = material.visible;
 			result.wireframe = material.wireframe;
 
-			result.side = ( material.shadowSide != null ) ? material.shadowSide : shadowSide[ material.side ];
+			if ( type === VSMShadowMap ) {
+
+				result.side = ( material.shadowSide !== null ) ? material.shadowSide : material.side;
+
+			} else {
+
+				result.side = ( material.shadowSide !== null ) ? material.shadowSide : shadowSide[ material.side ];
+
+			}
 
 			result.clipShadows = material.clipShadows;
 			result.clippingPlanes = material.clippingPlanes;
@@ -19878,9 +20287,9 @@ var Spacekit = (function (exports) {
 			result.wireframeLinewidth = material.wireframeLinewidth;
 			result.linewidth = material.linewidth;
 
-			if ( isPointLight && result.isMeshDistanceMaterial ) {
+			if ( light.isPointLight === true && result.isMeshDistanceMaterial === true ) {
 
-				result.referencePosition.copy( lightPositionWorld );
+				result.referencePosition.setFromMatrixPosition( light.matrixWorld );
 				result.nearDistance = shadowCameraNear;
 				result.farDistance = shadowCameraFar;
 
@@ -19890,7 +20299,7 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function renderObject( object, camera, shadowCamera, isPointLight ) {
+		function renderObject( object, camera, shadowCamera, light, type ) {
 
 			if ( object.visible === false ) return;
 
@@ -19898,7 +20307,7 @@ var Spacekit = (function (exports) {
 
 			if ( visible && ( object.isMesh || object.isLine || object.isPoints ) ) {
 
-				if ( object.castShadow && ( ! object.frustumCulled || _frustum.intersectsObject( object ) ) ) {
+				if ( ( object.castShadow || ( object.receiveShadow && type === VSMShadowMap ) ) && ( ! object.frustumCulled || _frustum.intersectsObject( object ) ) ) {
 
 					object.modelViewMatrix.multiplyMatrices( shadowCamera.matrixWorldInverse, object.matrixWorld );
 
@@ -19916,7 +20325,8 @@ var Spacekit = (function (exports) {
 
 							if ( groupMaterial && groupMaterial.visible ) {
 
-								var depthMaterial = getDepthMaterial( object, groupMaterial, isPointLight, _lightPositionWorld, shadowCamera.near, shadowCamera.far );
+								var depthMaterial = getDepthMaterial( object, geometry, groupMaterial, light, shadowCamera.near, shadowCamera.far, type );
+
 								_renderer.renderBufferDirect( shadowCamera, null, geometry, depthMaterial, object, group );
 
 							}
@@ -19925,7 +20335,8 @@ var Spacekit = (function (exports) {
 
 					} else if ( material.visible ) {
 
-						var depthMaterial = getDepthMaterial( object, material, isPointLight, _lightPositionWorld, shadowCamera.near, shadowCamera.far );
+						var depthMaterial = getDepthMaterial( object, geometry, material, light, shadowCamera.near, shadowCamera.far, type );
+
 						_renderer.renderBufferDirect( shadowCamera, null, geometry, depthMaterial, object, null );
 
 					}
@@ -19938,7 +20349,7 @@ var Spacekit = (function (exports) {
 
 			for ( var i = 0, l = children.length; i < l; i ++ ) {
 
-				renderObject( children[ i ], camera, shadowCamera, isPointLight );
+				renderObject( children[ i ], camera, shadowCamera, light, type );
 
 			}
 
@@ -19950,7 +20361,9 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-	function WebGLState( gl, extensions, utils, capabilities ) {
+	function WebGLState( gl, extensions, capabilities ) {
+
+		var isWebGL2 = capabilities.isWebGL2;
 
 		function ColorBuffer() {
 
@@ -20160,13 +20573,17 @@ var Spacekit = (function (exports) {
 
 				setTest: function ( stencilTest ) {
 
-					if ( stencilTest ) {
+					if ( ! locked ) {
 
-						enable( 2960 );
+						if ( stencilTest ) {
 
-					} else {
+							enable( 2960 );
 
-						disable( 2960 );
+						} else {
+
+							disable( 2960 );
+
+						}
 
 					}
 
@@ -20263,8 +20680,6 @@ var Spacekit = (function (exports) {
 		var attributeDivisors = new Uint8Array( maxVertexAttributes );
 
 		var enabledCapabilities = {};
-
-		var compressedTextureFormats = null;
 
 		var currentProgram = null;
 
@@ -20379,9 +20794,9 @@ var Spacekit = (function (exports) {
 
 			if ( attributeDivisors[ attribute ] !== meshPerAttribute ) {
 
-				var extension = capabilities.isWebGL2 ? gl : extensions.get( 'ANGLE_instanced_arrays' );
+				var extension = isWebGL2 ? gl : extensions.get( 'ANGLE_instanced_arrays' );
 
-				extension[ capabilities.isWebGL2 ? 'vertexAttribDivisor' : 'vertexAttribDivisorANGLE' ]( attribute, meshPerAttribute );
+				extension[ isWebGL2 ? 'vertexAttribDivisor' : 'vertexAttribDivisorANGLE' ]( attribute, meshPerAttribute );
 				attributeDivisors[ attribute ] = meshPerAttribute;
 
 			}
@@ -20398,6 +20813,20 @@ var Spacekit = (function (exports) {
 					enabledAttributes[ i ] = 0;
 
 				}
+
+			}
+
+		}
+
+		function vertexAttribPointer( index, size, type, normalized, stride, offset ) {
+
+			if ( isWebGL2 === true && ( type === 5124 || type === 5125 ) ) {
+
+				gl.vertexAttribIPointer( index, size, type, normalized, stride, offset );
+
+			} else {
+
+				gl.vertexAttribPointer( index, size, type, normalized, stride, offset );
 
 			}
 
@@ -20425,33 +20854,6 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function getCompressedTextureFormats() {
-
-			if ( compressedTextureFormats === null ) {
-
-				compressedTextureFormats = [];
-
-				if ( extensions.get( 'WEBGL_compressed_texture_pvrtc' ) ||
-				     extensions.get( 'WEBGL_compressed_texture_s3tc' ) ||
-				     extensions.get( 'WEBGL_compressed_texture_etc1' ) ||
-				     extensions.get( 'WEBGL_compressed_texture_astc' ) ) {
-
-					var formats = gl.getParameter( 34467 );
-
-					for ( var i = 0; i < formats.length; i ++ ) {
-
-						compressedTextureFormats.push( formats[ i ] );
-
-					}
-
-				}
-
-			}
-
-			return compressedTextureFormats;
-
-		}
-
 		function useProgram( program ) {
 
 			if ( currentProgram !== program ) {
@@ -20467,6 +20869,44 @@ var Spacekit = (function (exports) {
 			return false;
 
 		}
+
+		var equationToGL = {
+			[ AddEquation ]: 32774,
+			[ SubtractEquation ]: 32778,
+			[ ReverseSubtractEquation ]: 32779
+		};
+
+		if ( isWebGL2 ) {
+
+			equationToGL[ MinEquation ] = 32775;
+			equationToGL[ MaxEquation ] = 32776;
+
+		} else {
+
+			var extension = extensions.get( 'EXT_blend_minmax' );
+
+			if ( extension !== null ) {
+
+				equationToGL[ MinEquation ] = extension.MIN_EXT;
+				equationToGL[ MaxEquation ] = extension.MAX_EXT;
+
+			}
+
+		}
+
+		var factorToGL = {
+			[ ZeroFactor ]: 0,
+			[ OneFactor ]: 1,
+			[ SrcColorFactor ]: 768,
+			[ SrcAlphaFactor ]: 770,
+			[ SrcAlphaSaturateFactor ]: 776,
+			[ DstColorFactor ]: 774,
+			[ DstAlphaFactor ]: 772,
+			[ OneMinusSrcColorFactor ]: 769,
+			[ OneMinusSrcAlphaFactor ]: 771,
+			[ OneMinusDstColorFactor ]: 775,
+			[ OneMinusDstAlphaFactor ]: 773
+		};
 
 		function setBlending( blending, blendEquation, blendSrc, blendDst, blendEquationAlpha, blendSrcAlpha, blendDstAlpha, premultipliedAlpha ) {
 
@@ -20579,7 +21019,7 @@ var Spacekit = (function (exports) {
 
 			if ( blendEquation !== currentBlendEquation || blendEquationAlpha !== currentBlendEquationAlpha ) {
 
-				gl.blendEquationSeparate( utils.convert( blendEquation ), utils.convert( blendEquationAlpha ) );
+				gl.blendEquationSeparate( equationToGL[ blendEquation ], equationToGL[ blendEquationAlpha ] );
 
 				currentBlendEquation = blendEquation;
 				currentBlendEquationAlpha = blendEquationAlpha;
@@ -20588,7 +21028,7 @@ var Spacekit = (function (exports) {
 
 			if ( blendSrc !== currentBlendSrc || blendDst !== currentBlendDst || blendSrcAlpha !== currentBlendSrcAlpha || blendDstAlpha !== currentBlendDstAlpha ) {
 
-				gl.blendFuncSeparate( utils.convert( blendSrc ), utils.convert( blendDst ), utils.convert( blendSrcAlpha ), utils.convert( blendDstAlpha ) );
+				gl.blendFuncSeparate( factorToGL[ blendSrc ], factorToGL[ blendDst ], factorToGL[ blendSrcAlpha ], factorToGL[ blendDstAlpha ] );
 
 				currentBlendSrc = blendSrc;
 				currentBlendDst = blendDst;
@@ -20626,7 +21066,8 @@ var Spacekit = (function (exports) {
 			stencilBuffer.setTest( stencilWrite );
 			if ( stencilWrite ) {
 
-				stencilBuffer.setFunc( material.stencilFunc, material.stencilRef, material.stencilMask );
+				stencilBuffer.setMask( material.stencilWriteMask );
+				stencilBuffer.setFunc( material.stencilFunc, material.stencilRef, material.stencilFuncMask );
 				stencilBuffer.setOp( material.stencilFail, material.stencilZFail, material.stencilZPass );
 
 			}
@@ -20783,6 +21224,21 @@ var Spacekit = (function (exports) {
 
 		}
 
+		function unbindTexture() {
+
+			var boundTexture = currentBoundTextures[ currentTextureSlot ];
+
+			if ( boundTexture !== undefined && boundTexture.type !== undefined ) {
+
+				gl.bindTexture( boundTexture.type, null );
+
+				boundTexture.type = undefined;
+				boundTexture.texture = undefined;
+
+			}
+
+		}
+
 		function compressedTexImage2D() {
 
 			try {
@@ -20866,8 +21322,6 @@ var Spacekit = (function (exports) {
 
 			enabledCapabilities = {};
 
-			compressedTextureFormats = null;
-
 			currentTextureSlot = null;
 			currentBoundTextures = {};
 
@@ -20896,9 +21350,9 @@ var Spacekit = (function (exports) {
 			enableAttribute: enableAttribute,
 			enableAttributeAndDivisor: enableAttributeAndDivisor,
 			disableUnusedAttributes: disableUnusedAttributes,
+			vertexAttribPointer: vertexAttribPointer,
 			enable: enable,
 			disable: disable,
-			getCompressedTextureFormats: getCompressedTextureFormats,
 
 			useProgram: useProgram,
 
@@ -20915,6 +21369,7 @@ var Spacekit = (function (exports) {
 
 			activeTexture: activeTexture,
 			bindTexture: bindTexture,
+			unbindTexture: unbindTexture,
 			compressedTexImage2D: compressedTexImage2D,
 			texImage2D: texImage2D,
 			texImage3D: texImage3D,
@@ -20934,12 +21389,31 @@ var Spacekit = (function (exports) {
 
 	function WebGLTextures( _gl, extensions, state, properties, capabilities, utils, info ) {
 
-		var _videoTextures = {};
+		var isWebGL2 = capabilities.isWebGL2;
+		var maxTextures = capabilities.maxTextures;
+		var maxCubemapSize = capabilities.maxCubemapSize;
+		var maxTextureSize = capabilities.maxTextureSize;
+		var maxSamples = capabilities.maxSamples;
+
+		var _videoTextures = new WeakMap();
 		var _canvas;
 
-		//
+		// cordova iOS (as of 5.0) still uses UIWebView, which provides OffscreenCanvas,
+		// also OffscreenCanvas.getContext("webgl"), but not OffscreenCanvas.getContext("2d")!
+		// Some implementations may only implement OffscreenCanvas partially (e.g. lacking 2d).
 
-		var useOffscreenCanvas = typeof OffscreenCanvas !== 'undefined';
+		var useOffscreenCanvas = false;
+
+		try {
+
+			useOffscreenCanvas = typeof OffscreenCanvas !== 'undefined'
+				&& ( new OffscreenCanvas( 1, 1 ).getContext( "2d" ) ) !== null;
+
+		} catch ( err ) {
+
+			// Ignore any errors
+
+		}
 
 		function createCanvas( width, height ) {
 
@@ -20973,7 +21447,7 @@ var Spacekit = (function (exports) {
 					( typeof HTMLCanvasElement !== 'undefined' && image instanceof HTMLCanvasElement ) ||
 					( typeof ImageBitmap !== 'undefined' && image instanceof ImageBitmap ) ) {
 
-					var floor = needsPowerOfTwo ? _Math.floorPowerOfTwo : Math.floor;
+					var floor = needsPowerOfTwo ? MathUtils.floorPowerOfTwo : Math.floor;
 
 					var width = floor( scale * image.width );
 					var height = floor( scale * image.height );
@@ -21014,13 +21488,13 @@ var Spacekit = (function (exports) {
 
 		function isPowerOfTwo( image ) {
 
-			return _Math.isPowerOfTwo( image.width ) && _Math.isPowerOfTwo( image.height );
+			return MathUtils.isPowerOfTwo( image.width ) && MathUtils.isPowerOfTwo( image.height );
 
 		}
 
 		function textureNeedsPowerOfTwo( texture ) {
 
-			if ( capabilities.isWebGL2 ) return false;
+			if ( isWebGL2 ) return false;
 
 			return ( texture.wrapS !== ClampToEdgeWrapping || texture.wrapT !== ClampToEdgeWrapping ) ||
 				( texture.minFilter !== NearestFilter && texture.minFilter !== LinearFilter );
@@ -21045,9 +21519,17 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function getInternalFormat( glFormat, glType ) {
+		function getInternalFormat( internalFormatName, glFormat, glType ) {
 
-			if ( ! capabilities.isWebGL2 ) return glFormat;
+			if ( isWebGL2 === false ) return glFormat;
+
+			if ( internalFormatName !== null ) {
+
+				if ( _gl[ internalFormatName ] !== undefined ) return _gl[ internalFormatName ];
+
+				console.warn( 'THREE.WebGLRenderer: Attempt to use non-existing WebGL internal format \'' + internalFormatName + '\'' );
+
+			}
 
 			var internalFormat = glFormat;
 
@@ -21079,10 +21561,6 @@ var Spacekit = (function (exports) {
 				internalFormat === 34842 || internalFormat === 34836 ) {
 
 				extensions.get( 'EXT_color_buffer_float' );
-
-			} else if ( internalFormat === 34843 || internalFormat === 34837 ) {
-
-				console.warn( 'THREE.WebGLRenderer: Floating point textures with RGB format not supported. Please use RGBA instead.' );
 
 			}
 
@@ -21116,7 +21594,7 @@ var Spacekit = (function (exports) {
 
 			if ( texture.isVideoTexture ) {
 
-				delete _videoTextures[ texture.id ];
+				_videoTextures.delete( texture );
 
 			}
 
@@ -21169,7 +21647,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			if ( renderTarget.isWebGLRenderTargetCube ) {
+			if ( renderTarget.isWebGLCubeRenderTarget ) {
 
 				for ( var i = 0; i < 6; i ++ ) {
 
@@ -21182,6 +21660,9 @@ var Spacekit = (function (exports) {
 
 				_gl.deleteFramebuffer( renderTargetProperties.__webglFramebuffer );
 				if ( renderTargetProperties.__webglDepthbuffer ) _gl.deleteRenderbuffer( renderTargetProperties.__webglDepthbuffer );
+				if ( renderTargetProperties.__webglMultisampledFramebuffer ) _gl.deleteFramebuffer( renderTargetProperties.__webglMultisampledFramebuffer );
+				if ( renderTargetProperties.__webglColorRenderbuffer ) _gl.deleteRenderbuffer( renderTargetProperties.__webglColorRenderbuffer );
+				if ( renderTargetProperties.__webglDepthRenderbuffer ) _gl.deleteRenderbuffer( renderTargetProperties.__webglDepthRenderbuffer );
 
 			}
 
@@ -21204,9 +21685,9 @@ var Spacekit = (function (exports) {
 
 			var textureUnit = textureUnits;
 
-			if ( textureUnit >= capabilities.maxTextures ) {
+			if ( textureUnit >= maxTextures ) {
 
-				console.warn( 'THREE.WebGLTextures: Trying to use ' + textureUnit + ' texture units while this GPU supports only ' + capabilities.maxTextures );
+				console.warn( 'THREE.WebGLTextures: Trying to use ' + textureUnit + ' texture units while this GPU supports only ' + maxTextures );
 
 			}
 
@@ -21284,119 +21765,136 @@ var Spacekit = (function (exports) {
 
 		function setTextureCube( texture, slot ) {
 
+			if ( texture.image.length !== 6 ) return;
+
 			var textureProperties = properties.get( texture );
 
-			if ( texture.image.length === 6 ) {
+			if ( texture.version > 0 && textureProperties.__version !== texture.version ) {
 
-				if ( texture.version > 0 && textureProperties.__version !== texture.version ) {
+				initTexture( textureProperties, texture );
 
-					initTexture( textureProperties, texture );
+				state.activeTexture( 33984 + slot );
+				state.bindTexture( 34067, textureProperties.__webglTexture );
 
-					state.activeTexture( 33984 + slot );
-					state.bindTexture( 34067, textureProperties.__webglTexture );
+				_gl.pixelStorei( 37440, texture.flipY );
 
-					_gl.pixelStorei( 37440, texture.flipY );
+				var isCompressed = ( texture && ( texture.isCompressedTexture || texture.image[ 0 ].isCompressedTexture ) );
+				var isDataTexture = ( texture.image[ 0 ] && texture.image[ 0 ].isDataTexture );
 
-					var isCompressed = ( texture && texture.isCompressedTexture );
-					var isDataTexture = ( texture.image[ 0 ] && texture.image[ 0 ].isDataTexture );
+				var cubeImage = [];
 
-					var cubeImage = [];
+				for ( var i = 0; i < 6; i ++ ) {
 
-					for ( var i = 0; i < 6; i ++ ) {
+					if ( ! isCompressed && ! isDataTexture ) {
 
-						if ( ! isCompressed && ! isDataTexture ) {
-
-							cubeImage[ i ] = resizeImage( texture.image[ i ], false, true, capabilities.maxCubemapSize );
-
-						} else {
-
-							cubeImage[ i ] = isDataTexture ? texture.image[ i ].image : texture.image[ i ];
-
-						}
-
-					}
-
-					var image = cubeImage[ 0 ],
-						supportsMips = isPowerOfTwo( image ) || capabilities.isWebGL2,
-						glFormat = utils.convert( texture.format ),
-						glType = utils.convert( texture.type ),
-						glInternalFormat = getInternalFormat( glFormat, glType );
-
-					setTextureParameters( 34067, texture, supportsMips );
-
-					for ( var i = 0; i < 6; i ++ ) {
-
-						if ( ! isCompressed ) {
-
-							if ( isDataTexture ) {
-
-								state.texImage2D( 34069 + i, 0, glInternalFormat, cubeImage[ i ].width, cubeImage[ i ].height, 0, glFormat, glType, cubeImage[ i ].data );
-
-							} else {
-
-								state.texImage2D( 34069 + i, 0, glInternalFormat, glFormat, glType, cubeImage[ i ] );
-
-							}
-
-						} else {
-
-							var mipmap, mipmaps = cubeImage[ i ].mipmaps;
-
-							for ( var j = 0, jl = mipmaps.length; j < jl; j ++ ) {
-
-								mipmap = mipmaps[ j ];
-
-								if ( texture.format !== RGBAFormat && texture.format !== RGBFormat ) {
-
-									if ( state.getCompressedTextureFormats().indexOf( glFormat ) > - 1 ) {
-
-										state.compressedTexImage2D( 34069 + i, j, glInternalFormat, mipmap.width, mipmap.height, 0, mipmap.data );
-
-									} else {
-
-										console.warn( 'THREE.WebGLRenderer: Attempt to load unsupported compressed texture format in .setTextureCube()' );
-
-									}
-
-								} else {
-
-									state.texImage2D( 34069 + i, j, glInternalFormat, mipmap.width, mipmap.height, 0, glFormat, glType, mipmap.data );
-
-								}
-
-							}
-
-						}
-
-					}
-
-					if ( ! isCompressed ) {
-
-						textureProperties.__maxMipLevel = 0;
+						cubeImage[ i ] = resizeImage( texture.image[ i ], false, true, maxCubemapSize );
 
 					} else {
 
-						textureProperties.__maxMipLevel = mipmaps.length - 1;
+						cubeImage[ i ] = isDataTexture ? texture.image[ i ].image : texture.image[ i ];
 
 					}
 
-					if ( textureNeedsGenerateMipmaps( texture, supportsMips ) ) {
+				}
 
-						// We assume images for cube map have the same size.
-						generateMipmap( 34067, texture, image.width, image.height );
+				var image = cubeImage[ 0 ],
+					supportsMips = isPowerOfTwo( image ) || isWebGL2,
+					glFormat = utils.convert( texture.format ),
+					glType = utils.convert( texture.type ),
+					glInternalFormat = getInternalFormat( texture.internalFormat, glFormat, glType );
+
+				setTextureParameters( 34067, texture, supportsMips );
+
+				var mipmaps;
+
+				if ( isCompressed ) {
+
+					for ( var i = 0; i < 6; i ++ ) {
+
+						mipmaps = cubeImage[ i ].mipmaps;
+
+						for ( var j = 0; j < mipmaps.length; j ++ ) {
+
+							var mipmap = mipmaps[ j ];
+
+							if ( texture.format !== RGBAFormat && texture.format !== RGBFormat ) {
+
+								if ( glFormat !== null ) {
+
+									state.compressedTexImage2D( 34069 + i, j, glInternalFormat, mipmap.width, mipmap.height, 0, mipmap.data );
+
+								} else {
+
+									console.warn( 'THREE.WebGLRenderer: Attempt to load unsupported compressed texture format in .setTextureCube()' );
+
+								}
+
+							} else {
+
+								state.texImage2D( 34069 + i, j, glInternalFormat, mipmap.width, mipmap.height, 0, glFormat, glType, mipmap.data );
+
+							}
+
+						}
 
 					}
 
-					textureProperties.__version = texture.version;
-
-					if ( texture.onUpdate ) texture.onUpdate( texture );
+					textureProperties.__maxMipLevel = mipmaps.length - 1;
 
 				} else {
 
-					state.activeTexture( 33984 + slot );
-					state.bindTexture( 34067, textureProperties.__webglTexture );
+					mipmaps = texture.mipmaps;
+
+					for ( var i = 0; i < 6; i ++ ) {
+
+						if ( isDataTexture ) {
+
+							state.texImage2D( 34069 + i, 0, glInternalFormat, cubeImage[ i ].width, cubeImage[ i ].height, 0, glFormat, glType, cubeImage[ i ].data );
+
+							for ( var j = 0; j < mipmaps.length; j ++ ) {
+
+								var mipmap = mipmaps[ j ];
+								var mipmapImage = mipmap.image[ i ].image;
+
+								state.texImage2D( 34069 + i, j + 1, glInternalFormat, mipmapImage.width, mipmapImage.height, 0, glFormat, glType, mipmapImage.data );
+
+							}
+
+						} else {
+
+							state.texImage2D( 34069 + i, 0, glInternalFormat, glFormat, glType, cubeImage[ i ] );
+
+							for ( var j = 0; j < mipmaps.length; j ++ ) {
+
+								var mipmap = mipmaps[ j ];
+
+								state.texImage2D( 34069 + i, j + 1, glInternalFormat, glFormat, glType, mipmap.image[ i ] );
+
+							}
+
+						}
+
+					}
+
+					textureProperties.__maxMipLevel = mipmaps.length;
 
 				}
+
+				if ( textureNeedsGenerateMipmaps( texture, supportsMips ) ) {
+
+					// We assume images for cube map have the same size.
+					generateMipmap( 34067, texture, image.width, image.height );
+
+				}
+
+				textureProperties.__version = texture.version;
+
+				if ( texture.onUpdate ) texture.onUpdate( texture );
+
+			} else {
+
+				state.activeTexture( 33984 + slot );
+				state.bindTexture( 34067, textureProperties.__webglTexture );
 
 			}
 
@@ -21409,23 +21907,37 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function setTextureParameters( textureType, texture, supportsMips ) {
+		var wrappingToGL = {
+			[ RepeatWrapping ]: 10497,
+			[ ClampToEdgeWrapping ]: 33071,
+			[ MirroredRepeatWrapping ]: 33648
+		};
 
-			var extension;
+		var filterToGL = {
+			[ NearestFilter ]: 9728,
+			[ NearestMipmapNearestFilter ]: 9984,
+			[ NearestMipmapLinearFilter ]: 9986,
+
+			[ LinearFilter ]: 9729,
+			[ LinearMipmapNearestFilter ]: 9985,
+			[ LinearMipmapLinearFilter ]: 9987
+		};
+
+		function setTextureParameters( textureType, texture, supportsMips ) {
 
 			if ( supportsMips ) {
 
-				_gl.texParameteri( textureType, 10242, utils.convert( texture.wrapS ) );
-				_gl.texParameteri( textureType, 10243, utils.convert( texture.wrapT ) );
+				_gl.texParameteri( textureType, 10242, wrappingToGL[ texture.wrapS ] );
+				_gl.texParameteri( textureType, 10243, wrappingToGL[ texture.wrapT ] );
 
 				if ( textureType === 32879 || textureType === 35866 ) {
 
-					_gl.texParameteri( textureType, 32882, utils.convert( texture.wrapR ) );
+					_gl.texParameteri( textureType, 32882, wrappingToGL[ texture.wrapR ] );
 
 				}
 
-				_gl.texParameteri( textureType, 10240, utils.convert( texture.magFilter ) );
-				_gl.texParameteri( textureType, 10241, utils.convert( texture.minFilter ) );
+				_gl.texParameteri( textureType, 10240, filterToGL[ texture.magFilter ] );
+				_gl.texParameteri( textureType, 10241, filterToGL[ texture.minFilter ] );
 
 			} else {
 
@@ -21455,12 +21967,12 @@ var Spacekit = (function (exports) {
 
 			}
 
-			extension = extensions.get( 'EXT_texture_filter_anisotropic' );
+			var extension = extensions.get( 'EXT_texture_filter_anisotropic' );
 
 			if ( extension ) {
 
 				if ( texture.type === FloatType && extensions.get( 'OES_texture_float_linear' ) === null ) return;
-				if ( texture.type === HalfFloatType && ( capabilities.isWebGL2 || extensions.get( 'OES_texture_half_float_linear' ) ) === null ) return;
+				if ( texture.type === HalfFloatType && ( isWebGL2 || extensions.get( 'OES_texture_half_float_linear' ) ) === null ) return;
 
 				if ( texture.anisotropy > 1 || properties.get( texture ).__currentAnisotropy ) {
 
@@ -21506,12 +22018,12 @@ var Spacekit = (function (exports) {
 			_gl.pixelStorei( 3317, texture.unpackAlignment );
 
 			var needsPowerOfTwo = textureNeedsPowerOfTwo( texture ) && isPowerOfTwo( texture.image ) === false;
-			var image = resizeImage( texture.image, needsPowerOfTwo, false, capabilities.maxTextureSize );
+			var image = resizeImage( texture.image, needsPowerOfTwo, false, maxTextureSize );
 
-			var supportsMips = isPowerOfTwo( image ) || capabilities.isWebGL2,
+			var supportsMips = isPowerOfTwo( image ) || isWebGL2,
 				glFormat = utils.convert( texture.format ),
 				glType = utils.convert( texture.type ),
-				glInternalFormat = getInternalFormat( glFormat, glType );
+				glInternalFormat = getInternalFormat( texture.internalFormat, glFormat, glType );
 
 			setTextureParameters( textureType, texture, supportsMips );
 
@@ -21523,17 +22035,37 @@ var Spacekit = (function (exports) {
 
 				glInternalFormat = 6402;
 
-				if ( texture.type === FloatType ) {
+				if ( isWebGL2 ) {
 
-					if ( ! capabilities.isWebGL2 ) throw new Error( 'Float Depth Texture only supported in WebGL2.0' );
-					glInternalFormat = 36012;
+					if ( texture.type === FloatType ) {
 
-				} else if ( capabilities.isWebGL2 ) {
+						glInternalFormat = 36012;
 
-					// WebGL 2.0 requires signed internalformat for glTexImage2D
-					glInternalFormat = 33189;
+					} else if ( texture.type === UnsignedIntType ) {
+
+						glInternalFormat = 33190;
+
+					} else if ( texture.type === UnsignedInt248Type ) {
+
+						glInternalFormat = 35056;
+
+					} else {
+
+						glInternalFormat = 33189; // WebGL2 requires sized internalformat for glTexImage2D
+
+					}
+
+				} else {
+
+					if ( texture.type === FloatType ) {
+
+						console.error( 'WebGLRenderer: Floating point depth texture requires WebGL2.' );
+
+					}
 
 				}
+
+				// validation checks for WebGL 1
 
 				if ( texture.format === DepthFormat && glInternalFormat === 6402 ) {
 
@@ -21551,10 +22083,10 @@ var Spacekit = (function (exports) {
 
 				}
 
-				// Depth stencil textures need the DEPTH_STENCIL internal format
-				// (https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/)
-				if ( texture.format === DepthStencilFormat ) {
+				if ( texture.format === DepthStencilFormat && glInternalFormat === 6402 ) {
 
+					// Depth stencil textures need the DEPTH_STENCIL internal format
+					// (https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/)
 					glInternalFormat = 34041;
 
 					// The error INVALID_OPERATION is generated by texImage2D if format and internalformat are
@@ -21570,6 +22102,8 @@ var Spacekit = (function (exports) {
 					}
 
 				}
+
+				//
 
 				state.texImage2D( 3553, 0, glInternalFormat, image.width, image.height, 0, glFormat, glType, null );
 
@@ -21606,7 +22140,7 @@ var Spacekit = (function (exports) {
 
 					if ( texture.format !== RGBAFormat && texture.format !== RGBFormat ) {
 
-						if ( state.getCompressedTextureFormats().indexOf( glFormat ) > - 1 ) {
+						if ( glFormat !== null ) {
 
 							state.compressedTexImage2D( 3553, i, glInternalFormat, mipmap.width, mipmap.height, 0, mipmap.data );
 
@@ -21667,7 +22201,7 @@ var Spacekit = (function (exports) {
 
 			if ( textureNeedsGenerateMipmaps( texture, supportsMips ) ) {
 
-				generateMipmap( 3553, texture, image.width, image.height );
+				generateMipmap( textureType, texture, image.width, image.height );
 
 			}
 
@@ -21684,7 +22218,7 @@ var Spacekit = (function (exports) {
 
 			var glFormat = utils.convert( renderTarget.texture.format );
 			var glType = utils.convert( renderTarget.texture.type );
-			var glInternalFormat = getInternalFormat( glFormat, glType );
+			var glInternalFormat = getInternalFormat( renderTarget.texture.internalFormat, glFormat, glType );
 			state.texImage2D( textureTarget, 0, glInternalFormat, renderTarget.width, renderTarget.height, 0, glFormat, glType, null );
 			_gl.bindFramebuffer( 36160, framebuffer );
 			_gl.framebufferTexture2D( 36160, attachment, textureTarget, properties.get( renderTarget.texture ).__webglTexture, 0 );
@@ -21699,15 +22233,33 @@ var Spacekit = (function (exports) {
 
 			if ( renderTarget.depthBuffer && ! renderTarget.stencilBuffer ) {
 
+				var glInternalFormat = 33189;
+
 				if ( isMultisample ) {
+
+					var depthTexture = renderTarget.depthTexture;
+
+					if ( depthTexture && depthTexture.isDepthTexture ) {
+
+						if ( depthTexture.type === FloatType ) {
+
+							glInternalFormat = 36012;
+
+						} else if ( depthTexture.type === UnsignedIntType ) {
+
+							glInternalFormat = 33190;
+
+						}
+
+					}
 
 					var samples = getRenderTargetSamples( renderTarget );
 
-					_gl.renderbufferStorageMultisample( 36161, samples, 33189, renderTarget.width, renderTarget.height );
+					_gl.renderbufferStorageMultisample( 36161, samples, glInternalFormat, renderTarget.width, renderTarget.height );
 
 				} else {
 
-					_gl.renderbufferStorage( 36161, 33189, renderTarget.width, renderTarget.height );
+					_gl.renderbufferStorage( 36161, glInternalFormat, renderTarget.width, renderTarget.height );
 
 				}
 
@@ -21734,7 +22286,7 @@ var Spacekit = (function (exports) {
 
 				var glFormat = utils.convert( renderTarget.texture.format );
 				var glType = utils.convert( renderTarget.texture.type );
-				var glInternalFormat = getInternalFormat( glFormat, glType );
+				var glInternalFormat = getInternalFormat( renderTarget.texture.internalFormat, glFormat, glType );
 
 				if ( isMultisample ) {
 
@@ -21757,7 +22309,7 @@ var Spacekit = (function (exports) {
 		// Setup resources for a Depth Texture for a FBO (needs an extension)
 		function setupDepthTexture( framebuffer, renderTarget ) {
 
-			var isCube = ( renderTarget && renderTarget.isWebGLRenderTargetCube );
+			var isCube = ( renderTarget && renderTarget.isWebGLCubeRenderTarget );
 			if ( isCube ) throw new Error( 'Depth Texture with cube render targets is not supported' );
 
 			_gl.bindFramebuffer( 36160, framebuffer );
@@ -21804,7 +22356,7 @@ var Spacekit = (function (exports) {
 
 			var renderTargetProperties = properties.get( renderTarget );
 
-			var isCube = ( renderTarget.isWebGLRenderTargetCube === true );
+			var isCube = ( renderTarget.isWebGLCubeRenderTarget === true );
 
 			if ( renderTarget.depthTexture ) {
 
@@ -21822,7 +22374,7 @@ var Spacekit = (function (exports) {
 
 						_gl.bindFramebuffer( 36160, renderTargetProperties.__webglFramebuffer[ i ] );
 						renderTargetProperties.__webglDepthbuffer[ i ] = _gl.createRenderbuffer();
-						setupRenderBufferStorage( renderTargetProperties.__webglDepthbuffer[ i ], renderTarget );
+						setupRenderBufferStorage( renderTargetProperties.__webglDepthbuffer[ i ], renderTarget, false );
 
 					}
 
@@ -21830,7 +22382,7 @@ var Spacekit = (function (exports) {
 
 					_gl.bindFramebuffer( 36160, renderTargetProperties.__webglFramebuffer );
 					renderTargetProperties.__webglDepthbuffer = _gl.createRenderbuffer();
-					setupRenderBufferStorage( renderTargetProperties.__webglDepthbuffer, renderTarget );
+					setupRenderBufferStorage( renderTargetProperties.__webglDepthbuffer, renderTarget, false );
 
 				}
 
@@ -21852,9 +22404,19 @@ var Spacekit = (function (exports) {
 
 			info.memory.textures ++;
 
-			var isCube = ( renderTarget.isWebGLRenderTargetCube === true );
+			var isCube = ( renderTarget.isWebGLCubeRenderTarget === true );
 			var isMultisample = ( renderTarget.isWebGLMultisampleRenderTarget === true );
-			var supportsMips = isPowerOfTwo( renderTarget ) || capabilities.isWebGL2;
+			var supportsMips = isPowerOfTwo( renderTarget ) || isWebGL2;
+
+			// Handles WebGL2 RGBFormat fallback - #18858
+
+			if ( isWebGL2 && renderTarget.texture.format === RGBFormat && ( renderTarget.texture.type === FloatType || renderTarget.texture.type === HalfFloatType ) ) {
+
+				renderTarget.texture.format = RGBAFormat;
+
+				console.warn( 'THREE.WebGLRenderer: Rendering to textures with RGB format is not supported. Using RGBA format instead.' );
+
+			}
 
 			// Setup framebuffer
 
@@ -21874,15 +22436,16 @@ var Spacekit = (function (exports) {
 
 				if ( isMultisample ) {
 
-					if ( capabilities.isWebGL2 ) {
+					if ( isWebGL2 ) {
 
 						renderTargetProperties.__webglMultisampledFramebuffer = _gl.createFramebuffer();
 						renderTargetProperties.__webglColorRenderbuffer = _gl.createRenderbuffer();
 
 						_gl.bindRenderbuffer( 36161, renderTargetProperties.__webglColorRenderbuffer );
+
 						var glFormat = utils.convert( renderTarget.texture.format );
 						var glType = utils.convert( renderTarget.texture.type );
-						var glInternalFormat = getInternalFormat( glFormat, glType );
+						var glInternalFormat = getInternalFormat( renderTarget.texture.internalFormat, glFormat, glType );
 						var samples = getRenderTargetSamples( renderTarget );
 						_gl.renderbufferStorageMultisample( 36161, samples, glInternalFormat, renderTarget.width, renderTarget.height );
 
@@ -21960,11 +22523,11 @@ var Spacekit = (function (exports) {
 		function updateRenderTargetMipmap( renderTarget ) {
 
 			var texture = renderTarget.texture;
-			var supportsMips = isPowerOfTwo( renderTarget ) || capabilities.isWebGL2;
+			var supportsMips = isPowerOfTwo( renderTarget ) || isWebGL2;
 
 			if ( textureNeedsGenerateMipmaps( texture, supportsMips ) ) {
 
-				var target = renderTarget.isWebGLRenderTargetCube ? 34067 : 3553;
+				var target = renderTarget.isWebGLCubeRenderTarget ? 34067 : 3553;
 				var webglTexture = properties.get( texture ).__webglTexture;
 
 				state.bindTexture( target, webglTexture );
@@ -21979,7 +22542,7 @@ var Spacekit = (function (exports) {
 
 			if ( renderTarget.isWebGLMultisampleRenderTarget ) {
 
-				if ( capabilities.isWebGL2 ) {
+				if ( isWebGL2 ) {
 
 					var renderTargetProperties = properties.get( renderTarget );
 
@@ -21995,6 +22558,8 @@ var Spacekit = (function (exports) {
 
 					_gl.blitFramebuffer( 0, 0, width, height, 0, 0, width, height, mask, 9728 );
 
+					_gl.bindFramebuffer( 36160, renderTargetProperties.__webglMultisampledFramebuffer ); // see #18905
+
 				} else {
 
 					console.warn( 'THREE.WebGLRenderer: WebGLMultisampleRenderTarget can only be used with WebGL2.' );
@@ -22007,21 +22572,20 @@ var Spacekit = (function (exports) {
 
 		function getRenderTargetSamples( renderTarget ) {
 
-			return ( capabilities.isWebGL2 && renderTarget.isWebGLMultisampleRenderTarget ) ?
-				Math.min( capabilities.maxSamples, renderTarget.samples ) : 0;
+			return ( isWebGL2 && renderTarget.isWebGLMultisampleRenderTarget ) ?
+				Math.min( maxSamples, renderTarget.samples ) : 0;
 
 		}
 
 		function updateVideoTexture( texture ) {
 
-			var id = texture.id;
 			var frame = info.render.frame;
 
 			// Check the last frame we updated the VideoTexture
 
-			if ( _videoTextures[ id ] !== frame ) {
+			if ( _videoTextures.get( texture ) !== frame ) {
 
-				_videoTextures[ id ] = frame;
+				_videoTextures.set( texture, frame );
 				texture.update();
 
 			}
@@ -22054,7 +22618,7 @@ var Spacekit = (function (exports) {
 
 		function safeSetTextureCube( texture, slot ) {
 
-			if ( texture && texture.isWebGLRenderTargetCube ) {
+			if ( texture && texture.isWebGLCubeRenderTarget ) {
 
 				if ( warnedTextureCube === false ) {
 
@@ -22067,7 +22631,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			// currently relying on the fact that WebGLRenderTargetCube.texture is a Texture and NOT a CubeTexture
+			// currently relying on the fact that WebGLCubeRenderTarget.texture is a Texture and NOT a CubeTexture
 			// TODO: unify these code paths
 			if ( ( texture && texture.isCubeTexture ) ||
 				( Array.isArray( texture.image ) && texture.image.length === 6 ) ) {
@@ -22079,7 +22643,7 @@ var Spacekit = (function (exports) {
 
 			} else {
 
-				// assumed: texture property of THREE.WebGLRenderTargetCube
+				// assumed: texture property of THREE.WebGLCubeRenderTarget
 				setTextureCubeDynamic( texture, slot );
 
 			}
@@ -22111,21 +22675,11 @@ var Spacekit = (function (exports) {
 
 	function WebGLUtils( gl, extensions, capabilities ) {
 
+		var isWebGL2 = capabilities.isWebGL2;
+
 		function convert( p ) {
 
 			var extension;
-
-			if ( p === RepeatWrapping ) return 10497;
-			if ( p === ClampToEdgeWrapping ) return 33071;
-			if ( p === MirroredRepeatWrapping ) return 33648;
-
-			if ( p === NearestFilter ) return 9728;
-			if ( p === NearestMipmapNearestFilter ) return 9984;
-			if ( p === NearestMipmapLinearFilter ) return 9986;
-
-			if ( p === LinearFilter ) return 9729;
-			if ( p === LinearMipmapNearestFilter ) return 9985;
-			if ( p === LinearMipmapLinearFilter ) return 9987;
 
 			if ( p === UnsignedByteType ) return 5121;
 			if ( p === UnsignedShort4444Type ) return 32819;
@@ -22141,11 +22695,19 @@ var Spacekit = (function (exports) {
 
 			if ( p === HalfFloatType ) {
 
-				if ( capabilities.isWebGL2 ) return 5131;
+				if ( isWebGL2 ) return 5131;
 
 				extension = extensions.get( 'OES_texture_half_float' );
 
-				if ( extension !== null ) return extension.HALF_FLOAT_OES;
+				if ( extension !== null ) {
+
+					return extension.HALF_FLOAT_OES;
+
+				} else {
+
+					return null;
+
+				}
 
 			}
 
@@ -22158,22 +22720,13 @@ var Spacekit = (function (exports) {
 			if ( p === DepthStencilFormat ) return 34041;
 			if ( p === RedFormat ) return 6403;
 
-			if ( p === AddEquation ) return 32774;
-			if ( p === SubtractEquation ) return 32778;
-			if ( p === ReverseSubtractEquation ) return 32779;
+			// WebGL2 formats.
 
-			if ( p === ZeroFactor ) return 0;
-			if ( p === OneFactor ) return 1;
-			if ( p === SrcColorFactor ) return 768;
-			if ( p === OneMinusSrcColorFactor ) return 769;
-			if ( p === SrcAlphaFactor ) return 770;
-			if ( p === OneMinusSrcAlphaFactor ) return 771;
-			if ( p === DstAlphaFactor ) return 772;
-			if ( p === OneMinusDstAlphaFactor ) return 773;
-
-			if ( p === DstColorFactor ) return 774;
-			if ( p === OneMinusDstColorFactor ) return 775;
-			if ( p === SrcAlphaSaturateFactor ) return 776;
+			if ( p === RedIntegerFormat ) return 36244;
+			if ( p === RGFormat ) return 33319;
+			if ( p === RGIntegerFormat ) return 33320;
+			if ( p === RGBIntegerFormat ) return 36248;
+			if ( p === RGBAIntegerFormat ) return 36249;
 
 			if ( p === RGB_S3TC_DXT1_Format || p === RGBA_S3TC_DXT1_Format ||
 				p === RGBA_S3TC_DXT3_Format || p === RGBA_S3TC_DXT5_Format ) {
@@ -22186,6 +22739,10 @@ var Spacekit = (function (exports) {
 					if ( p === RGBA_S3TC_DXT1_Format ) return extension.COMPRESSED_RGBA_S3TC_DXT1_EXT;
 					if ( p === RGBA_S3TC_DXT3_Format ) return extension.COMPRESSED_RGBA_S3TC_DXT3_EXT;
 					if ( p === RGBA_S3TC_DXT5_Format ) return extension.COMPRESSED_RGBA_S3TC_DXT5_EXT;
+
+				} else {
+
+					return null;
 
 				}
 
@@ -22203,6 +22760,10 @@ var Spacekit = (function (exports) {
 					if ( p === RGBA_PVRTC_4BPPV1_Format ) return extension.COMPRESSED_RGBA_PVRTC_4BPPV1_IMG;
 					if ( p === RGBA_PVRTC_2BPPV1_Format ) return extension.COMPRESSED_RGBA_PVRTC_2BPPV1_IMG;
 
+				} else {
+
+					return null;
+
 				}
 
 			}
@@ -22211,7 +22772,28 @@ var Spacekit = (function (exports) {
 
 				extension = extensions.get( 'WEBGL_compressed_texture_etc1' );
 
-				if ( extension !== null ) return extension.COMPRESSED_RGB_ETC1_WEBGL;
+				if ( extension !== null ) {
+
+					return extension.COMPRESSED_RGB_ETC1_WEBGL;
+
+				} else {
+
+					return null;
+
+				}
+
+			}
+
+			if ( p === RGB_ETC2_Format || p === RGBA_ETC2_EAC_Format ) {
+
+				extension = extensions.get( 'WEBGL_compressed_texture_etc' );
+
+				if ( extension !== null ) {
+
+					if ( p === RGB_ETC2_Format ) return extension.COMPRESSED_RGB8_ETC2;
+					if ( p === RGBA_ETC2_EAC_Format ) return extension.COMPRESSED_RGBA8_ETC2_EAC;
+
+				}
 
 			}
 
@@ -22219,33 +22801,42 @@ var Spacekit = (function (exports) {
 				p === RGBA_ASTC_6x5_Format || p === RGBA_ASTC_6x6_Format || p === RGBA_ASTC_8x5_Format ||
 				p === RGBA_ASTC_8x6_Format || p === RGBA_ASTC_8x8_Format || p === RGBA_ASTC_10x5_Format ||
 				p === RGBA_ASTC_10x6_Format || p === RGBA_ASTC_10x8_Format || p === RGBA_ASTC_10x10_Format ||
-				p === RGBA_ASTC_12x10_Format || p === RGBA_ASTC_12x12_Format ) {
+				p === RGBA_ASTC_12x10_Format || p === RGBA_ASTC_12x12_Format ||
+				p === SRGB8_ALPHA8_ASTC_4x4_Format || p === SRGB8_ALPHA8_ASTC_5x4_Format || p === SRGB8_ALPHA8_ASTC_5x5_Format ||
+				p === SRGB8_ALPHA8_ASTC_6x5_Format || p === SRGB8_ALPHA8_ASTC_6x6_Format || p === SRGB8_ALPHA8_ASTC_8x5_Format ||
+				p === SRGB8_ALPHA8_ASTC_8x6_Format || p === SRGB8_ALPHA8_ASTC_8x8_Format || p === SRGB8_ALPHA8_ASTC_10x5_Format ||
+				p === SRGB8_ALPHA8_ASTC_10x6_Format || p === SRGB8_ALPHA8_ASTC_10x8_Format || p === SRGB8_ALPHA8_ASTC_10x10_Format ||
+				p === SRGB8_ALPHA8_ASTC_12x10_Format || p === SRGB8_ALPHA8_ASTC_12x12_Format ) {
 
 				extension = extensions.get( 'WEBGL_compressed_texture_astc' );
 
 				if ( extension !== null ) {
 
+					// TODO Complete?
+
 					return p;
+
+				} else {
+
+					return null;
 
 				}
 
 			}
 
-			if ( p === MinEquation || p === MaxEquation ) {
+			if ( p === RGBA_BPTC_Format ) {
 
-				if ( capabilities.isWebGL2 ) {
-
-					if ( p === MinEquation ) return 32775;
-					if ( p === MaxEquation ) return 32776;
-
-				}
-
-				extension = extensions.get( 'EXT_blend_minmax' );
+				extension = extensions.get( 'EXT_texture_compression_bptc' );
 
 				if ( extension !== null ) {
 
-					if ( p === MinEquation ) return extension.MIN_EXT;
-					if ( p === MaxEquation ) return extension.MAX_EXT;
+					// TODO Complete?
+
+					return p;
+
+				} else {
+
+					return null;
 
 				}
 
@@ -22253,41 +22844,27 @@ var Spacekit = (function (exports) {
 
 			if ( p === UnsignedInt248Type ) {
 
-				if ( capabilities.isWebGL2 ) return 34042;
+				if ( isWebGL2 ) return 34042;
 
 				extension = extensions.get( 'WEBGL_depth_texture' );
 
-				if ( extension !== null ) return extension.UNSIGNED_INT_24_8_WEBGL;
+				if ( extension !== null ) {
+
+					return extension.UNSIGNED_INT_24_8_WEBGL;
+
+				} else {
+
+					return null;
+
+				}
 
 			}
-
-			return 0;
 
 		}
 
 		return { convert: convert };
 
 	}
-
-	/**
-	 * @author mrdoob / http://mrdoob.com/
-	 */
-
-	function Group() {
-
-		Object3D.call( this );
-
-		this.type = 'Group';
-
-	}
-
-	Group.prototype = Object.assign( Object.create( Object3D.prototype ), {
-
-		constructor: Group,
-
-		isGroup: true
-
-	} );
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -22310,481 +22887,161 @@ var Spacekit = (function (exports) {
 	} );
 
 	/**
-	 * @author jsantell / https://www.jsantell.com/
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-	var cameraLPos = new Vector3();
-	var cameraRPos = new Vector3();
+	function Group() {
 
-	/**
-	 * Assumes 2 cameras that are parallel and share an X-axis, and that
-	 * the cameras' projection and world matrices have already been set.
-	 * And that near and far planes are identical for both cameras.
-	 * Visualization of this technique: https://computergraphics.stackexchange.com/a/4765
-	 */
-	function setProjectionFromUnion( camera, cameraL, cameraR ) {
+		Object3D.call( this );
 
-		cameraLPos.setFromMatrixPosition( cameraL.matrixWorld );
-		cameraRPos.setFromMatrixPosition( cameraR.matrixWorld );
-
-		var ipd = cameraLPos.distanceTo( cameraRPos );
-
-		var projL = cameraL.projectionMatrix.elements;
-		var projR = cameraR.projectionMatrix.elements;
-
-		// VR systems will have identical far and near planes, and
-		// most likely identical top and bottom frustum extents.
-		// Use the left camera for these values.
-		var near = projL[ 14 ] / ( projL[ 10 ] - 1 );
-		var far = projL[ 14 ] / ( projL[ 10 ] + 1 );
-		var topFov = ( projL[ 9 ] + 1 ) / projL[ 5 ];
-		var bottomFov = ( projL[ 9 ] - 1 ) / projL[ 5 ];
-
-		var leftFov = ( projL[ 8 ] - 1 ) / projL[ 0 ];
-		var rightFov = ( projR[ 8 ] + 1 ) / projR[ 0 ];
-		var left = near * leftFov;
-		var right = near * rightFov;
-
-		// Calculate the new camera's position offset from the
-		// left camera. xOffset should be roughly half `ipd`.
-		var zOffset = ipd / ( - leftFov + rightFov );
-		var xOffset = zOffset * - leftFov;
-
-		// TODO: Better way to apply this offset?
-		cameraL.matrixWorld.decompose( camera.position, camera.quaternion, camera.scale );
-		camera.translateX( xOffset );
-		camera.translateZ( zOffset );
-		camera.matrixWorld.compose( camera.position, camera.quaternion, camera.scale );
-		camera.matrixWorldInverse.getInverse( camera.matrixWorld );
-
-		// Find the union of the frustum values of the cameras and scale
-		// the values so that the near plane's position does not change in world space,
-		// although must now be relative to the new union camera.
-		var near2 = near + zOffset;
-		var far2 = far + zOffset;
-		var left2 = left - xOffset;
-		var right2 = right + ( ipd - xOffset );
-		var top2 = topFov * far / far2 * near2;
-		var bottom2 = bottomFov * far / far2 * near2;
-
-		camera.projectionMatrix.makePerspective( left2, right2, top2, bottom2, near2, far2 );
+		this.type = 'Group';
 
 	}
 
+	Group.prototype = Object.assign( Object.create( Object3D.prototype ), {
+
+		constructor: Group,
+
+		isGroup: true
+
+	} );
+
 	/**
-	 * @author mrdoob / http://mrdoob.com/
+	 * @author Mugen87 / https://github.com/Mugen87
 	 */
 
-	function WebVRManager( renderer ) {
+	function WebXRController() {
 
-		var renderWidth, renderHeight;
-		var scope = this;
+		this._targetRay = null;
+		this._grip = null;
 
-		var device = null;
-		var frameData = null;
+	}
 
-		var poseTarget = null;
+	Object.assign( WebXRController.prototype, {
 
-		var controllers = [];
-		var standingMatrix = new Matrix4();
-		var standingMatrixInverse = new Matrix4();
+		constructor: WebXRController,
 
-		var framebufferScaleFactor = 1.0;
+		getTargetRaySpace: function () {
 
-		var referenceSpaceType = 'local-floor';
+			if ( this._targetRay === null ) {
 
-		if ( typeof window !== 'undefined' && 'VRFrameData' in window ) {
-
-			frameData = new window.VRFrameData();
-			window.addEventListener( 'vrdisplaypresentchange', onVRDisplayPresentChange, false );
-
-		}
-
-		var matrixWorldInverse = new Matrix4();
-		var tempQuaternion = new Quaternion();
-		var tempPosition = new Vector3();
-
-		var cameraL = new PerspectiveCamera();
-		cameraL.viewport = new Vector4();
-		cameraL.layers.enable( 1 );
-
-		var cameraR = new PerspectiveCamera();
-		cameraR.viewport = new Vector4();
-		cameraR.layers.enable( 2 );
-
-		var cameraVR = new ArrayCamera( [ cameraL, cameraR ] );
-		cameraVR.layers.enable( 1 );
-		cameraVR.layers.enable( 2 );
-
-		//
-
-		function isPresenting() {
-
-			return device !== null && device.isPresenting === true;
-
-		}
-
-		var currentSize = new Vector2(), currentPixelRatio;
-
-		function onVRDisplayPresentChange() {
-
-			if ( isPresenting() ) {
-
-				var eyeParameters = device.getEyeParameters( 'left' );
-				renderWidth = 2 * eyeParameters.renderWidth * framebufferScaleFactor;
-				renderHeight = eyeParameters.renderHeight * framebufferScaleFactor;
-
-				currentPixelRatio = renderer.getPixelRatio();
-				renderer.getSize( currentSize );
-
-				renderer.setDrawingBufferSize( renderWidth, renderHeight, 1 );
-
-				cameraL.viewport.set( 0, 0, renderWidth / 2, renderHeight );
-				cameraR.viewport.set( renderWidth / 2, 0, renderWidth / 2, renderHeight );
-
-				animation.start();
-
-				scope.dispatchEvent( { type: 'sessionstart' } );
-
-			} else {
-
-				if ( scope.enabled ) {
-
-					renderer.setDrawingBufferSize( currentSize.width, currentSize.height, currentPixelRatio );
-
-				}
-
-				animation.stop();
-
-				scope.dispatchEvent( { type: 'sessionend' } );
+				this._targetRay = new Group();
+				this._targetRay.matrixAutoUpdate = false;
+				this._targetRay.visible = false;
 
 			}
 
-		}
+			return this._targetRay;
 
-		//
+		},
 
-		var triggers = [];
+		getGripSpace: function () {
 
-		function findGamepad( id ) {
+			if ( this._grip === null ) {
 
-			var gamepads = navigator.getGamepads && navigator.getGamepads();
-
-			for ( var i = 0, j = 0, l = gamepads.length; i < l; i ++ ) {
-
-				var gamepad = gamepads[ i ];
-
-				if ( gamepad && ( gamepad.id === 'Daydream Controller' ||
-					gamepad.id === 'Gear VR Controller' || gamepad.id === 'Oculus Go Controller' ||
-					gamepad.id === 'OpenVR Gamepad' || gamepad.id.startsWith( 'Oculus Touch' ) ||
-					gamepad.id.startsWith( 'HTC Vive Focus' ) ||
-					gamepad.id.startsWith( 'Spatial Controller' ) ) ) {
-
-					if ( j === id ) return gamepad;
-
-					j ++;
-
-				}
+				this._grip = new Group();
+				this._grip.matrixAutoUpdate = false;
+				this._grip.visible = false;
 
 			}
 
-		}
+			return this._grip;
 
-		function updateControllers() {
+		},
 
-			for ( var i = 0; i < controllers.length; i ++ ) {
+		dispatchEvent: function ( event ) {
 
-				var controller = controllers[ i ];
+			if ( this._targetRay !== null ) {
 
-				var gamepad = findGamepad( i );
+				this._targetRay.dispatchEvent( event );
 
-				if ( gamepad !== undefined && gamepad.pose !== undefined ) {
+			}
 
-					if ( gamepad.pose === null ) return;
+			if ( this._grip !== null ) {
 
-					// Pose
+				this._grip.dispatchEvent( event );
 
-					var pose = gamepad.pose;
+			}
 
-					if ( pose.hasPosition === false ) controller.position.set( 0.2, - 0.6, - 0.05 );
+			return this;
 
-					if ( pose.position !== null ) controller.position.fromArray( pose.position );
-					if ( pose.orientation !== null ) controller.quaternion.fromArray( pose.orientation );
-					controller.matrix.compose( controller.position, controller.quaternion, controller.scale );
-					controller.matrix.premultiply( standingMatrix );
-					controller.matrix.decompose( controller.position, controller.quaternion, controller.scale );
-					controller.matrixWorldNeedsUpdate = true;
-					controller.visible = true;
+		},
 
-					// Trigger
+		disconnect: function ( inputSource ) {
 
-					var buttonId = gamepad.id === 'Daydream Controller' ? 0 : 1;
+			this.dispatchEvent( { type: 'disconnected', data: inputSource } );
 
-					if ( triggers[ i ] === undefined ) triggers[ i ] = false;
+			if ( this._targetRay !== null ) {
 
-					if ( triggers[ i ] !== gamepad.buttons[ buttonId ].pressed ) {
+				this._targetRay.visible = false;
 
-						triggers[ i ] = gamepad.buttons[ buttonId ].pressed;
+			}
 
-						if ( triggers[ i ] === true ) {
+			if ( this._grip !== null ) {
 
-							controller.dispatchEvent( { type: 'selectstart' } );
+				this._grip.visible = false;
 
-						} else {
+			}
 
-							controller.dispatchEvent( { type: 'selectend' } );
-							controller.dispatchEvent( { type: 'select' } );
+			return this;
 
-						}
+		},
+
+		update: function ( inputSource, frame, referenceSpace ) {
+
+			var inputPose = null;
+			var gripPose = null;
+
+			var targetRay = this._targetRay;
+			var grip = this._grip;
+
+			if ( inputSource ) {
+
+				if ( targetRay !== null ) {
+
+					inputPose = frame.getPose( inputSource.targetRaySpace, referenceSpace );
+
+					if ( inputPose !== null ) {
+
+						targetRay.matrix.fromArray( inputPose.transform.matrix );
+						targetRay.matrix.decompose( targetRay.position, targetRay.rotation, targetRay.scale );
 
 					}
 
-				} else {
+				}
 
-					controller.visible = false;
+				if ( grip !== null && inputSource.gripSpace ) {
+
+					gripPose = frame.getPose( inputSource.gripSpace, referenceSpace );
+
+					if ( gripPose !== null ) {
+
+						grip.matrix.fromArray( gripPose.transform.matrix );
+						grip.matrix.decompose( grip.position, grip.rotation, grip.scale );
+
+					}
 
 				}
 
 			}
 
+			if ( targetRay !== null ) {
+
+				targetRay.visible = ( inputPose !== null );
+
+			}
+
+			if ( grip !== null ) {
+
+				grip.visible = ( gripPose !== null );
+
+			}
+
+			return this;
+
 		}
 
-		function updateViewportFromBounds( viewport, bounds ) {
-
-			if ( bounds !== null && bounds.length === 4 ) {
-
-				viewport.set( bounds[ 0 ] * renderWidth, bounds[ 1 ] * renderHeight, bounds[ 2 ] * renderWidth, bounds[ 3 ] * renderHeight );
-
-			}
-
-		}
-
-		//
-
-		this.enabled = false;
-
-		this.getController = function ( id ) {
-
-			var controller = controllers[ id ];
-
-			if ( controller === undefined ) {
-
-				controller = new Group();
-				controller.matrixAutoUpdate = false;
-				controller.visible = false;
-
-				controllers[ id ] = controller;
-
-			}
-
-			return controller;
-
-		};
-
-		this.getDevice = function () {
-
-			return device;
-
-		};
-
-		this.setDevice = function ( value ) {
-
-			if ( value !== undefined ) device = value;
-
-			animation.setContext( value );
-
-		};
-
-		this.setFramebufferScaleFactor = function ( value ) {
-
-			framebufferScaleFactor = value;
-
-		};
-
-		this.setReferenceSpaceType = function ( value ) {
-
-			referenceSpaceType = value;
-
-		};
-
-		this.setPoseTarget = function ( object ) {
-
-			if ( object !== undefined ) poseTarget = object;
-
-		};
-
-		this.getCamera = function ( camera ) {
-
-			var userHeight = referenceSpaceType === 'local-floor' ? 1.6 : 0;
-
-			if ( isPresenting() === false ) {
-
-				camera.position.set( 0, userHeight, 0 );
-				camera.rotation.set( 0, 0, 0 );
-
-				return camera;
-
-			}
-
-			device.depthNear = camera.near;
-			device.depthFar = camera.far;
-
-			device.getFrameData( frameData );
-
-			//
-
-			if ( referenceSpaceType === 'local-floor' ) {
-
-				var stageParameters = device.stageParameters;
-
-				if ( stageParameters ) {
-
-					standingMatrix.fromArray( stageParameters.sittingToStandingTransform );
-
-				} else {
-
-					standingMatrix.makeTranslation( 0, userHeight, 0 );
-
-				}
-
-			}
-
-
-			var pose = frameData.pose;
-			var poseObject = poseTarget !== null ? poseTarget : camera;
-
-			// We want to manipulate poseObject by its position and quaternion components since users may rely on them.
-			poseObject.matrix.copy( standingMatrix );
-			poseObject.matrix.decompose( poseObject.position, poseObject.quaternion, poseObject.scale );
-
-			if ( pose.orientation !== null ) {
-
-				tempQuaternion.fromArray( pose.orientation );
-				poseObject.quaternion.multiply( tempQuaternion );
-
-			}
-
-			if ( pose.position !== null ) {
-
-				tempQuaternion.setFromRotationMatrix( standingMatrix );
-				tempPosition.fromArray( pose.position );
-				tempPosition.applyQuaternion( tempQuaternion );
-				poseObject.position.add( tempPosition );
-
-			}
-
-			poseObject.updateMatrixWorld();
-
-			//
-
-			cameraL.near = camera.near;
-			cameraR.near = camera.near;
-
-			cameraL.far = camera.far;
-			cameraR.far = camera.far;
-
-			cameraL.matrixWorldInverse.fromArray( frameData.leftViewMatrix );
-			cameraR.matrixWorldInverse.fromArray( frameData.rightViewMatrix );
-
-			// TODO (mrdoob) Double check this code
-
-			standingMatrixInverse.getInverse( standingMatrix );
-
-			if ( referenceSpaceType === 'local-floor' ) {
-
-				cameraL.matrixWorldInverse.multiply( standingMatrixInverse );
-				cameraR.matrixWorldInverse.multiply( standingMatrixInverse );
-
-			}
-
-			var parent = poseObject.parent;
-
-			if ( parent !== null ) {
-
-				matrixWorldInverse.getInverse( parent.matrixWorld );
-
-				cameraL.matrixWorldInverse.multiply( matrixWorldInverse );
-				cameraR.matrixWorldInverse.multiply( matrixWorldInverse );
-
-			}
-
-			// envMap and Mirror needs camera.matrixWorld
-
-			cameraL.matrixWorld.getInverse( cameraL.matrixWorldInverse );
-			cameraR.matrixWorld.getInverse( cameraR.matrixWorldInverse );
-
-			cameraL.projectionMatrix.fromArray( frameData.leftProjectionMatrix );
-			cameraR.projectionMatrix.fromArray( frameData.rightProjectionMatrix );
-
-			setProjectionFromUnion( cameraVR, cameraL, cameraR );
-
-			//
-
-			var layers = device.getLayers();
-
-			if ( layers.length ) {
-
-				var layer = layers[ 0 ];
-
-				updateViewportFromBounds( cameraL.viewport, layer.leftBounds );
-				updateViewportFromBounds( cameraR.viewport, layer.rightBounds );
-
-			}
-
-			updateControllers();
-
-			return cameraVR;
-
-		};
-
-		this.getStandingMatrix = function () {
-
-			return standingMatrix;
-
-		};
-
-		this.isPresenting = isPresenting;
-
-		// Animation Loop
-
-		var animation = new WebGLAnimation();
-
-		this.setAnimationLoop = function ( callback ) {
-
-			animation.setAnimationLoop( callback );
-
-			if ( isPresenting() ) animation.start();
-
-		};
-
-		this.submitFrame = function () {
-
-			if ( isPresenting() ) device.submitFrame();
-
-		};
-
-		this.dispose = function () {
-
-			if ( typeof window !== 'undefined' ) {
-
-				window.removeEventListener( 'vrdisplaypresentchange', onVRDisplayPresentChange );
-
-			}
-
-		};
-
-		// DEPRECATED
-
-		this.setFrameOfReferenceType = function () {
-
-			console.warn( 'THREE.WebVRManager: setFrameOfReferenceType() has been deprecated.' );
-
-		};
-
-	}
-
-	Object.assign( WebVRManager.prototype, EventDispatcher.prototype );
+	} );
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -22796,19 +23053,15 @@ var Spacekit = (function (exports) {
 
 		var session = null;
 
+		var framebufferScaleFactor = 1.0;
+
 		var referenceSpace = null;
 		var referenceSpaceType = 'local-floor';
 
 		var pose = null;
 
 		var controllers = [];
-		var inputSources = [];
-
-		function isPresenting() {
-
-			return session !== null && referenceSpace !== null;
-
-		}
+		var inputSourcesMap = new Map();
 
 		//
 
@@ -22820,29 +23073,48 @@ var Spacekit = (function (exports) {
 		cameraR.layers.enable( 2 );
 		cameraR.viewport = new Vector4();
 
-		var cameraVR = new ArrayCamera( [ cameraL, cameraR ] );
+		var cameras = [ cameraL, cameraR ];
+
+		var cameraVR = new ArrayCamera();
 		cameraVR.layers.enable( 1 );
 		cameraVR.layers.enable( 2 );
+
+		var _currentDepthNear = null;
+		var _currentDepthFar = null;
 
 		//
 
 		this.enabled = false;
 
-		this.getController = function ( id ) {
+		this.isPresenting = false;
 
-			var controller = controllers[ id ];
+		this.getController = function ( index ) {
+
+			var controller = controllers[ index ];
 
 			if ( controller === undefined ) {
 
-				controller = new Group();
-				controller.matrixAutoUpdate = false;
-				controller.visible = false;
-
-				controllers[ id ] = controller;
+				controller = new WebXRController();
+				controllers[ index ] = controller;
 
 			}
 
-			return controller;
+			return controller.getTargetRaySpace();
+
+		};
+
+		this.getControllerGrip = function ( index ) {
+
+			var controller = controllers[ index ];
+
+			if ( controller === undefined ) {
+
+				controller = new WebXRController();
+				controllers[ index ] = controller;
+
+			}
+
+			return controller.getGripSpace();
 
 		};
 
@@ -22850,13 +23122,11 @@ var Spacekit = (function (exports) {
 
 		function onSessionEvent( event ) {
 
-			for ( var i = 0; i < controllers.length; i ++ ) {
+			var controller = inputSourcesMap.get( event.inputSource );
 
-				if ( inputSources[ i ] === event.inputSource ) {
+			if ( controller ) {
 
-					controllers[ i ].dispatchEvent( { type: event.type } );
-
-				}
+				controller.dispatchEvent( { type: event.type } );
 
 			}
 
@@ -22864,9 +23134,21 @@ var Spacekit = (function (exports) {
 
 		function onSessionEnd() {
 
+			inputSourcesMap.forEach( function ( controller, inputSource ) {
+
+				controller.disconnect( inputSource );
+
+			} );
+
+			inputSourcesMap.clear();
+
+			//
+
 			renderer.setFramebuffer( null );
 			renderer.setRenderTarget( renderer.getRenderTarget() ); // Hack #15830
 			animation.stop();
+
+			scope.isPresenting = false;
 
 			scope.dispatchEvent( { type: 'sessionend' } );
 
@@ -22879,17 +23161,39 @@ var Spacekit = (function (exports) {
 			animation.setContext( session );
 			animation.start();
 
+			scope.isPresenting = true;
+
 			scope.dispatchEvent( { type: 'sessionstart' } );
 
 		}
 
 		this.setFramebufferScaleFactor = function ( value ) {
 
+			framebufferScaleFactor = value;
+
+			if ( scope.isPresenting === true ) {
+
+				console.warn( 'THREE.WebXRManager: Cannot change framebuffer scale while presenting.' );
+
+			}
+
 		};
 
 		this.setReferenceSpaceType = function ( value ) {
 
 			referenceSpaceType = value;
+
+			if ( scope.isPresenting === true ) {
+
+				console.warn( 'THREE.WebXRManager: Cannot change reference space type while presenting.' );
+
+			}
+
+		};
+
+		this.getReferenceSpace = function () {
+
+			return referenceSpace;
 
 		};
 
@@ -22908,33 +23212,142 @@ var Spacekit = (function (exports) {
 				session.addEventListener( 'select', onSessionEvent );
 				session.addEventListener( 'selectstart', onSessionEvent );
 				session.addEventListener( 'selectend', onSessionEvent );
+				session.addEventListener( 'squeeze', onSessionEvent );
+				session.addEventListener( 'squeezestart', onSessionEvent );
+				session.addEventListener( 'squeezeend', onSessionEvent );
 				session.addEventListener( 'end', onSessionEnd );
 
-				session.updateRenderState( { baseLayer: new XRWebGLLayer( session, gl ) } );
+				var attributes = gl.getContextAttributes();
+
+				var layerInit = {
+					antialias: attributes.antialias,
+					alpha: attributes.alpha,
+					depth: attributes.depth,
+					stencil: attributes.stencil,
+					framebufferScaleFactor: framebufferScaleFactor
+				};
+
+				// eslint-disable-next-line no-undef
+				var baseLayer = new XRWebGLLayer( session, gl, layerInit );
+
+				session.updateRenderState( { baseLayer: baseLayer } );
 
 				session.requestReferenceSpace( referenceSpaceType ).then( onRequestReferenceSpace );
 
 				//
 
-				inputSources = session.inputSources;
-
-				session.addEventListener( 'inputsourceschange', function () {
-
-					inputSources = session.inputSources;
-					console.log( inputSources );
-
-					for ( var i = 0; i < controllers.length; i ++ ) {
-
-						var controller = controllers[ i ];
-						controller.userData.inputSource = inputSources[ i ];
-
-					}
-
-				} );
+				session.addEventListener( 'inputsourceschange', updateInputSources );
 
 			}
 
 		};
+
+		function updateInputSources( event ) {
+
+			var inputSources = session.inputSources;
+
+			// Assign inputSources to available controllers
+
+			for ( var i = 0; i < controllers.length; i ++ ) {
+
+				inputSourcesMap.set( inputSources[ i ], controllers[ i ] );
+
+			}
+
+			// Notify disconnected
+
+			for ( var i = 0; i < event.removed.length; i ++ ) {
+
+				var inputSource = event.removed[ i ];
+				var controller = inputSourcesMap.get( inputSource );
+
+				if ( controller ) {
+
+					controller.dispatchEvent( { type: 'disconnected', data: inputSource } );
+					inputSourcesMap.delete( inputSource );
+
+				}
+
+			}
+
+			// Notify connected
+
+			for ( var i = 0; i < event.added.length; i ++ ) {
+
+				var inputSource = event.added[ i ];
+				var controller = inputSourcesMap.get( inputSource );
+
+				if ( controller ) {
+
+					controller.dispatchEvent( { type: 'connected', data: inputSource } );
+
+				}
+
+			}
+
+		}
+
+		//
+
+		var cameraLPos = new Vector3();
+		var cameraRPos = new Vector3();
+
+		/**
+		 * @author jsantell / https://www.jsantell.com/
+		 *
+		 * Assumes 2 cameras that are parallel and share an X-axis, and that
+		 * the cameras' projection and world matrices have already been set.
+		 * And that near and far planes are identical for both cameras.
+		 * Visualization of this technique: https://computergraphics.stackexchange.com/a/4765
+		 */
+		function setProjectionFromUnion( camera, cameraL, cameraR ) {
+
+			cameraLPos.setFromMatrixPosition( cameraL.matrixWorld );
+			cameraRPos.setFromMatrixPosition( cameraR.matrixWorld );
+
+			var ipd = cameraLPos.distanceTo( cameraRPos );
+
+			var projL = cameraL.projectionMatrix.elements;
+			var projR = cameraR.projectionMatrix.elements;
+
+			// VR systems will have identical far and near planes, and
+			// most likely identical top and bottom frustum extents.
+			// Use the left camera for these values.
+			var near = projL[ 14 ] / ( projL[ 10 ] - 1 );
+			var far = projL[ 14 ] / ( projL[ 10 ] + 1 );
+			var topFov = ( projL[ 9 ] + 1 ) / projL[ 5 ];
+			var bottomFov = ( projL[ 9 ] - 1 ) / projL[ 5 ];
+
+			var leftFov = ( projL[ 8 ] - 1 ) / projL[ 0 ];
+			var rightFov = ( projR[ 8 ] + 1 ) / projR[ 0 ];
+			var left = near * leftFov;
+			var right = near * rightFov;
+
+			// Calculate the new camera's position offset from the
+			// left camera. xOffset should be roughly half `ipd`.
+			var zOffset = ipd / ( - leftFov + rightFov );
+			var xOffset = zOffset * - leftFov;
+
+			// TODO: Better way to apply this offset?
+			cameraL.matrixWorld.decompose( camera.position, camera.quaternion, camera.scale );
+			camera.translateX( xOffset );
+			camera.translateZ( zOffset );
+			camera.matrixWorld.compose( camera.position, camera.quaternion, camera.scale );
+			camera.matrixWorldInverse.getInverse( camera.matrixWorld );
+
+			// Find the union of the frustum values of the cameras and scale
+			// the values so that the near plane's position does not change in world space,
+			// although must now be relative to the new union camera.
+			var near2 = near + zOffset;
+			var far2 = far + zOffset;
+			var left2 = left - xOffset;
+			var right2 = right + ( ipd - xOffset );
+			var top2 = topFov * far / far2 * near2;
+			var bottom2 = bottomFov * far / far2 * near2;
+
+			camera.projectionMatrix.makePerspective( left2, right2, top2, bottom2, near2, far2 );
+
+		}
 
 		function updateCamera( camera, parent ) {
 
@@ -22954,42 +23367,63 @@ var Spacekit = (function (exports) {
 
 		this.getCamera = function ( camera ) {
 
-			if ( isPresenting() ) {
+			cameraVR.near = cameraR.near = cameraL.near = camera.near;
+			cameraVR.far = cameraR.far = cameraL.far = camera.far;
 
-				var parent = camera.parent;
-				var cameras = cameraVR.cameras;
+			if ( _currentDepthNear !== cameraVR.near || _currentDepthFar !== cameraVR.far ) {
 
-				updateCamera( cameraVR, parent );
+				// Note that the new renderState won't apply until the next frame. See #18320
 
-				for ( var i = 0; i < cameras.length; i ++ ) {
+				session.updateRenderState( {
+					depthNear: cameraVR.near,
+					depthFar: cameraVR.far
+				} );
 
-					updateCamera( cameras[ i ], parent );
-
-				}
-
-				// update camera and its children
-
-				camera.matrixWorld.copy( cameraVR.matrixWorld );
-
-				var children = camera.children;
-
-				for ( var i = 0, l = children.length; i < l; i ++ ) {
-
-					children[ i ].updateMatrixWorld( true );
-
-				}
-
-				setProjectionFromUnion( cameraVR, cameraL, cameraR );
-
-				return cameraVR;
+				_currentDepthNear = cameraVR.near;
+				_currentDepthFar = cameraVR.far;
 
 			}
 
-			return camera;
+			var parent = camera.parent;
+			var cameras = cameraVR.cameras;
+
+			updateCamera( cameraVR, parent );
+
+			for ( var i = 0; i < cameras.length; i ++ ) {
+
+				updateCamera( cameras[ i ], parent );
+
+			}
+
+			// update camera and its children
+
+			camera.matrixWorld.copy( cameraVR.matrixWorld );
+
+			var children = camera.children;
+
+			for ( var i = 0, l = children.length; i < l; i ++ ) {
+
+				children[ i ].updateMatrixWorld( true );
+
+			}
+
+			// update projection matrix for proper view frustum culling
+
+			if ( cameras.length === 2 ) {
+
+				setProjectionFromUnion( cameraVR, cameraL, cameraR );
+
+			} else {
+
+				// assume single camera setup (AR)
+
+				cameraVR.projectionMatrix.copy( cameraL.projectionMatrix );
+
+			}
+
+			return cameraVR;
 
 		};
-
-		this.isPresenting = isPresenting;
 
 		// Animation Loop
 
@@ -23006,14 +23440,24 @@ var Spacekit = (function (exports) {
 
 				renderer.setFramebuffer( baseLayer.framebuffer );
 
+				var cameraVRNeedsUpdate = false;
+
+				// check if it's necessary to rebuild cameraVR's camera list
+
+				if ( views.length !== cameraVR.cameras.length ) {
+
+					cameraVR.cameras.length = 0;
+					cameraVRNeedsUpdate = true;
+
+				}
+
 				for ( var i = 0; i < views.length; i ++ ) {
 
 					var view = views[ i ];
 					var viewport = baseLayer.getViewport( view );
-					var viewMatrix = view.transform.inverse.matrix;
 
-					var camera = cameraVR.cameras[ i ];
-					camera.matrix.fromArray( viewMatrix ).getInverse( camera.matrix );
+					var camera = cameras[ i ];
+					camera.matrix.fromArray( view.transform.matrix );
 					camera.projectionMatrix.fromArray( view.projectionMatrix );
 					camera.viewport.set( viewport.x, viewport.y, viewport.width, viewport.height );
 
@@ -23023,39 +23467,30 @@ var Spacekit = (function (exports) {
 
 					}
 
+					if ( cameraVRNeedsUpdate === true ) {
+
+						cameraVR.cameras.push( camera );
+
+					}
+
 				}
 
 			}
 
 			//
 
+			var inputSources = session.inputSources;
+
 			for ( var i = 0; i < controllers.length; i ++ ) {
 
 				var controller = controllers[ i ];
-
 				var inputSource = inputSources[ i ];
 
-				if ( inputSource ) {
-
-					var inputPose = frame.getPose( inputSource.targetRaySpace, referenceSpace );
-
-					if ( inputPose !== null ) {
-
-						controller.matrix.fromArray( inputPose.transform.matrix );
-						controller.matrix.decompose( controller.position, controller.rotation, controller.scale );
-						controller.visible = true;
-
-						continue;
-
-					}
-
-				}
-
-				controller.visible = false;
+				controller.update( inputSource, frame, referenceSpace );
 
 			}
 
-			if ( onAnimationFrameCallback ) onAnimationFrameCallback( time );
+			if ( onAnimationFrameCallback ) onAnimationFrameCallback( time, frame );
 
 		}
 
@@ -23070,35 +23505,6 @@ var Spacekit = (function (exports) {
 
 		this.dispose = function () {};
 
-		// DEPRECATED
-
-		this.getStandingMatrix = function () {
-
-			console.warn( 'THREE.WebXRManager: getStandingMatrix() is no longer needed.' );
-			return new Matrix4();
-
-		};
-
-		this.getDevice = function () {
-
-			console.warn( 'THREE.WebXRManager: getDevice() has been deprecated.' );
-
-		};
-
-		this.setDevice = function () {
-
-			console.warn( 'THREE.WebXRManager: setDevice() has been deprecated.' );
-
-		};
-
-		this.setFrameOfReferenceType = function () {
-
-			console.warn( 'THREE.WebXRManager: setFrameOfReferenceType() has been deprecated.' );
-
-		};
-
-		this.submitFrame = function () {};
-
 	}
 
 	Object.assign( WebXRManager.prototype, EventDispatcher.prototype );
@@ -23112,8 +23518,6 @@ var Spacekit = (function (exports) {
 	 */
 
 	function WebGLRenderer( parameters ) {
-
-		console.log( 'THREE.WebGLRenderer', REVISION );
 
 		parameters = parameters || {};
 
@@ -23165,8 +23569,7 @@ var Spacekit = (function (exports) {
 		// physically based shading
 
 		this.gammaFactor = 2.0;	// for backwards compatibility
-		this.gammaInput = false;
-		this.gammaOutput = false;
+		this.outputEncoding = LinearEncoding;
 
 		// physical lights
 
@@ -23174,7 +23577,7 @@ var Spacekit = (function (exports) {
 
 		// tone mapping
 
-		this.toneMapping = LinearToneMapping;
+		this.toneMapping = NoToneMapping;
 		this.toneMappingExposure = 1.0;
 		this.toneMappingWhitePoint = 1.0;
 
@@ -23220,6 +23623,8 @@ var Spacekit = (function (exports) {
 			_height = _canvas.height,
 
 			_pixelRatio = 1,
+			_opaqueSort = null,
+			_transparentSort = null,
 
 			_viewport = new Vector4( 0, 0, _width, _height ),
 			_scissor = new Vector4( 0, 0, _width, _height ),
@@ -23319,7 +23724,7 @@ var Spacekit = (function (exports) {
 
 			capabilities = new WebGLCapabilities( _gl, extensions, parameters );
 
-			if ( ! capabilities.isWebGL2 ) {
+			if ( capabilities.isWebGL2 === false ) {
 
 				extensions.get( 'WEBGL_depth_texture' );
 				extensions.get( 'OES_texture_float' );
@@ -23335,16 +23740,16 @@ var Spacekit = (function (exports) {
 
 			utils = new WebGLUtils( _gl, extensions, capabilities );
 
-			state = new WebGLState( _gl, extensions, utils, capabilities );
+			state = new WebGLState( _gl, extensions, capabilities );
 			state.scissor( _currentScissor.copy( _scissor ).multiplyScalar( _pixelRatio ).floor() );
 			state.viewport( _currentViewport.copy( _viewport ).multiplyScalar( _pixelRatio ).floor() );
 
 			info = new WebGLInfo( _gl );
 			properties = new WebGLProperties();
 			textures = new WebGLTextures( _gl, extensions, state, properties, capabilities, utils, info );
-			attributes = new WebGLAttributes( _gl );
+			attributes = new WebGLAttributes( _gl, capabilities );
 			geometries = new WebGLGeometries( _gl, attributes, info );
-			objects = new WebGLObjects( geometries, info );
+			objects = new WebGLObjects( _gl, geometries, attributes, info );
 			morphtargets = new WebGLMorphtargets( _gl );
 			programCache = new WebGLPrograms( _this, extensions, capabilities );
 			renderLists = new WebGLRenderLists();
@@ -23368,11 +23773,11 @@ var Spacekit = (function (exports) {
 
 		initGLContext();
 
-		// vr
+		// xr
 
-		var vr = ( typeof navigator !== 'undefined' && 'xr' in navigator && 'supportsSession' in navigator.xr ) ? new WebXRManager( _this, _gl ) : new WebVRManager( _this );
+		var xr = new WebXRManager( _this, _gl );
 
-		this.vr = vr;
+		this.xr = xr;
 
 		// shadow map
 
@@ -23440,7 +23845,7 @@ var Spacekit = (function (exports) {
 
 		this.setSize = function ( width, height, updateStyle ) {
 
-			if ( vr.isPresenting() ) {
+			if ( xr.isPresenting ) {
 
 				console.warn( 'THREE.WebGLRenderer: Can\'t change size while VR device is presenting.' );
 				return;
@@ -23562,6 +23967,18 @@ var Spacekit = (function (exports) {
 
 		};
 
+		this.setOpaqueSort = function ( method ) {
+
+			_opaqueSort = method;
+
+		};
+
+		this.setTransparentSort = function ( method ) {
+
+			_transparentSort = method;
+
+		};
+
 		// Clearing
 
 		this.getClearColor = function () {
@@ -23630,7 +24047,7 @@ var Spacekit = (function (exports) {
 			properties.dispose();
 			objects.dispose();
 
-			vr.dispose();
+			xr.dispose();
 
 			animation.stop();
 
@@ -23766,13 +24183,17 @@ var Spacekit = (function (exports) {
 
 		};
 
-		this.renderBufferDirect = function ( camera, fog, geometry, material, object, group ) {
+		var tempScene = new Scene();
+
+		this.renderBufferDirect = function ( camera, scene, geometry, material, object, group ) {
+
+			if ( scene === null ) scene = tempScene; // renderBufferDirect second parameter used to be fog (could be null)
 
 			var frontFaceCW = ( object.isMesh && object.matrixWorld.determinant() < 0 );
 
-			state.setMaterial( material, frontFaceCW );
+			var program = setProgram( camera, scene, material, object );
 
-			var program = setProgram( camera, fog, material, object );
+			state.setMaterial( material, frontFaceCW );
 
 			var updateBuffers = false;
 
@@ -23787,9 +24208,15 @@ var Spacekit = (function (exports) {
 
 			}
 
-			if ( object.morphTargetInfluences ) {
+			if ( material.morphTargets || material.morphNormals ) {
 
 				morphtargets.update( object, geometry, material, program );
+
+				updateBuffers = true;
+
+			}
+
+			if ( object.isInstancedMesh === true ) {
 
 				updateBuffers = true;
 
@@ -23799,6 +24226,21 @@ var Spacekit = (function (exports) {
 
 			var index = geometry.index;
 			var position = geometry.attributes.position;
+
+			//
+
+			if ( index === null ) {
+
+				if ( position === undefined || position.count === 0 ) return;
+
+			} else if ( index.count === 0 ) {
+
+				return;
+
+			}
+
+			//
+
 			var rangeFactor = 1;
 
 			if ( material.wireframe === true ) {
@@ -23822,7 +24264,7 @@ var Spacekit = (function (exports) {
 
 			if ( updateBuffers ) {
 
-				setupVertexAttributes( material, program, geometry );
+				setupVertexAttributes( object, geometry, material, program );
 
 				if ( index !== null ) {
 
@@ -23834,17 +24276,7 @@ var Spacekit = (function (exports) {
 
 			//
 
-			var dataCount = Infinity;
-
-			if ( index !== null ) {
-
-				dataCount = index.count;
-
-			} else if ( position !== undefined ) {
-
-				dataCount = position.count;
-
-			}
+			var dataCount = ( index !== null ) ? index.count : position.count;
 
 			var rangeStart = geometry.drawRange.start * rangeFactor;
 			var rangeCount = geometry.drawRange.count * rangeFactor;
@@ -23870,24 +24302,9 @@ var Spacekit = (function (exports) {
 
 				} else {
 
-					switch ( object.drawMode ) {
-
-						case TrianglesDrawMode:
-							renderer.setMode( 4 );
-							break;
-
-						case TriangleStripDrawMode:
-							renderer.setMode( 5 );
-							break;
-
-						case TriangleFanDrawMode:
-							renderer.setMode( 6 );
-							break;
-
-					}
+					renderer.setMode( 4 );
 
 				}
-
 
 			} else if ( object.isLine ) {
 
@@ -23921,13 +24338,13 @@ var Spacekit = (function (exports) {
 
 			}
 
-			if ( geometry && geometry.isInstancedBufferGeometry ) {
+			if ( object.isInstancedMesh ) {
 
-				if ( geometry.maxInstancedCount > 0 ) {
+				renderer.renderInstances( geometry, drawStart, drawCount, object.count );
 
-					renderer.renderInstances( geometry, drawStart, drawCount );
+			} else if ( geometry.isInstancedBufferGeometry ) {
 
-				}
+				renderer.renderInstances( geometry, drawStart, drawCount, geometry.maxInstancedCount );
 
 			} else {
 
@@ -23937,16 +24354,11 @@ var Spacekit = (function (exports) {
 
 		};
 
-		function setupVertexAttributes( material, program, geometry ) {
+		function setupVertexAttributes( object, geometry, material, program ) {
 
-			if ( geometry && geometry.isInstancedBufferGeometry && ! capabilities.isWebGL2 ) {
+			if ( capabilities.isWebGL2 === false && ( object.isInstancedMesh || geometry.isInstancedBufferGeometry ) ) {
 
-				if ( extensions.get( 'ANGLE_instanced_arrays' ) === null ) {
-
-					console.error( 'THREE.WebGLRenderer.setupVertexAttributes: using THREE.InstancedBufferGeometry but hardware does not support extension ANGLE_instanced_arrays.' );
-					return;
-
-				}
+				if ( extensions.get( 'ANGLE_instanced_arrays' ) === null ) return;
 
 			}
 
@@ -24004,7 +24416,7 @@ var Spacekit = (function (exports) {
 							}
 
 							_gl.bindBuffer( 34962, buffer );
-							_gl.vertexAttribPointer( programAttribute, size, type, normalized, stride * bytesPerElement, offset * bytesPerElement );
+							state.vertexAttribPointer( programAttribute, size, type, normalized, stride * bytesPerElement, offset * bytesPerElement );
 
 						} else {
 
@@ -24025,9 +24437,32 @@ var Spacekit = (function (exports) {
 							}
 
 							_gl.bindBuffer( 34962, buffer );
-							_gl.vertexAttribPointer( programAttribute, size, type, normalized, 0, 0 );
+							state.vertexAttribPointer( programAttribute, size, type, normalized, 0, 0 );
 
 						}
+
+					} else if ( name === 'instanceMatrix' ) {
+
+						var attribute = attributes.get( object.instanceMatrix );
+
+						// TODO Attribute may not be available on context restore
+
+						if ( attribute === undefined ) continue;
+
+						var buffer = attribute.buffer;
+						var type = attribute.type;
+
+						state.enableAttributeAndDivisor( programAttribute + 0, 1 );
+						state.enableAttributeAndDivisor( programAttribute + 1, 1 );
+						state.enableAttributeAndDivisor( programAttribute + 2, 1 );
+						state.enableAttributeAndDivisor( programAttribute + 3, 1 );
+
+						_gl.bindBuffer( 34962, buffer );
+
+						_gl.vertexAttribPointer( programAttribute + 0, 4, type, false, 64, 0 );
+						_gl.vertexAttribPointer( programAttribute + 1, 4, type, false, 64, 16 );
+						_gl.vertexAttribPointer( programAttribute + 2, 4, type, false, 64, 32 );
+						_gl.vertexAttribPointer( programAttribute + 3, 4, type, false, 64, 48 );
 
 					} else if ( materialDefaultAttributeValues !== undefined ) {
 
@@ -24091,6 +24526,8 @@ var Spacekit = (function (exports) {
 
 			currentRenderState.setupLights( camera );
 
+			var compiled = {};
+
 			scene.traverse( function ( object ) {
 
 				if ( object.material ) {
@@ -24099,13 +24536,19 @@ var Spacekit = (function (exports) {
 
 						for ( var i = 0; i < object.material.length; i ++ ) {
 
-							initMaterial( object.material[ i ], scene.fog, object );
+							if ( object.material[ i ].uuid in compiled === false ) {
+
+								initMaterial( object.material[ i ], scene, object );
+								compiled[ object.material[ i ].uuid ] = true;
+
+							}
 
 						}
 
-					} else {
+					} else if ( object.material.uuid in compiled === false ) {
 
-						initMaterial( object.material, scene.fog, object );
+						initMaterial( object.material, scene, object );
+						compiled[ object.material.uuid ] = true;
 
 					}
 
@@ -24121,7 +24564,7 @@ var Spacekit = (function (exports) {
 
 		function onAnimationFrame( time ) {
 
-			if ( vr.isPresenting() ) return;
+			if ( xr.isPresenting ) return;
 			if ( onAnimationFrameCallback ) onAnimationFrameCallback( time );
 
 		}
@@ -24134,7 +24577,7 @@ var Spacekit = (function (exports) {
 		this.setAnimationLoop = function ( callback ) {
 
 			onAnimationFrameCallback = callback;
-			vr.setAnimationLoop( callback );
+			xr.setAnimationLoop( callback );
 
 			animation.start();
 
@@ -24185,21 +24628,20 @@ var Spacekit = (function (exports) {
 
 			if ( camera.parent === null ) camera.updateMatrixWorld();
 
-			if ( vr.enabled ) {
+			if ( xr.enabled && xr.isPresenting ) {
 
-				camera = vr.getCamera( camera );
+				camera = xr.getCamera( camera );
 
 			}
 
 			//
+			scene.onBeforeRender( _this, scene, camera, renderTarget || _currentRenderTarget );
 
 			currentRenderState = renderStates.get( scene, camera );
 			currentRenderState.init();
 
-			scene.onBeforeRender( _this, scene, camera, renderTarget || _currentRenderTarget );
-
 			_projScreenMatrix.multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse );
-			_frustum.setFromMatrix( _projScreenMatrix );
+			_frustum.setFromProjectionMatrix( _projScreenMatrix );
 
 			_localClippingEnabled = this.localClippingEnabled;
 			_clippingEnabled = _clipping.init( this.clippingPlanes, _localClippingEnabled, camera );
@@ -24209,9 +24651,11 @@ var Spacekit = (function (exports) {
 
 			projectObject( scene, camera, 0, _this.sortObjects );
 
+			currentRenderList.finish();
+
 			if ( _this.sortObjects === true ) {
 
-				currentRenderList.sort();
+				currentRenderList.sort( _opaqueSort, _transparentSort );
 
 			}
 
@@ -24291,12 +24735,6 @@ var Spacekit = (function (exports) {
 
 			state.setPolygonOffset( false );
 
-			if ( vr.enabled ) {
-
-				vr.submitFrame();
-
-			}
-
 			// _gl.finish();
 
 			currentRenderList = null;
@@ -24367,7 +24805,14 @@ var Spacekit = (function (exports) {
 
 					if ( object.isSkinnedMesh ) {
 
-						object.skeleton.update();
+						// update skeleton only once in a frame
+
+						if ( object.skeleton.frame !== info.render.frame ) {
+
+							object.skeleton.update();
+							object.skeleton.frame = info.render.frame;
+
+						}
 
 					}
 
@@ -24477,9 +24922,9 @@ var Spacekit = (function (exports) {
 
 			if ( object.isImmediateRenderObject ) {
 
-				state.setMaterial( material );
+				var program = setProgram( camera, scene, material, object );
 
-				var program = setProgram( camera, scene.fog, material, object );
+				state.setMaterial( material );
 
 				_currentGeometryProgram.geometry = null;
 				_currentGeometryProgram.program = null;
@@ -24489,7 +24934,7 @@ var Spacekit = (function (exports) {
 
 			} else {
 
-				_this.renderBufferDirect( camera, scene.fog, geometry, material, object, group );
+				_this.renderBufferDirect( camera, scene, geometry, material, object, group );
 
 			}
 
@@ -24498,7 +24943,7 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function initMaterial( material, fog, object ) {
+		function initMaterial( material, scene, object ) {
 
 			var materialProperties = properties.get( material );
 
@@ -24507,10 +24952,8 @@ var Spacekit = (function (exports) {
 
 			var lightsStateVersion = lights.state.version;
 
-			var parameters = programCache.getParameters(
-				material, lights.state, shadowsArray, fog, _clipping.numPlanes, _clipping.numIntersection, object );
-
-			var code = programCache.getProgramCode( material, parameters );
+			var parameters = programCache.getParameters( material, lights.state, shadowsArray, scene, _clipping.numPlanes, _clipping.numIntersection, object );
+			var programCacheKey = programCache.getProgramCacheKey( parameters );
 
 			var program = materialProperties.program;
 			var programChange = true;
@@ -24520,7 +24963,7 @@ var Spacekit = (function (exports) {
 				// new material
 				material.addEventListener( 'dispose', onMaterialDispose );
 
-			} else if ( program.code !== code ) {
+			} else if ( program.cacheKey !== programCacheKey ) {
 
 				// changed glsl or parameters
 				releaseMaterialProgramReference( material );
@@ -24545,36 +24988,11 @@ var Spacekit = (function (exports) {
 
 			if ( programChange ) {
 
-				if ( parameters.shaderID ) {
-
-					var shader = ShaderLib[ parameters.shaderID ];
-
-					materialProperties.shader = {
-						name: material.type,
-						uniforms: cloneUniforms( shader.uniforms ),
-						vertexShader: shader.vertexShader,
-						fragmentShader: shader.fragmentShader
-					};
-
-				} else {
-
-					materialProperties.shader = {
-						name: material.type,
-						uniforms: material.uniforms,
-						vertexShader: material.vertexShader,
-						fragmentShader: material.fragmentShader
-					};
-
-				}
-
-				material.onBeforeCompile( materialProperties.shader, _this );
-
-				// Computing code again as onBeforeCompile may have changed the shaders
-				code = programCache.getProgramCode( material, parameters );
-
-				program = programCache.acquireProgram( material, materialProperties.shader, parameters, code );
+				program = programCache.acquireProgram( parameters, programCacheKey );
 
 				materialProperties.program = program;
+				materialProperties.uniforms = parameters.uniforms;
+				materialProperties.outputEncoding = parameters.outputEncoding;
 				material.program = program;
 
 			}
@@ -24613,7 +25031,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			var uniforms = materialProperties.shader.uniforms;
+			var uniforms = materialProperties.uniforms;
 
 			if ( ! material.isShaderMaterial &&
 				! material.isRawShaderMaterial ||
@@ -24625,22 +25043,27 @@ var Spacekit = (function (exports) {
 
 			}
 
-			materialProperties.fog = fog;
+			materialProperties.environment = material.isMeshStandardMaterial ? scene.environment : null;
+			materialProperties.fog = scene.fog;
 
 			// store the light setup it was created for
 
+			materialProperties.needsLights = materialNeedsLights( material );
 			materialProperties.lightsStateVersion = lightsStateVersion;
 
-			if ( material.lights ) {
+			if ( materialProperties.needsLights ) {
 
 				// wire up the material to this renderer's lighting state
 
 				uniforms.ambientLightColor.value = lights.state.ambient;
 				uniforms.lightProbe.value = lights.state.probe;
 				uniforms.directionalLights.value = lights.state.directional;
+				uniforms.directionalLightShadows.value = lights.state.directionalShadow;
 				uniforms.spotLights.value = lights.state.spot;
+				uniforms.spotLightShadows.value = lights.state.spotShadow;
 				uniforms.rectAreaLights.value = lights.state.rectArea;
 				uniforms.pointLights.value = lights.state.point;
+				uniforms.pointLightShadows.value = lights.state.pointShadow;
 				uniforms.hemisphereLights.value = lights.state.hemi;
 
 				uniforms.directionalShadowMap.value = lights.state.directionalShadowMap;
@@ -24661,9 +25084,13 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function setProgram( camera, fog, material, object ) {
+		function setProgram( camera, scene, material, object ) {
 
 			textures.resetTextureUnits();
+
+			var fog = scene.fog;
+			var environment = material.isMeshStandardMaterial ? scene.environment : null;
+			var encoding = ( _currentRenderTarget === null ) ? _this.outputEncoding : _currentRenderTarget.texture.encoding;
 
 			var materialProperties = properties.get( material );
 			var lights = currentRenderState.state.lights;
@@ -24687,34 +25114,40 @@ var Spacekit = (function (exports) {
 
 			}
 
-			if ( material.needsUpdate === false ) {
+			if ( material.version === materialProperties.__version ) {
 
 				if ( materialProperties.program === undefined ) {
 
-					material.needsUpdate = true;
+					initMaterial( material, scene, object );
 
 				} else if ( material.fog && materialProperties.fog !== fog ) {
 
-					material.needsUpdate = true;
+					initMaterial( material, scene, object );
 
-				} else if ( material.lights && materialProperties.lightsStateVersion !== lights.state.version ) {
+				} else if ( materialProperties.environment !== environment ) {
 
-					material.needsUpdate = true;
+					initMaterial( material, scene, object );
+
+				} else if ( materialProperties.needsLights && ( materialProperties.lightsStateVersion !== lights.state.version ) ) {
+
+					initMaterial( material, scene, object );
 
 				} else if ( materialProperties.numClippingPlanes !== undefined &&
 					( materialProperties.numClippingPlanes !== _clipping.numPlanes ||
 					materialProperties.numIntersection !== _clipping.numIntersection ) ) {
 
-					material.needsUpdate = true;
+					initMaterial( material, scene, object );
+
+				} else if ( materialProperties.outputEncoding !== encoding ) {
+
+					initMaterial( material, scene, object );
 
 				}
 
-			}
+			} else {
 
-			if ( material.needsUpdate ) {
-
-				initMaterial( material, fog, object );
-				material.needsUpdate = false;
+				initMaterial( material, scene, object );
+				materialProperties.__version = material.version;
 
 			}
 
@@ -24724,7 +25157,7 @@ var Spacekit = (function (exports) {
 
 			var program = materialProperties.program,
 				p_uniforms = program.getUniforms(),
-				m_uniforms = materialProperties.shader.uniforms;
+				m_uniforms = materialProperties.uniforms;
 
 			if ( state.useProgram( program.program ) ) {
 
@@ -24771,6 +25204,7 @@ var Spacekit = (function (exports) {
 
 				if ( material.isShaderMaterial ||
 					material.isMeshPhongMaterial ||
+					material.isMeshToonMaterial ||
 					material.isMeshStandardMaterial ||
 					material.envMap ) {
 
@@ -24786,6 +25220,18 @@ var Spacekit = (function (exports) {
 				}
 
 				if ( material.isMeshPhongMaterial ||
+					material.isMeshToonMaterial ||
+					material.isMeshLambertMaterial ||
+					material.isMeshBasicMaterial ||
+					material.isMeshStandardMaterial ||
+					material.isShaderMaterial ) {
+
+					p_uniforms.setValue( _gl, 'isOrthographic', camera.isOrthographicCamera === true );
+
+				}
+
+				if ( material.isMeshPhongMaterial ||
+					material.isMeshToonMaterial ||
 					material.isMeshLambertMaterial ||
 					material.isMeshBasicMaterial ||
 					material.isMeshStandardMaterial ||
@@ -24800,7 +25246,7 @@ var Spacekit = (function (exports) {
 
 			// skinning uniforms must be set even if material didn't change
 			// auto-setting of texture unit for bone texture must go before other textures
-			// not sure why, but otherwise weird things happen
+			// otherwise textures used for skinning can take over texture units reserved for other material textures
 
 			if ( material.skinning ) {
 
@@ -24826,14 +25272,13 @@ var Spacekit = (function (exports) {
 
 
 							var size = Math.sqrt( bones.length * 4 ); // 4 pixels needed for 1 matrix
-							size = _Math.ceilPowerOfTwo( size );
+							size = MathUtils.ceilPowerOfTwo( size );
 							size = Math.max( size, 4 );
 
 							var boneMatrices = new Float32Array( size * size * 4 ); // 4 floats per RGBA pixel
 							boneMatrices.set( skeleton.boneMatrices ); // copy current values
 
 							var boneTexture = new DataTexture( boneMatrices, size, size, RGBAFormat, FloatType );
-							boneTexture.needsUpdate = true;
 
 							skeleton.boneMatrices = boneMatrices;
 							skeleton.boneTexture = boneTexture;
@@ -24854,12 +25299,19 @@ var Spacekit = (function (exports) {
 
 			}
 
+			if ( refreshMaterial || materialProperties.receiveShadow !== object.receiveShadow ) {
+
+				materialProperties.receiveShadow = object.receiveShadow;
+				p_uniforms.setValue( _gl, 'receiveShadow', object.receiveShadow );
+
+			}
+
 			if ( refreshMaterial ) {
 
 				p_uniforms.setValue( _gl, 'toneMappingExposure', _this.toneMappingExposure );
 				p_uniforms.setValue( _gl, 'toneMappingWhitePoint', _this.toneMappingWhitePoint );
 
-				if ( material.lights ) {
+				if ( materialProperties.needsLights ) {
 
 					// the current material requires lighting info
 
@@ -24891,38 +25343,33 @@ var Spacekit = (function (exports) {
 					refreshUniformsCommon( m_uniforms, material );
 					refreshUniformsLambert( m_uniforms, material );
 
+				} else if ( material.isMeshToonMaterial ) {
+
+					refreshUniformsCommon( m_uniforms, material );
+					refreshUniformsToon( m_uniforms, material );
+
 				} else if ( material.isMeshPhongMaterial ) {
 
 					refreshUniformsCommon( m_uniforms, material );
-
-					if ( material.isMeshToonMaterial ) {
-
-						refreshUniformsToon( m_uniforms, material );
-
-					} else {
-
-						refreshUniformsPhong( m_uniforms, material );
-
-					}
+					refreshUniformsPhong( m_uniforms, material );
 
 				} else if ( material.isMeshStandardMaterial ) {
 
-					refreshUniformsCommon( m_uniforms, material );
+					refreshUniformsCommon( m_uniforms, material, environment );
 
 					if ( material.isMeshPhysicalMaterial ) {
 
-						refreshUniformsPhysical( m_uniforms, material );
+						refreshUniformsPhysical( m_uniforms, material, environment );
 
 					} else {
 
-						refreshUniformsStandard( m_uniforms, material );
+						refreshUniformsStandard( m_uniforms, material, environment );
 
 					}
 
 				} else if ( material.isMeshMatcapMaterial ) {
 
 					refreshUniformsCommon( m_uniforms, material );
-
 					refreshUniformsMatcap( m_uniforms, material );
 
 				} else if ( material.isMeshDepthMaterial ) {
@@ -24973,6 +25420,12 @@ var Spacekit = (function (exports) {
 
 				WebGLUniforms.upload( _gl, materialProperties.uniformsList, m_uniforms, textures );
 
+				if ( material.isShaderMaterial ) {
+
+					material.uniformsNeedUpdate = false; // #15581
+
+				}
+
 			}
 
 			if ( material.isShaderMaterial && material.uniformsNeedUpdate === true ) {
@@ -25000,7 +25453,7 @@ var Spacekit = (function (exports) {
 
 		// Uniforms (refresh uniforms objects)
 
-		function refreshUniformsCommon( uniforms, material ) {
+		function refreshUniformsCommon( uniforms, material, environment ) {
 
 			uniforms.opacity.value = material.opacity;
 
@@ -25034,20 +25487,18 @@ var Spacekit = (function (exports) {
 
 			}
 
-			if ( material.envMap ) {
+			var envMap = material.envMap || environment;
 
-				uniforms.envMap.value = material.envMap;
+			if ( envMap ) {
 
-				// don't flip CubeTexture envMaps, flip everything else:
-				//  WebGLRenderTargetCube will be flipped for backwards compatibility
-				//  WebGLRenderTargetCube.texture will be flipped because it's a Texture and NOT a CubeTexture
-				// this check must be handled differently, or removed entirely, if WebGLRenderTargetCube uses a CubeTexture in the future
-				uniforms.flipEnvMap.value = material.envMap.isCubeTexture ? - 1 : 1;
+				uniforms.envMap.value = envMap;
+
+				uniforms.flipEnvMap.value = envMap.isCubeTexture ? - 1 : 1;
 
 				uniforms.reflectivity.value = material.reflectivity;
 				uniforms.refractionRatio.value = material.refractionRatio;
 
-				uniforms.maxMipLevel.value = properties.get( material.envMap ).__maxMipLevel;
+				uniforms.maxMipLevel.value = properties.get( envMap ).__maxMipLevel;
 
 			}
 
@@ -25132,6 +25583,41 @@ var Spacekit = (function (exports) {
 
 			}
 
+			// uv repeat and offset setting priorities for uv2
+			// 1. ao map
+			// 2. light map
+
+			var uv2ScaleMap;
+
+			if ( material.aoMap ) {
+
+				uv2ScaleMap = material.aoMap;
+
+			} else if ( material.lightMap ) {
+
+				uv2ScaleMap = material.lightMap;
+
+			}
+
+			if ( uv2ScaleMap !== undefined ) {
+
+				// backwards compatibility
+				if ( uv2ScaleMap.isWebGLRenderTarget ) {
+
+					uv2ScaleMap = uv2ScaleMap.texture;
+
+				}
+
+				if ( uv2ScaleMap.matrixAutoUpdate === true ) {
+
+					uv2ScaleMap.updateMatrix();
+
+				}
+
+				uniforms.uv2Transform.value.copy( uv2ScaleMap.matrix );
+
+			}
+
 		}
 
 		function refreshUniformsLine( uniforms, material ) {
@@ -25156,17 +25642,43 @@ var Spacekit = (function (exports) {
 			uniforms.size.value = material.size * _pixelRatio;
 			uniforms.scale.value = _height * 0.5;
 
-			uniforms.map.value = material.map;
+			if ( material.map ) {
 
-			if ( material.map !== null ) {
+				uniforms.map.value = material.map;
 
-				if ( material.map.matrixAutoUpdate === true ) {
+			}
 
-					material.map.updateMatrix();
+			if ( material.alphaMap ) {
+
+				uniforms.alphaMap.value = material.alphaMap;
+
+			}
+
+			// uv repeat and offset setting priorities
+			// 1. color map
+			// 2. alpha map
+
+			var uvScaleMap;
+
+			if ( material.map ) {
+
+				uvScaleMap = material.map;
+
+			} else if ( material.alphaMap ) {
+
+				uvScaleMap = material.alphaMap;
+
+			}
+
+			if ( uvScaleMap !== undefined ) {
+
+				if ( uvScaleMap.matrixAutoUpdate === true ) {
+
+					uvScaleMap.updateMatrix();
 
 				}
 
-				uniforms.uvTransform.value.copy( material.map.matrix );
+				uniforms.uvTransform.value.copy( uvScaleMap.matrix );
 
 			}
 
@@ -25177,17 +25689,44 @@ var Spacekit = (function (exports) {
 			uniforms.diffuse.value.copy( material.color );
 			uniforms.opacity.value = material.opacity;
 			uniforms.rotation.value = material.rotation;
-			uniforms.map.value = material.map;
 
-			if ( material.map !== null ) {
+			if ( material.map ) {
 
-				if ( material.map.matrixAutoUpdate === true ) {
+				uniforms.map.value = material.map;
 
-					material.map.updateMatrix();
+			}
+
+			if ( material.alphaMap ) {
+
+				uniforms.alphaMap.value = material.alphaMap;
+
+			}
+
+			// uv repeat and offset setting priorities
+			// 1. color map
+			// 2. alpha map
+
+			var uvScaleMap;
+
+			if ( material.map ) {
+
+				uvScaleMap = material.map;
+
+			} else if ( material.alphaMap ) {
+
+				uvScaleMap = material.alphaMap;
+
+			}
+
+			if ( uvScaleMap !== undefined ) {
+
+				if ( uvScaleMap.matrixAutoUpdate === true ) {
+
+					uvScaleMap.updateMatrix();
 
 				}
 
-				uniforms.uvTransform.value.copy( material.map.matrix );
+				uniforms.uvTransform.value.copy( uvScaleMap.matrix );
 
 			}
 
@@ -25259,7 +25798,8 @@ var Spacekit = (function (exports) {
 
 		function refreshUniformsToon( uniforms, material ) {
 
-			refreshUniformsPhong( uniforms, material );
+			uniforms.specular.value.copy( material.specular );
+			uniforms.shininess.value = Math.max( material.shininess, 1e-4 ); // to prevent pow( 0.0, 0.0 )
 
 			if ( material.gradientMap ) {
 
@@ -25267,9 +25807,39 @@ var Spacekit = (function (exports) {
 
 			}
 
+			if ( material.emissiveMap ) {
+
+				uniforms.emissiveMap.value = material.emissiveMap;
+
+			}
+
+			if ( material.bumpMap ) {
+
+				uniforms.bumpMap.value = material.bumpMap;
+				uniforms.bumpScale.value = material.bumpScale;
+				if ( material.side === BackSide ) uniforms.bumpScale.value *= - 1;
+
+			}
+
+			if ( material.normalMap ) {
+
+				uniforms.normalMap.value = material.normalMap;
+				uniforms.normalScale.value.copy( material.normalScale );
+				if ( material.side === BackSide ) uniforms.normalScale.value.negate();
+
+			}
+
+			if ( material.displacementMap ) {
+
+				uniforms.displacementMap.value = material.displacementMap;
+				uniforms.displacementScale.value = material.displacementScale;
+				uniforms.displacementBias.value = material.displacementBias;
+
+			}
+
 		}
 
-		function refreshUniformsStandard( uniforms, material ) {
+		function refreshUniformsStandard( uniforms, material, environment ) {
 
 			uniforms.roughness.value = material.roughness;
 			uniforms.metalness.value = material.metalness;
@@ -25316,7 +25886,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			if ( material.envMap ) {
+			if ( material.envMap || environment ) {
 
 				//uniforms.envMap.value = material.envMap; // part of uniforms common
 				uniforms.envMapIntensity.value = material.envMapIntensity;
@@ -25325,14 +25895,42 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function refreshUniformsPhysical( uniforms, material ) {
+		function refreshUniformsPhysical( uniforms, material, environment ) {
 
-			refreshUniformsStandard( uniforms, material );
+			refreshUniformsStandard( uniforms, material, environment );
 
 			uniforms.reflectivity.value = material.reflectivity; // also part of uniforms common
 
-			uniforms.clearCoat.value = material.clearCoat;
-			uniforms.clearCoatRoughness.value = material.clearCoatRoughness;
+			uniforms.clearcoat.value = material.clearcoat;
+			uniforms.clearcoatRoughness.value = material.clearcoatRoughness;
+			if ( material.sheen ) uniforms.sheen.value.copy( material.sheen );
+
+			if ( material.clearcoatMap ) {
+
+				uniforms.clearcoatMap.value = material.clearcoatMap;
+
+			}
+
+			if ( material.clearcoatRoughnessMap ) {
+
+				uniforms.clearcoatRoughnessMap.value = material.clearcoatRoughnessMap;
+
+			}
+
+			if ( material.clearcoatNormalMap ) {
+
+				uniforms.clearcoatNormalScale.value.copy( material.clearcoatNormalScale );
+				uniforms.clearcoatNormalMap.value = material.clearcoatNormalMap;
+
+				if ( material.side === BackSide ) {
+
+					uniforms.clearcoatNormalScale.value.negate();
+
+				}
+
+			}
+
+			uniforms.transparency.value = material.transparency;
 
 		}
 
@@ -25434,17 +26032,28 @@ var Spacekit = (function (exports) {
 			uniforms.lightProbe.needsUpdate = value;
 
 			uniforms.directionalLights.needsUpdate = value;
+			uniforms.directionalLightShadows.needsUpdate = value;
 			uniforms.pointLights.needsUpdate = value;
+			uniforms.pointLightShadows.needsUpdate = value;
 			uniforms.spotLights.needsUpdate = value;
+			uniforms.spotLightShadows.needsUpdate = value;
 			uniforms.rectAreaLights.needsUpdate = value;
 			uniforms.hemisphereLights.needsUpdate = value;
+
+		}
+
+		function materialNeedsLights( material ) {
+
+			return material.isMeshLambertMaterial || material.isMeshToonMaterial || material.isMeshPhongMaterial ||
+				material.isMeshStandardMaterial || material.isShadowMaterial ||
+				( material.isShaderMaterial && material.lights === true );
 
 		}
 
 		//
 		this.setFramebuffer = function ( value ) {
 
-			if ( _framebuffer !== value ) _gl.bindFramebuffer( 36160, value );
+			if ( _framebuffer !== value && _currentRenderTarget === null ) _gl.bindFramebuffer( 36160, value );
 
 			_framebuffer = value;
 
@@ -25487,7 +26096,7 @@ var Spacekit = (function (exports) {
 
 				var __webglFramebuffer = properties.get( renderTarget ).__webglFramebuffer;
 
-				if ( renderTarget.isWebGLRenderTargetCube ) {
+				if ( renderTarget.isWebGLCubeRenderTarget ) {
 
 					framebuffer = __webglFramebuffer[ activeCubeFace || 0 ];
 					isCube = true;
@@ -25545,7 +26154,7 @@ var Spacekit = (function (exports) {
 
 			var framebuffer = properties.get( renderTarget ).__webglFramebuffer;
 
-			if ( renderTarget.isWebGLRenderTargetCube && activeCubeFaceIndex !== undefined ) {
+			if ( renderTarget.isWebGLCubeRenderTarget && activeCubeFaceIndex !== undefined ) {
 
 				framebuffer = framebuffer[ activeCubeFaceIndex ];
 
@@ -25617,17 +26226,24 @@ var Spacekit = (function (exports) {
 
 		this.copyFramebufferToTexture = function ( position, texture, level ) {
 
-			var width = texture.image.width;
-			var height = texture.image.height;
+			if ( level === undefined ) level = 0;
+
+			var levelScale = Math.pow( 2, - level );
+			var width = Math.floor( texture.image.width * levelScale );
+			var height = Math.floor( texture.image.height * levelScale );
 			var glFormat = utils.convert( texture.format );
 
 			textures.setTexture2D( texture, 0 );
 
-			_gl.copyTexImage2D( 3553, level || 0, glFormat, position.x, position.y, width, height, 0 );
+			_gl.copyTexImage2D( 3553, level, glFormat, position.x, position.y, width, height, 0 );
+
+			state.unbindTexture();
 
 		};
 
 		this.copyTextureToTexture = function ( position, srcTexture, dstTexture, level ) {
+
+			if ( level === undefined ) level = 0;
 
 			var width = srcTexture.image.width;
 			var height = srcTexture.image.height;
@@ -25638,13 +26254,34 @@ var Spacekit = (function (exports) {
 
 			if ( srcTexture.isDataTexture ) {
 
-				_gl.texSubImage2D( 3553, level || 0, position.x, position.y, width, height, glFormat, glType, srcTexture.image.data );
+				_gl.texSubImage2D( 3553, level, position.x, position.y, width, height, glFormat, glType, srcTexture.image.data );
 
 			} else {
 
-				_gl.texSubImage2D( 3553, level || 0, position.x, position.y, glFormat, glType, srcTexture.image );
+				if ( srcTexture.isCompressedTexture ) {
+
+					_gl.compressedTexSubImage2D( 3553, level, position.x, position.y, srcTexture.mipmaps[ 0 ].width, srcTexture.mipmaps[ 0 ].height, glFormat, srcTexture.mipmaps[ 0 ].data );
+
+				} else {
+
+					_gl.texSubImage2D( 3553, level, position.x, position.y, glFormat, glType, srcTexture.image );
+
+				}
 
 			}
+
+			// Generate mipmaps only when copying level 0
+			if ( level === 0 && dstTexture.generateMipmaps ) _gl.generateMipmap( 3553 );
+
+			state.unbindTexture();
+
+		};
+
+		this.initTexture = function ( texture ) {
+
+			textures.setTexture2D( texture, 0 );
+
+			state.unbindTexture();
 
 		};
 
@@ -25741,7 +26378,7 @@ var Spacekit = (function (exports) {
 		this.stride = stride;
 		this.count = array !== undefined ? array.length / stride : 0;
 
-		this.dynamic = false;
+		this.usage = StaticDrawUsage;
 		this.updateRange = { offset: 0, count: - 1 };
 
 		this.version = 0;
@@ -25764,24 +26401,9 @@ var Spacekit = (function (exports) {
 
 		onUploadCallback: function () {},
 
-		setArray: function ( array ) {
+		setUsage: function ( value ) {
 
-			if ( Array.isArray( array ) ) {
-
-				throw new TypeError( 'THREE.BufferAttribute: array should be a Typed Array.' );
-
-			}
-
-			this.count = array !== undefined ? array.length / this.stride : 0;
-			this.array = array;
-
-			return this;
-
-		},
-
-		setDynamic: function ( value ) {
-
-			this.dynamic = value;
+			this.usage = value;
 
 			return this;
 
@@ -25792,7 +26414,7 @@ var Spacekit = (function (exports) {
 			this.array = new source.array.constructor( source.array );
 			this.count = source.count;
 			this.stride = source.stride;
-			this.dynamic = source.dynamic;
+			this.usage = source.usage;
 
 			return this;
 
@@ -25843,6 +26465,8 @@ var Spacekit = (function (exports) {
 	 * @author benaadams / https://twitter.com/ben_a_adams
 	 */
 
+	var _vector$6 = new Vector3();
+
 	function InterleavedBufferAttribute( interleavedBuffer, itemSize, offset, normalized ) {
 
 		this.data = interleavedBuffer;
@@ -25880,6 +26504,24 @@ var Spacekit = (function (exports) {
 	Object.assign( InterleavedBufferAttribute.prototype, {
 
 		isInterleavedBufferAttribute: true,
+
+		applyMatrix4: function ( m ) {
+
+			for ( var i = 0, l = this.data.count; i < l; i ++ ) {
+
+				_vector$6.x = this.getX( i );
+				_vector$6.y = this.getY( i );
+				_vector$6.z = this.getZ( i );
+
+				_vector$6.applyMatrix4( m );
+
+				this.setXYZ( i, _vector$6.x, _vector$6.y, _vector$6.z );
+
+			}
+
+			return this;
+
+		},
 
 		setX: function ( index, x ) {
 
@@ -25981,6 +26623,7 @@ var Spacekit = (function (exports) {
 	 * parameters = {
 	 *  color: <hex>,
 	 *  map: new THREE.Texture( <Image> ),
+	 *  alphaMap: new THREE.Texture( <Image> ),
 	 *  rotation: <float>,
 	 *  sizeAttenuation: <bool>
 	 * }
@@ -25993,13 +26636,15 @@ var Spacekit = (function (exports) {
 		this.type = 'SpriteMaterial';
 
 		this.color = new Color( 0xffffff );
+
 		this.map = null;
+
+		this.alphaMap = null;
 
 		this.rotation = 0;
 
 		this.sizeAttenuation = true;
 
-		this.lights = false;
 		this.transparent = true;
 
 		this.setValues( parameters );
@@ -26015,7 +26660,10 @@ var Spacekit = (function (exports) {
 		Material.prototype.copy.call( this, source );
 
 		this.color.copy( source.color );
+
 		this.map = source.map;
+
+		this.alphaMap = source.alphaMap;
 
 		this.rotation = source.rotation;
 
@@ -26030,7 +26678,23 @@ var Spacekit = (function (exports) {
 	 * @author alteredq / http://alteredqualia.com/
 	 */
 
-	var geometry;
+	var _geometry;
+
+	var _intersectPoint = new Vector3();
+	var _worldScale = new Vector3();
+	var _mvPosition = new Vector3();
+
+	var _alignedPosition = new Vector2();
+	var _rotatedPosition = new Vector2();
+	var _viewWorldMatrix = new Matrix4();
+
+	var _vA$1 = new Vector3();
+	var _vB$1 = new Vector3();
+	var _vC$1 = new Vector3();
+
+	var _uvA$1 = new Vector2();
+	var _uvB$1 = new Vector2();
+	var _uvC$1 = new Vector2();
 
 	function Sprite( material ) {
 
@@ -26038,9 +26702,9 @@ var Spacekit = (function (exports) {
 
 		this.type = 'Sprite';
 
-		if ( geometry === undefined ) {
+		if ( _geometry === undefined ) {
 
-			geometry = new BufferGeometry();
+			_geometry = new BufferGeometry();
 
 			var float32Array = new Float32Array( [
 				- 0.5, - 0.5, 0, 0, 0,
@@ -26051,13 +26715,13 @@ var Spacekit = (function (exports) {
 
 			var interleavedBuffer = new InterleavedBuffer( float32Array, 5 );
 
-			geometry.setIndex( [ 0, 1, 2,	0, 2, 3 ] );
-			geometry.addAttribute( 'position', new InterleavedBufferAttribute( interleavedBuffer, 3, 0, false ) );
-			geometry.addAttribute( 'uv', new InterleavedBufferAttribute( interleavedBuffer, 2, 3, false ) );
+			_geometry.setIndex( [ 0, 1, 2,	0, 2, 3 ] );
+			_geometry.setAttribute( 'position', new InterleavedBufferAttribute( interleavedBuffer, 3, 0, false ) );
+			_geometry.setAttribute( 'uv', new InterleavedBufferAttribute( interleavedBuffer, 2, 3, false ) );
 
 		}
 
-		this.geometry = geometry;
+		this.geometry = _geometry;
 		this.material = ( material !== undefined ) ? material : new SpriteMaterial();
 
 		this.center = new Vector2( 0.5, 0.5 );
@@ -26070,120 +26734,79 @@ var Spacekit = (function (exports) {
 
 		isSprite: true,
 
-		raycast: ( function () {
+		raycast: function ( raycaster, intersects ) {
 
-			var intersectPoint = new Vector3();
-			var worldScale = new Vector3();
-			var mvPosition = new Vector3();
+			if ( raycaster.camera === null ) {
 
-			var alignedPosition = new Vector2();
-			var rotatedPosition = new Vector2();
-			var viewWorldMatrix = new Matrix4();
-
-			var vA = new Vector3();
-			var vB = new Vector3();
-			var vC = new Vector3();
-
-			var uvA = new Vector2();
-			var uvB = new Vector2();
-			var uvC = new Vector2();
-
-			function transformVertex( vertexPosition, mvPosition, center, scale, sin, cos ) {
-
-				// compute position in camera space
-				alignedPosition.subVectors( vertexPosition, center ).addScalar( 0.5 ).multiply( scale );
-
-				// to check if rotation is not zero
-				if ( sin !== undefined ) {
-
-					rotatedPosition.x = ( cos * alignedPosition.x ) - ( sin * alignedPosition.y );
-					rotatedPosition.y = ( sin * alignedPosition.x ) + ( cos * alignedPosition.y );
-
-				} else {
-
-					rotatedPosition.copy( alignedPosition );
-
-				}
-
-
-				vertexPosition.copy( mvPosition );
-				vertexPosition.x += rotatedPosition.x;
-				vertexPosition.y += rotatedPosition.y;
-
-				// transform to world space
-				vertexPosition.applyMatrix4( viewWorldMatrix );
+				console.error( 'THREE.Sprite: "Raycaster.camera" needs to be set in order to raycast against sprites.' );
 
 			}
 
-			return function raycast( raycaster, intersects ) {
+			_worldScale.setFromMatrixScale( this.matrixWorld );
 
-				worldScale.setFromMatrixScale( this.matrixWorld );
+			_viewWorldMatrix.copy( raycaster.camera.matrixWorld );
+			this.modelViewMatrix.multiplyMatrices( raycaster.camera.matrixWorldInverse, this.matrixWorld );
 
-				viewWorldMatrix.copy( raycaster._camera.matrixWorld );
-				this.modelViewMatrix.multiplyMatrices( raycaster._camera.matrixWorldInverse, this.matrixWorld );
+			_mvPosition.setFromMatrixPosition( this.modelViewMatrix );
 
-				mvPosition.setFromMatrixPosition( this.modelViewMatrix );
+			if ( raycaster.camera.isPerspectiveCamera && this.material.sizeAttenuation === false ) {
 
-				if ( raycaster._camera.isPerspectiveCamera && this.material.sizeAttenuation === false ) {
+				_worldScale.multiplyScalar( - _mvPosition.z );
 
-					worldScale.multiplyScalar( - mvPosition.z );
+			}
 
-				}
+			var rotation = this.material.rotation;
+			var sin, cos;
+			if ( rotation !== 0 ) {
 
-				var rotation = this.material.rotation;
-				var sin, cos;
-				if ( rotation !== 0 ) {
+				cos = Math.cos( rotation );
+				sin = Math.sin( rotation );
 
-					cos = Math.cos( rotation );
-					sin = Math.sin( rotation );
+			}
 
-				}
+			var center = this.center;
 
-				var center = this.center;
+			transformVertex( _vA$1.set( - 0.5, - 0.5, 0 ), _mvPosition, center, _worldScale, sin, cos );
+			transformVertex( _vB$1.set( 0.5, - 0.5, 0 ), _mvPosition, center, _worldScale, sin, cos );
+			transformVertex( _vC$1.set( 0.5, 0.5, 0 ), _mvPosition, center, _worldScale, sin, cos );
 
-				transformVertex( vA.set( - 0.5, - 0.5, 0 ), mvPosition, center, worldScale, sin, cos );
-				transformVertex( vB.set( 0.5, - 0.5, 0 ), mvPosition, center, worldScale, sin, cos );
-				transformVertex( vC.set( 0.5, 0.5, 0 ), mvPosition, center, worldScale, sin, cos );
+			_uvA$1.set( 0, 0 );
+			_uvB$1.set( 1, 0 );
+			_uvC$1.set( 1, 1 );
 
-				uvA.set( 0, 0 );
-				uvB.set( 1, 0 );
-				uvC.set( 1, 1 );
+			// check first triangle
+			var intersect = raycaster.ray.intersectTriangle( _vA$1, _vB$1, _vC$1, false, _intersectPoint );
 
-				// check first triangle
-				var intersect = raycaster.ray.intersectTriangle( vA, vB, vC, false, intersectPoint );
+			if ( intersect === null ) {
 
+				// check second triangle
+				transformVertex( _vB$1.set( - 0.5, 0.5, 0 ), _mvPosition, center, _worldScale, sin, cos );
+				_uvB$1.set( 0, 1 );
+
+				intersect = raycaster.ray.intersectTriangle( _vA$1, _vC$1, _vB$1, false, _intersectPoint );
 				if ( intersect === null ) {
 
-					// check second triangle
-					transformVertex( vB.set( - 0.5, 0.5, 0 ), mvPosition, center, worldScale, sin, cos );
-					uvB.set( 0, 1 );
-
-					intersect = raycaster.ray.intersectTriangle( vA, vC, vB, false, intersectPoint );
-					if ( intersect === null ) {
-
-						return;
-
-					}
+					return;
 
 				}
 
-				var distance = raycaster.ray.origin.distanceTo( intersectPoint );
+			}
 
-				if ( distance < raycaster.near || distance > raycaster.far ) return;
+			var distance = raycaster.ray.origin.distanceTo( _intersectPoint );
 
-				intersects.push( {
+			if ( distance < raycaster.near || distance > raycaster.far ) return;
 
-					distance: distance,
-					point: intersectPoint.clone(),
-					uv: Triangle.getUV( intersectPoint, vA, vB, vC, uvA, uvB, uvC, new Vector2() ),
-					face: null,
-					object: this
+			intersects.push( {
 
-				} );
+				distance: distance,
+				point: _intersectPoint.clone(),
+				uv: Triangle.getUV( _intersectPoint, _vA$1, _vB$1, _vC$1, _uvA$1, _uvB$1, _uvC$1, new Vector2() ),
+				face: null,
+				object: this
 
-			};
+			} );
 
-		}() ),
+		},
 
 		clone: function () {
 
@@ -26204,15 +26827,47 @@ var Spacekit = (function (exports) {
 
 	} );
 
+	function transformVertex( vertexPosition, mvPosition, center, scale, sin, cos ) {
+
+		// compute position in camera space
+		_alignedPosition.subVectors( vertexPosition, center ).addScalar( 0.5 ).multiply( scale );
+
+		// to check if rotation is not zero
+		if ( sin !== undefined ) {
+
+			_rotatedPosition.x = ( cos * _alignedPosition.x ) - ( sin * _alignedPosition.y );
+			_rotatedPosition.y = ( sin * _alignedPosition.x ) + ( cos * _alignedPosition.y );
+
+		} else {
+
+			_rotatedPosition.copy( _alignedPosition );
+
+		}
+
+
+		vertexPosition.copy( mvPosition );
+		vertexPosition.x += _rotatedPosition.x;
+		vertexPosition.y += _rotatedPosition.y;
+
+		// transform to world space
+		vertexPosition.applyMatrix4( _viewWorldMatrix );
+
+	}
+
 	/**
 	 * @author mikael emtinger / http://gomo.se/
 	 * @author alteredq / http://alteredqualia.com/
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
+	var _v1$4 = new Vector3();
+	var _v2$2 = new Vector3();
+
 	function LOD() {
 
 		Object3D.call( this );
+
+		this._currentLevel = 0;
 
 		this.type = 'LOD';
 
@@ -26247,6 +26902,8 @@ var Spacekit = (function (exports) {
 
 			}
 
+			this.autoUpdate = source.autoUpdate;
+
 			return this;
 
 		},
@@ -26277,88 +26934,97 @@ var Spacekit = (function (exports) {
 
 		},
 
+		getCurrentLevel: function () {
+
+			return this._currentLevel;
+
+		},
+
 		getObjectForDistance: function ( distance ) {
 
 			var levels = this.levels;
 
-			for ( var i = 1, l = levels.length; i < l; i ++ ) {
+			if ( levels.length > 0 ) {
 
-				if ( distance < levels[ i ].distance ) {
+				for ( var i = 1, l = levels.length; i < l; i ++ ) {
 
-					break;
+					if ( distance < levels[ i ].distance ) {
+
+						break;
+
+					}
+
+				}
+
+				return levels[ i - 1 ].object;
+
+			}
+
+			return null;
+
+		},
+
+		raycast: function ( raycaster, intersects ) {
+
+			var levels = this.levels;
+
+			if ( levels.length > 0 ) {
+
+				_v1$4.setFromMatrixPosition( this.matrixWorld );
+
+				var distance = raycaster.ray.origin.distanceTo( _v1$4 );
+
+				this.getObjectForDistance( distance ).raycast( raycaster, intersects );
+
+			}
+
+		},
+
+		update: function ( camera ) {
+
+			var levels = this.levels;
+
+			if ( levels.length > 1 ) {
+
+				_v1$4.setFromMatrixPosition( camera.matrixWorld );
+				_v2$2.setFromMatrixPosition( this.matrixWorld );
+
+				var distance = _v1$4.distanceTo( _v2$2 ) / camera.zoom;
+
+				levels[ 0 ].object.visible = true;
+
+				for ( var i = 1, l = levels.length; i < l; i ++ ) {
+
+					if ( distance >= levels[ i ].distance ) {
+
+						levels[ i - 1 ].object.visible = false;
+						levels[ i ].object.visible = true;
+
+					} else {
+
+						break;
+
+					}
+
+				}
+
+				this._currentLevel = i - 1;
+
+				for ( ; i < l; i ++ ) {
+
+					levels[ i ].object.visible = false;
 
 				}
 
 			}
 
-			return levels[ i - 1 ].object;
-
 		},
-
-		raycast: ( function () {
-
-			var matrixPosition = new Vector3();
-
-			return function raycast( raycaster, intersects ) {
-
-				matrixPosition.setFromMatrixPosition( this.matrixWorld );
-
-				var distance = raycaster.ray.origin.distanceTo( matrixPosition );
-
-				this.getObjectForDistance( distance ).raycast( raycaster, intersects );
-
-			};
-
-		}() ),
-
-		update: function () {
-
-			var v1 = new Vector3();
-			var v2 = new Vector3();
-
-			return function update( camera ) {
-
-				var levels = this.levels;
-
-				if ( levels.length > 1 ) {
-
-					v1.setFromMatrixPosition( camera.matrixWorld );
-					v2.setFromMatrixPosition( this.matrixWorld );
-
-					var distance = v1.distanceTo( v2 );
-
-					levels[ 0 ].object.visible = true;
-
-					for ( var i = 1, l = levels.length; i < l; i ++ ) {
-
-						if ( distance >= levels[ i ].distance ) {
-
-							levels[ i - 1 ].object.visible = false;
-							levels[ i ].object.visible = true;
-
-						} else {
-
-							break;
-
-						}
-
-					}
-
-					for ( ; i < l; i ++ ) {
-
-						levels[ i ].object.visible = false;
-
-					}
-
-				}
-
-			};
-
-		}(),
 
 		toJSON: function ( meta ) {
 
 			var data = Object3D.prototype.toJSON.call( this, meta );
+
+			if ( this.autoUpdate === false ) data.object.autoUpdate = false;
 
 			data.object.levels = [];
 
@@ -26491,7 +27157,51 @@ var Spacekit = (function (exports) {
 
 			return new this.constructor( this.geometry, this.material ).copy( this );
 
-		}
+		},
+
+		boneTransform: ( function () {
+
+			var basePosition = new Vector3();
+
+			var skinIndex = new Vector4();
+			var skinWeight = new Vector4();
+
+			var vector = new Vector3();
+			var matrix = new Matrix4();
+
+			return function ( index, target ) {
+
+				var skeleton = this.skeleton;
+				var geometry = this.geometry;
+
+				skinIndex.fromBufferAttribute( geometry.attributes.skinIndex, index );
+				skinWeight.fromBufferAttribute( geometry.attributes.skinWeight, index );
+
+				basePosition.fromBufferAttribute( geometry.attributes.position, index ).applyMatrix4( this.bindMatrix );
+
+				target.set( 0, 0, 0 );
+
+				for ( var i = 0; i < 4; i ++ ) {
+
+					var weight = skinWeight.getComponent( i );
+
+					if ( weight !== 0 ) {
+
+						var boneIndex = skinIndex.getComponent( i );
+
+						matrix.multiplyMatrices( skeleton.bones[ boneIndex ].matrixWorld, skeleton.boneInverses[ boneIndex ] );
+
+						target.addScaledVector( vector.copy( basePosition ).applyMatrix4( matrix ), weight );
+
+					}
+
+				}
+
+				return target.applyMatrix4( this.bindMatrixInverse );
+
+			};
+
+		}() )
 
 	} );
 
@@ -26502,6 +27212,9 @@ var Spacekit = (function (exports) {
 	 * @author ikerr / http://verold.com
 	 */
 
+	var _offsetMatrix = new Matrix4();
+	var _identityMatrix = new Matrix4();
+
 	function Skeleton( bones, boneInverses ) {
 
 		// copy the bone array
@@ -26510,6 +27223,8 @@ var Spacekit = (function (exports) {
 
 		this.bones = bones.slice( 0 );
 		this.boneMatrices = new Float32Array( this.bones.length * 16 );
+
+		this.frame = - 1;
 
 		// use the supplied bone inverses or calculate the inverses
 
@@ -26608,40 +27323,33 @@ var Spacekit = (function (exports) {
 
 		},
 
-		update: ( function () {
+		update: function () {
 
-			var offsetMatrix = new Matrix4();
-			var identityMatrix = new Matrix4();
+			var bones = this.bones;
+			var boneInverses = this.boneInverses;
+			var boneMatrices = this.boneMatrices;
+			var boneTexture = this.boneTexture;
 
-			return function update() {
+			// flatten bone matrices to array
 
-				var bones = this.bones;
-				var boneInverses = this.boneInverses;
-				var boneMatrices = this.boneMatrices;
-				var boneTexture = this.boneTexture;
+			for ( var i = 0, il = bones.length; i < il; i ++ ) {
 
-				// flatten bone matrices to array
+				// compute the offset between the current and the original transform
 
-				for ( var i = 0, il = bones.length; i < il; i ++ ) {
+				var matrix = bones[ i ] ? bones[ i ].matrixWorld : _identityMatrix;
 
-					// compute the offset between the current and the original transform
+				_offsetMatrix.multiplyMatrices( matrix, boneInverses[ i ] );
+				_offsetMatrix.toArray( boneMatrices, i * 16 );
 
-					var matrix = bones[ i ] ? bones[ i ].matrixWorld : identityMatrix;
+			}
 
-					offsetMatrix.multiplyMatrices( matrix, boneInverses[ i ] );
-					offsetMatrix.toArray( boneMatrices, i * 16 );
+			if ( boneTexture !== undefined ) {
 
-				}
+				boneTexture.needsUpdate = true;
 
-				if ( boneTexture !== undefined ) {
+			}
 
-					boneTexture.needsUpdate = true;
-
-				}
-
-			};
-
-		} )(),
+		},
 
 		clone: function () {
 
@@ -26664,6 +27372,18 @@ var Spacekit = (function (exports) {
 			}
 
 			return undefined;
+
+		},
+
+		dispose: function ( ) {
+
+			if ( this.boneTexture ) {
+
+				this.boneTexture.dispose();
+
+				this.boneTexture = undefined;
+
+			}
 
 		}
 
@@ -26693,6 +27413,94 @@ var Spacekit = (function (exports) {
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
+	 */
+
+	var _instanceLocalMatrix = new Matrix4();
+	var _instanceWorldMatrix = new Matrix4();
+
+	var _instanceIntersects = [];
+
+	var _mesh = new Mesh();
+
+	function InstancedMesh( geometry, material, count ) {
+
+		Mesh.call( this, geometry, material );
+
+		this.instanceMatrix = new BufferAttribute( new Float32Array( count * 16 ), 16 );
+
+		this.count = count;
+
+		this.frustumCulled = false;
+
+	}
+
+	InstancedMesh.prototype = Object.assign( Object.create( Mesh.prototype ), {
+
+		constructor: InstancedMesh,
+
+		isInstancedMesh: true,
+
+		getMatrixAt: function ( index, matrix ) {
+
+			matrix.fromArray( this.instanceMatrix.array, index * 16 );
+
+		},
+
+		raycast: function ( raycaster, intersects ) {
+
+			var matrixWorld = this.matrixWorld;
+			var raycastTimes = this.count;
+
+			_mesh.geometry = this.geometry;
+			_mesh.material = this.material;
+
+			if ( _mesh.material === undefined ) return;
+
+			for ( var instanceId = 0; instanceId < raycastTimes; instanceId ++ ) {
+
+				// calculate the world matrix for each instance
+
+				this.getMatrixAt( instanceId, _instanceLocalMatrix );
+
+				_instanceWorldMatrix.multiplyMatrices( matrixWorld, _instanceLocalMatrix );
+
+				// the mesh represents this single instance
+
+				_mesh.matrixWorld = _instanceWorldMatrix;
+
+				_mesh.raycast( raycaster, _instanceIntersects );
+
+				// process the result of raycast
+
+				for ( var i = 0, l = _instanceIntersects.length; i < l; i ++ ) {
+
+					var intersect = _instanceIntersects[ i ];
+					intersect.instanceId = instanceId;
+					intersect.object = this;
+					intersects.push( intersect );
+
+				}
+
+				_instanceIntersects.length = 0;
+
+			}
+
+		},
+
+		setMatrixAt: function ( index, matrix ) {
+
+			matrix.toArray( this.instanceMatrix.array, index * 16 );
+
+		},
+
+		updateMorphTargets: function () {
+
+		}
+
+	} );
+
+	/**
+	 * @author mrdoob / http://mrdoob.com/
 	 * @author alteredq / http://alteredqualia.com/
 	 *
 	 * parameters = {
@@ -26716,8 +27524,6 @@ var Spacekit = (function (exports) {
 		this.linewidth = 1;
 		this.linecap = 'round';
 		this.linejoin = 'round';
-
-		this.lights = false;
 
 		this.setValues( parameters );
 
@@ -26746,6 +27552,12 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
+	var _start = new Vector3();
+	var _end = new Vector3();
+	var _inverseMatrix$1 = new Matrix4();
+	var _ray$1 = new Ray();
+	var _sphere$2 = new Sphere();
+
 	function Line( geometry, material, mode ) {
 
 		if ( mode === 1 ) {
@@ -26759,7 +27571,7 @@ var Spacekit = (function (exports) {
 		this.type = 'Line';
 
 		this.geometry = geometry !== undefined ? geometry : new BufferGeometry();
-		this.material = material !== undefined ? material : new LineBasicMaterial( { color: Math.random() * 0xffffff } );
+		this.material = material !== undefined ? material : new LineBasicMaterial();
 
 	}
 
@@ -26769,188 +27581,140 @@ var Spacekit = (function (exports) {
 
 		isLine: true,
 
-		computeLineDistances: ( function () {
+		computeLineDistances: function () {
 
-			var start = new Vector3();
-			var end = new Vector3();
+			var geometry = this.geometry;
 
-			return function computeLineDistances() {
+			if ( geometry.isBufferGeometry ) {
 
-				var geometry = this.geometry;
+				// we assume non-indexed geometry
 
-				if ( geometry.isBufferGeometry ) {
+				if ( geometry.index === null ) {
 
-					// we assume non-indexed geometry
+					var positionAttribute = geometry.attributes.position;
+					var lineDistances = [ 0 ];
 
-					if ( geometry.index === null ) {
+					for ( var i = 1, l = positionAttribute.count; i < l; i ++ ) {
 
-						var positionAttribute = geometry.attributes.position;
-						var lineDistances = [ 0 ];
-
-						for ( var i = 1, l = positionAttribute.count; i < l; i ++ ) {
-
-							start.fromBufferAttribute( positionAttribute, i - 1 );
-							end.fromBufferAttribute( positionAttribute, i );
-
-							lineDistances[ i ] = lineDistances[ i - 1 ];
-							lineDistances[ i ] += start.distanceTo( end );
-
-						}
-
-						geometry.addAttribute( 'lineDistance', new Float32BufferAttribute( lineDistances, 1 ) );
-
-					} else {
-
-						console.warn( 'THREE.Line.computeLineDistances(): Computation only possible with non-indexed BufferGeometry.' );
-
-					}
-
-				} else if ( geometry.isGeometry ) {
-
-					var vertices = geometry.vertices;
-					var lineDistances = geometry.lineDistances;
-
-					lineDistances[ 0 ] = 0;
-
-					for ( var i = 1, l = vertices.length; i < l; i ++ ) {
+						_start.fromBufferAttribute( positionAttribute, i - 1 );
+						_end.fromBufferAttribute( positionAttribute, i );
 
 						lineDistances[ i ] = lineDistances[ i - 1 ];
-						lineDistances[ i ] += vertices[ i - 1 ].distanceTo( vertices[ i ] );
+						lineDistances[ i ] += _start.distanceTo( _end );
 
 					}
+
+					geometry.setAttribute( 'lineDistance', new Float32BufferAttribute( lineDistances, 1 ) );
+
+				} else {
+
+					console.warn( 'THREE.Line.computeLineDistances(): Computation only possible with non-indexed BufferGeometry.' );
 
 				}
 
-				return this;
+			} else if ( geometry.isGeometry ) {
 
-			};
+				var vertices = geometry.vertices;
+				var lineDistances = geometry.lineDistances;
 
-		}() ),
+				lineDistances[ 0 ] = 0;
 
-		raycast: ( function () {
+				for ( var i = 1, l = vertices.length; i < l; i ++ ) {
 
-			var inverseMatrix = new Matrix4();
-			var ray = new Ray();
-			var sphere = new Sphere();
+					lineDistances[ i ] = lineDistances[ i - 1 ];
+					lineDistances[ i ] += vertices[ i - 1 ].distanceTo( vertices[ i ] );
 
-			return function raycast( raycaster, intersects ) {
+				}
 
-				var precision = raycaster.linePrecision;
+			}
 
-				var geometry = this.geometry;
-				var matrixWorld = this.matrixWorld;
+			return this;
 
-				// Checking boundingSphere distance to ray
+		},
 
-				if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
+		raycast: function ( raycaster, intersects ) {
 
-				sphere.copy( geometry.boundingSphere );
-				sphere.applyMatrix4( matrixWorld );
-				sphere.radius += precision;
+			var geometry = this.geometry;
+			var matrixWorld = this.matrixWorld;
+			var threshold = raycaster.params.Line.threshold;
 
-				if ( raycaster.ray.intersectsSphere( sphere ) === false ) return;
+			// Checking boundingSphere distance to ray
 
-				//
+			if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
 
-				inverseMatrix.getInverse( matrixWorld );
-				ray.copy( raycaster.ray ).applyMatrix4( inverseMatrix );
+			_sphere$2.copy( geometry.boundingSphere );
+			_sphere$2.applyMatrix4( matrixWorld );
+			_sphere$2.radius += threshold;
 
-				var localPrecision = precision / ( ( this.scale.x + this.scale.y + this.scale.z ) / 3 );
-				var localPrecisionSq = localPrecision * localPrecision;
+			if ( raycaster.ray.intersectsSphere( _sphere$2 ) === false ) return;
 
-				var vStart = new Vector3();
-				var vEnd = new Vector3();
-				var interSegment = new Vector3();
-				var interRay = new Vector3();
-				var step = ( this && this.isLineSegments ) ? 2 : 1;
+			//
 
-				if ( geometry.isBufferGeometry ) {
+			_inverseMatrix$1.getInverse( matrixWorld );
+			_ray$1.copy( raycaster.ray ).applyMatrix4( _inverseMatrix$1 );
 
-					var index = geometry.index;
-					var attributes = geometry.attributes;
-					var positions = attributes.position.array;
+			var localThreshold = threshold / ( ( this.scale.x + this.scale.y + this.scale.z ) / 3 );
+			var localThresholdSq = localThreshold * localThreshold;
 
-					if ( index !== null ) {
+			var vStart = new Vector3();
+			var vEnd = new Vector3();
+			var interSegment = new Vector3();
+			var interRay = new Vector3();
+			var step = ( this && this.isLineSegments ) ? 2 : 1;
 
-						var indices = index.array;
+			if ( geometry.isBufferGeometry ) {
 
-						for ( var i = 0, l = indices.length - 1; i < l; i += step ) {
+				var index = geometry.index;
+				var attributes = geometry.attributes;
+				var positions = attributes.position.array;
 
-							var a = indices[ i ];
-							var b = indices[ i + 1 ];
+				if ( index !== null ) {
 
-							vStart.fromArray( positions, a * 3 );
-							vEnd.fromArray( positions, b * 3 );
+					var indices = index.array;
 
-							var distSq = ray.distanceSqToSegment( vStart, vEnd, interRay, interSegment );
+					for ( var i = 0, l = indices.length - 1; i < l; i += step ) {
 
-							if ( distSq > localPrecisionSq ) continue;
+						var a = indices[ i ];
+						var b = indices[ i + 1 ];
 
-							interRay.applyMatrix4( this.matrixWorld ); //Move back to world space for distance calculation
+						vStart.fromArray( positions, a * 3 );
+						vEnd.fromArray( positions, b * 3 );
 
-							var distance = raycaster.ray.origin.distanceTo( interRay );
+						var distSq = _ray$1.distanceSqToSegment( vStart, vEnd, interRay, interSegment );
 
-							if ( distance < raycaster.near || distance > raycaster.far ) continue;
+						if ( distSq > localThresholdSq ) continue;
 
-							intersects.push( {
+						interRay.applyMatrix4( this.matrixWorld ); //Move back to world space for distance calculation
 
-								distance: distance,
-								// What do we want? intersection point on the ray or on the segment??
-								// point: raycaster.ray.at( distance ),
-								point: interSegment.clone().applyMatrix4( this.matrixWorld ),
-								index: i,
-								face: null,
-								faceIndex: null,
-								object: this
+						var distance = raycaster.ray.origin.distanceTo( interRay );
 
-							} );
+						if ( distance < raycaster.near || distance > raycaster.far ) continue;
 
-						}
+						intersects.push( {
 
-					} else {
+							distance: distance,
+							// What do we want? intersection point on the ray or on the segment??
+							// point: raycaster.ray.at( distance ),
+							point: interSegment.clone().applyMatrix4( this.matrixWorld ),
+							index: i,
+							face: null,
+							faceIndex: null,
+							object: this
 
-						for ( var i = 0, l = positions.length / 3 - 1; i < l; i += step ) {
-
-							vStart.fromArray( positions, 3 * i );
-							vEnd.fromArray( positions, 3 * i + 3 );
-
-							var distSq = ray.distanceSqToSegment( vStart, vEnd, interRay, interSegment );
-
-							if ( distSq > localPrecisionSq ) continue;
-
-							interRay.applyMatrix4( this.matrixWorld ); //Move back to world space for distance calculation
-
-							var distance = raycaster.ray.origin.distanceTo( interRay );
-
-							if ( distance < raycaster.near || distance > raycaster.far ) continue;
-
-							intersects.push( {
-
-								distance: distance,
-								// What do we want? intersection point on the ray or on the segment??
-								// point: raycaster.ray.at( distance ),
-								point: interSegment.clone().applyMatrix4( this.matrixWorld ),
-								index: i,
-								face: null,
-								faceIndex: null,
-								object: this
-
-							} );
-
-						}
+						} );
 
 					}
 
-				} else if ( geometry.isGeometry ) {
+				} else {
 
-					var vertices = geometry.vertices;
-					var nbVertices = vertices.length;
+					for ( var i = 0, l = positions.length / 3 - 1; i < l; i += step ) {
 
-					for ( var i = 0; i < nbVertices - 1; i += step ) {
+						vStart.fromArray( positions, 3 * i );
+						vEnd.fromArray( positions, 3 * i + 3 );
 
-						var distSq = ray.distanceSqToSegment( vertices[ i ], vertices[ i + 1 ], interRay, interSegment );
+						var distSq = _ray$1.distanceSqToSegment( vStart, vEnd, interRay, interSegment );
 
-						if ( distSq > localPrecisionSq ) continue;
+						if ( distSq > localThresholdSq ) continue;
 
 						interRay.applyMatrix4( this.matrixWorld ); //Move back to world space for distance calculation
 
@@ -26975,9 +27739,41 @@ var Spacekit = (function (exports) {
 
 				}
 
-			};
+			} else if ( geometry.isGeometry ) {
 
-		}() ),
+				var vertices = geometry.vertices;
+				var nbVertices = vertices.length;
+
+				for ( var i = 0; i < nbVertices - 1; i += step ) {
+
+					var distSq = _ray$1.distanceSqToSegment( vertices[ i ], vertices[ i + 1 ], interRay, interSegment );
+
+					if ( distSq > localThresholdSq ) continue;
+
+					interRay.applyMatrix4( this.matrixWorld ); //Move back to world space for distance calculation
+
+					var distance = raycaster.ray.origin.distanceTo( interRay );
+
+					if ( distance < raycaster.near || distance > raycaster.far ) continue;
+
+					intersects.push( {
+
+						distance: distance,
+						// What do we want? intersection point on the ray or on the segment??
+						// point: raycaster.ray.at( distance ),
+						point: interSegment.clone().applyMatrix4( this.matrixWorld ),
+						index: i,
+						face: null,
+						faceIndex: null,
+						object: this
+
+					} );
+
+				}
+
+			}
+
+		},
 
 		clone: function () {
 
@@ -26990,6 +27786,9 @@ var Spacekit = (function (exports) {
 	/**
 	 * @author mrdoob / http://mrdoob.com/
 	 */
+
+	var _start$1 = new Vector3();
+	var _end$1 = new Vector3();
 
 	function LineSegments( geometry, material ) {
 
@@ -27005,64 +27804,57 @@ var Spacekit = (function (exports) {
 
 		isLineSegments: true,
 
-		computeLineDistances: ( function () {
+		computeLineDistances: function () {
 
-			var start = new Vector3();
-			var end = new Vector3();
+			var geometry = this.geometry;
 
-			return function computeLineDistances() {
+			if ( geometry.isBufferGeometry ) {
 
-				var geometry = this.geometry;
+				// we assume non-indexed geometry
 
-				if ( geometry.isBufferGeometry ) {
+				if ( geometry.index === null ) {
 
-					// we assume non-indexed geometry
+					var positionAttribute = geometry.attributes.position;
+					var lineDistances = [];
 
-					if ( geometry.index === null ) {
+					for ( var i = 0, l = positionAttribute.count; i < l; i += 2 ) {
 
-						var positionAttribute = geometry.attributes.position;
-						var lineDistances = [];
-
-						for ( var i = 0, l = positionAttribute.count; i < l; i += 2 ) {
-
-							start.fromBufferAttribute( positionAttribute, i );
-							end.fromBufferAttribute( positionAttribute, i + 1 );
-
-							lineDistances[ i ] = ( i === 0 ) ? 0 : lineDistances[ i - 1 ];
-							lineDistances[ i + 1 ] = lineDistances[ i ] + start.distanceTo( end );
-
-						}
-
-						geometry.addAttribute( 'lineDistance', new Float32BufferAttribute( lineDistances, 1 ) );
-
-					} else {
-
-						console.warn( 'THREE.LineSegments.computeLineDistances(): Computation only possible with non-indexed BufferGeometry.' );
-
-					}
-
-				} else if ( geometry.isGeometry ) {
-
-					var vertices = geometry.vertices;
-					var lineDistances = geometry.lineDistances;
-
-					for ( var i = 0, l = vertices.length; i < l; i += 2 ) {
-
-						start.copy( vertices[ i ] );
-						end.copy( vertices[ i + 1 ] );
+						_start$1.fromBufferAttribute( positionAttribute, i );
+						_end$1.fromBufferAttribute( positionAttribute, i + 1 );
 
 						lineDistances[ i ] = ( i === 0 ) ? 0 : lineDistances[ i - 1 ];
-						lineDistances[ i + 1 ] = lineDistances[ i ] + start.distanceTo( end );
+						lineDistances[ i + 1 ] = lineDistances[ i ] + _start$1.distanceTo( _end$1 );
 
 					}
+
+					geometry.setAttribute( 'lineDistance', new Float32BufferAttribute( lineDistances, 1 ) );
+
+				} else {
+
+					console.warn( 'THREE.LineSegments.computeLineDistances(): Computation only possible with non-indexed BufferGeometry.' );
 
 				}
 
-				return this;
+			} else if ( geometry.isGeometry ) {
 
-			};
+				var vertices = geometry.vertices;
+				var lineDistances = geometry.lineDistances;
 
-		}() )
+				for ( var i = 0, l = vertices.length; i < l; i += 2 ) {
+
+					_start$1.copy( vertices[ i ] );
+					_end$1.copy( vertices[ i + 1 ] );
+
+					lineDistances[ i ] = ( i === 0 ) ? 0 : lineDistances[ i - 1 ];
+					lineDistances[ i + 1 ] = lineDistances[ i ] + _start$1.distanceTo( _end$1 );
+
+				}
+
+			}
+
+			return this;
+
+		}
 
 	} );
 
@@ -27094,6 +27886,7 @@ var Spacekit = (function (exports) {
 	 *  color: <hex>,
 	 *  opacity: <float>,
 	 *  map: new THREE.Texture( <Image> ),
+	 *  alphaMap: new THREE.Texture( <Image> ),
 	 *
 	 *  size: <float>,
 	 *  sizeAttenuation: <bool>
@@ -27112,12 +27905,12 @@ var Spacekit = (function (exports) {
 
 		this.map = null;
 
+		this.alphaMap = null;
+
 		this.size = 1;
 		this.sizeAttenuation = true;
 
 		this.morphTargets = false;
-
-		this.lights = false;
 
 		this.setValues( parameters );
 
@@ -27136,6 +27929,8 @@ var Spacekit = (function (exports) {
 
 		this.map = source.map;
 
+		this.alphaMap = source.alphaMap;
+
 		this.size = source.size;
 		this.sizeAttenuation = source.sizeAttenuation;
 
@@ -27149,6 +27944,11 @@ var Spacekit = (function (exports) {
 	 * @author alteredq / http://alteredqualia.com/
 	 */
 
+	var _inverseMatrix$2 = new Matrix4();
+	var _ray$2 = new Ray();
+	var _sphere$3 = new Sphere();
+	var _position$1 = new Vector3();
+
 	function Points( geometry, material ) {
 
 		Object3D.call( this );
@@ -27156,7 +27956,7 @@ var Spacekit = (function (exports) {
 		this.type = 'Points';
 
 		this.geometry = geometry !== undefined ? geometry : new BufferGeometry();
-		this.material = material !== undefined ? material : new PointsMaterial( { color: Math.random() * 0xffffff } );
+		this.material = material !== undefined ? material : new PointsMaterial();
 
 		this.updateMorphTargets();
 
@@ -27168,114 +27968,75 @@ var Spacekit = (function (exports) {
 
 		isPoints: true,
 
-		raycast: ( function () {
+		raycast: function ( raycaster, intersects ) {
 
-			var inverseMatrix = new Matrix4();
-			var ray = new Ray();
-			var sphere = new Sphere();
+			var geometry = this.geometry;
+			var matrixWorld = this.matrixWorld;
+			var threshold = raycaster.params.Points.threshold;
 
-			return function raycast( raycaster, intersects ) {
+			// Checking boundingSphere distance to ray
 
-				var object = this;
-				var geometry = this.geometry;
-				var matrixWorld = this.matrixWorld;
-				var threshold = raycaster.params.Points.threshold;
+			if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
 
-				// Checking boundingSphere distance to ray
+			_sphere$3.copy( geometry.boundingSphere );
+			_sphere$3.applyMatrix4( matrixWorld );
+			_sphere$3.radius += threshold;
 
-				if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
+			if ( raycaster.ray.intersectsSphere( _sphere$3 ) === false ) return;
 
-				sphere.copy( geometry.boundingSphere );
-				sphere.applyMatrix4( matrixWorld );
-				sphere.radius += threshold;
+			//
 
-				if ( raycaster.ray.intersectsSphere( sphere ) === false ) return;
+			_inverseMatrix$2.getInverse( matrixWorld );
+			_ray$2.copy( raycaster.ray ).applyMatrix4( _inverseMatrix$2 );
 
-				//
+			var localThreshold = threshold / ( ( this.scale.x + this.scale.y + this.scale.z ) / 3 );
+			var localThresholdSq = localThreshold * localThreshold;
 
-				inverseMatrix.getInverse( matrixWorld );
-				ray.copy( raycaster.ray ).applyMatrix4( inverseMatrix );
+			if ( geometry.isBufferGeometry ) {
 
-				var localThreshold = threshold / ( ( this.scale.x + this.scale.y + this.scale.z ) / 3 );
-				var localThresholdSq = localThreshold * localThreshold;
-				var position = new Vector3();
-				var intersectPoint = new Vector3();
+				var index = geometry.index;
+				var attributes = geometry.attributes;
+				var positions = attributes.position.array;
 
-				function testPoint( point, index ) {
+				if ( index !== null ) {
 
-					var rayPointDistanceSq = ray.distanceSqToPoint( point );
+					var indices = index.array;
 
-					if ( rayPointDistanceSq < localThresholdSq ) {
+					for ( var i = 0, il = indices.length; i < il; i ++ ) {
 
-						ray.closestPointToPoint( point, intersectPoint );
-						intersectPoint.applyMatrix4( matrixWorld );
+						var a = indices[ i ];
 
-						var distance = raycaster.ray.origin.distanceTo( intersectPoint );
+						_position$1.fromArray( positions, a * 3 );
 
-						if ( distance < raycaster.near || distance > raycaster.far ) return;
-
-						intersects.push( {
-
-							distance: distance,
-							distanceToRay: Math.sqrt( rayPointDistanceSq ),
-							point: intersectPoint.clone(),
-							index: index,
-							face: null,
-							object: object
-
-						} );
-
-					}
-
-				}
-
-				if ( geometry.isBufferGeometry ) {
-
-					var index = geometry.index;
-					var attributes = geometry.attributes;
-					var positions = attributes.position.array;
-
-					if ( index !== null ) {
-
-						var indices = index.array;
-
-						for ( var i = 0, il = indices.length; i < il; i ++ ) {
-
-							var a = indices[ i ];
-
-							position.fromArray( positions, a * 3 );
-
-							testPoint( position, a );
-
-						}
-
-					} else {
-
-						for ( var i = 0, l = positions.length / 3; i < l; i ++ ) {
-
-							position.fromArray( positions, i * 3 );
-
-							testPoint( position, i );
-
-						}
+						testPoint( _position$1, a, localThresholdSq, matrixWorld, raycaster, intersects, this );
 
 					}
 
 				} else {
 
-					var vertices = geometry.vertices;
+					for ( var i = 0, l = positions.length / 3; i < l; i ++ ) {
 
-					for ( var i = 0, l = vertices.length; i < l; i ++ ) {
+						_position$1.fromArray( positions, i * 3 );
 
-						testPoint( vertices[ i ], i );
+						testPoint( _position$1, i, localThresholdSq, matrixWorld, raycaster, intersects, this );
 
 					}
 
 				}
 
-			};
+			} else {
 
-		}() ),
+				var vertices = geometry.vertices;
+
+				for ( var i = 0, l = vertices.length; i < l; i ++ ) {
+
+					testPoint( vertices[ i ], i, localThresholdSq, matrixWorld, raycaster, intersects, this );
+
+				}
+
+			}
+
+		},
 
 		updateMorphTargets: function () {
 
@@ -27330,6 +28091,36 @@ var Spacekit = (function (exports) {
 		}
 
 	} );
+
+	function testPoint( point, index, localThresholdSq, matrixWorld, raycaster, intersects, object ) {
+
+		var rayPointDistanceSq = _ray$2.distanceSqToPoint( point );
+
+		if ( rayPointDistanceSq < localThresholdSq ) {
+
+			var intersectPoint = new Vector3();
+
+			_ray$2.closestPointToPoint( point, intersectPoint );
+			intersectPoint.applyMatrix4( matrixWorld );
+
+			var distance = raycaster.ray.origin.distanceTo( intersectPoint );
+
+			if ( distance < raycaster.near || distance > raycaster.far ) return;
+
+			intersects.push( {
+
+				distance: distance,
+				distanceToRay: Math.sqrt( rayPointDistanceSq ),
+				point: intersectPoint,
+				index: index,
+				face: null,
+				object: object
+
+			} );
+
+		}
+
+	}
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -27612,7 +28403,7 @@ var Spacekit = (function (exports) {
 
 		// build geometry
 
-		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
 
 	}
 
@@ -27624,7 +28415,7 @@ var Spacekit = (function (exports) {
 	 * @author Mugen87 / https://github.com/Mugen87
 	 *
 	 * Parametric Surfaces Geometry
-	 * based on the brilliant article by @prideout http://prideout.net/blog/?p=44
+	 * based on the brilliant article by @prideout https://prideout.net/blog/old/blog/index.html@p=44.html
 	 */
 
 	// ParametricGeometry
@@ -27766,9 +28557,9 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	}
 
@@ -27842,9 +28633,9 @@ var Spacekit = (function (exports) {
 
 		// build non-indexed geometry
 
-		this.addAttribute( 'position', new Float32BufferAttribute( vertexBuffer, 3 ) );
-		this.addAttribute( 'normal', new Float32BufferAttribute( vertexBuffer.slice(), 3 ) );
-		this.addAttribute( 'uv', new Float32BufferAttribute( uvBuffer, 2 ) );
+		this.setAttribute( 'position', new Float32BufferAttribute( vertexBuffer, 3 ) );
+		this.setAttribute( 'normal', new Float32BufferAttribute( vertexBuffer.slice(), 3 ) );
+		this.setAttribute( 'uv', new Float32BufferAttribute( uvBuffer, 2 ) );
 
 		if ( detail === 0 ) {
 
@@ -28455,9 +29246,9 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 		// functions
 
@@ -28745,9 +29536,9 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 		// this function calculates the current position on the torus curve
 
@@ -28895,9 +29686,9 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	}
 
@@ -28906,7 +29697,7 @@ var Spacekit = (function (exports) {
 
 	/**
 	 * @author Mugen87 / https://github.com/Mugen87
-	 * Port from https://github.com/mapbox/earcut (v2.1.5)
+	 * Port from https://github.com/mapbox/earcut (v2.2.2)
 	 */
 
 	var Earcut = {
@@ -29062,7 +29853,7 @@ var Spacekit = (function (exports) {
 
 				} else if ( pass === 1 ) {
 
-					ear = cureLocalIntersections( ear, triangles, dim );
+					ear = cureLocalIntersections( filterPoints( ear ), triangles, dim );
 					earcutLinked( ear, triangles, dim, minX, minY, invSize, 2 );
 
 					// as a last resort, try splitting the remaining polygon into two
@@ -29192,7 +29983,7 @@ var Spacekit = (function (exports) {
 
 		} while ( p !== start );
 
-		return p;
+		return filterPoints( p );
 
 	}
 
@@ -29275,6 +30066,9 @@ var Spacekit = (function (exports) {
 		if ( outerNode ) {
 
 			var b = splitPolygon( outerNode, hole );
+
+			// filter collinear points around the cuts
+			filterPoints( outerNode, outerNode.next );
 			filterPoints( b, b.next );
 
 		}
@@ -29319,7 +30113,7 @@ var Spacekit = (function (exports) {
 
 		if ( ! m ) return null;
 
-		if ( hx === qx ) return m.prev; // hole touches outer segment; pick lower endpoint
+		if ( hx === qx ) return m; // hole touches outer segment; pick leftmost endpoint
 
 		// look for points inside the triangle of hole point, segment intersection and endpoint;
 		// if there are no points found, we have a valid connection;
@@ -29331,16 +30125,16 @@ var Spacekit = (function (exports) {
 			tanMin = Infinity,
 			tan;
 
-		p = m.next;
+		p = m;
 
-		while ( p !== stop ) {
+		do {
 
 			if ( hx >= p.x && p.x >= mx && hx !== p.x &&
 					pointInTriangle( hy < my ? hx : qx, hy, mx, my, hy < my ? qx : hx, hy, p.x, p.y ) ) {
 
 				tan = Math.abs( hy - p.y ) / ( hx - p.x ); // tangential
 
-				if ( ( tan < tanMin || ( tan === tanMin && p.x > m.x ) ) && locallyInside( p, hole ) ) {
+				if ( locallyInside( p, hole ) && ( tan < tanMin || ( tan === tanMin && ( p.x > m.x || ( p.x === m.x && sectorContainsSector( m, p ) ) ) ) ) ) {
 
 					m = p;
 					tanMin = tan;
@@ -29351,9 +30145,16 @@ var Spacekit = (function (exports) {
 
 			p = p.next;
 
-		}
+		} while ( p !== stop );
 
 		return m;
+
+	}
+
+	// whether sector in vertex m contains sector in vertex p in the same coordinates
+	function sectorContainsSector( m, p ) {
+
+		return area( m.prev, m, p.prev ) < 0 && area( p.next, m, m.next ) < 0;
 
 	}
 
@@ -29484,16 +30285,18 @@ var Spacekit = (function (exports) {
 	function pointInTriangle( ax, ay, bx, by, cx, cy, px, py ) {
 
 		return ( cx - px ) * ( ay - py ) - ( ax - px ) * ( cy - py ) >= 0 &&
-			   ( ax - px ) * ( by - py ) - ( bx - px ) * ( ay - py ) >= 0 &&
-			   ( bx - px ) * ( cy - py ) - ( cx - px ) * ( by - py ) >= 0;
+				( ax - px ) * ( by - py ) - ( bx - px ) * ( ay - py ) >= 0 &&
+				( bx - px ) * ( cy - py ) - ( cx - px ) * ( by - py ) >= 0;
 
 	}
 
 	// check if a diagonal between two polygon nodes is valid (lies in polygon interior)
 	function isValidDiagonal( a, b ) {
 
-		return a.next.i !== b.i && a.prev.i !== b.i && ! intersectsPolygon( a, b ) &&
-			   locallyInside( a, b ) && locallyInside( b, a ) && middleInside( a, b );
+		return a.next.i !== b.i && a.prev.i !== b.i && ! intersectsPolygon( a, b ) && // dones't intersect other edges
+			( locallyInside( a, b ) && locallyInside( b, a ) && middleInside( a, b ) && // locally visible
+			( area( a.prev, a, b.prev ) || area( a, b.prev, b ) ) || // does not create opposite-facing sectors
+			equals( a, b ) && area( a.prev, a, a.next ) > 0 && area( b.prev, b, b.next ) > 0 ); // special zero-length case
 
 	}
 
@@ -29514,10 +30317,32 @@ var Spacekit = (function (exports) {
 	// check if two segments intersect
 	function intersects( p1, q1, p2, q2 ) {
 
-		if ( ( equals( p1, p2 ) && equals( q1, q2 ) ) ||
-			( equals( p1, q2 ) && equals( p2, q1 ) ) ) return true;
-		return area( p1, q1, p2 ) > 0 !== area( p1, q1, q2 ) > 0 &&
-			   area( p2, q2, p1 ) > 0 !== area( p2, q2, q1 ) > 0;
+		var o1 = sign( area( p1, q1, p2 ) );
+		var o2 = sign( area( p1, q1, q2 ) );
+		var o3 = sign( area( p2, q2, p1 ) );
+		var o4 = sign( area( p2, q2, q1 ) );
+
+		if ( o1 !== o2 && o3 !== o4 ) return true; // general case
+
+		if ( o1 === 0 && onSegment( p1, p2, q1 ) ) return true; // p1, q1 and p2 are collinear and p2 lies on p1q1
+		if ( o2 === 0 && onSegment( p1, q2, q1 ) ) return true; // p1, q1 and q2 are collinear and q2 lies on p1q1
+		if ( o3 === 0 && onSegment( p2, p1, q2 ) ) return true; // p2, q2 and p1 are collinear and p1 lies on p2q2
+		if ( o4 === 0 && onSegment( p2, q1, q2 ) ) return true; // p2, q2 and q1 are collinear and q1 lies on p2q2
+
+		return false;
+
+	}
+
+	// for collinear points p, q, r, check if point q lies on segment pr
+	function onSegment( p, q, r ) {
+
+		return q.x <= Math.max( p.x, r.x ) && q.x >= Math.min( p.x, r.x ) && q.y <= Math.max( p.y, r.y ) && q.y >= Math.min( p.y, r.y );
+
+	}
+
+	function sign( num ) {
+
+		return num > 0 ? 1 : num < 0 ? - 1 : 0;
 
 	}
 
@@ -29841,8 +30666,8 @@ var Spacekit = (function (exports) {
 
 		// build geometry
 
-		this.addAttribute( 'position', new Float32BufferAttribute( verticesArray, 3 ) );
-		this.addAttribute( 'uv', new Float32BufferAttribute( uvArray, 2 ) );
+		this.setAttribute( 'position', new Float32BufferAttribute( verticesArray, 3 ) );
+		this.setAttribute( 'uv', new Float32BufferAttribute( uvArray, 2 ) );
 
 		this.computeVertexNormals();
 
@@ -30809,9 +31634,9 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	}
 
@@ -30953,9 +31778,9 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	}
 
@@ -31012,7 +31837,7 @@ var Spacekit = (function (exports) {
 
 		// clamp phiLength so it's in range of [ 0, 2PI ]
 
-		phiLength = _Math.clamp( phiLength, 0, Math.PI * 2 );
+		phiLength = MathUtils.clamp( phiLength, 0, Math.PI * 2 );
 
 
 		// buffers
@@ -31085,8 +31910,8 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 		// generate normals
 
@@ -31234,9 +32059,9 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 
 		// helper functions
@@ -31375,7 +32200,7 @@ var Spacekit = (function (exports) {
 
 		// helper variables
 
-		var thresholdDot = Math.cos( _Math.DEG2RAD * thresholdAngle );
+		var thresholdDot = Math.cos( MathUtils.DEG2RAD * thresholdAngle );
 		var edge = [ 0, 0 ], edges = {}, edge1, edge2;
 		var key, keys = [ 'a', 'b', 'c' ];
 
@@ -31451,7 +32276,7 @@ var Spacekit = (function (exports) {
 
 		// build geometry
 
-		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
 
 	}
 
@@ -31550,9 +32375,9 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 		function generateTorso() {
 
@@ -31920,18 +32745,17 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	}
 
 	CircleBufferGeometry.prototype = Object.create( BufferGeometry.prototype );
 	CircleBufferGeometry.prototype.constructor = CircleBufferGeometry;
 
-
-
 	var Geometries = /*#__PURE__*/Object.freeze({
+		__proto__: null,
 		WireframeGeometry: WireframeGeometry,
 		ParametricGeometry: ParametricGeometry,
 		ParametricBufferGeometry: ParametricBufferGeometry,
@@ -32090,8 +32914,8 @@ var Spacekit = (function (exports) {
 		this.type = 'MeshStandardMaterial';
 
 		this.color = new Color( 0xffffff ); // diffuse
-		this.roughness = 0.5;
-		this.metalness = 0.5;
+		this.roughness = 1.0;
+		this.metalness = 0.0;
 
 		this.map = null;
 
@@ -32135,6 +32959,8 @@ var Spacekit = (function (exports) {
 		this.skinning = false;
 		this.morphTargets = false;
 		this.morphNormals = false;
+
+		this.vertexTangents = false;
 
 		this.setValues( parameters );
 
@@ -32198,6 +33024,8 @@ var Spacekit = (function (exports) {
 		this.morphTargets = source.morphTargets;
 		this.morphNormals = source.morphNormals;
 
+		this.vertexTangents = source.vertexTangents;
+
 		return this;
 
 	};
@@ -32206,9 +33034,18 @@ var Spacekit = (function (exports) {
 	 * @author WestLangley / http://github.com/WestLangley
 	 *
 	 * parameters = {
-	 *  reflectivity: <float>
-	 *  clearCoat: <float>
-	 *  clearCoatRoughness: <float>
+	 *  clearcoat: <float>,
+	 *  clearcoatMap: new THREE.Texture( <Image> ),
+	 *  clearcoatRoughness: <float>,
+	 *  clearcoatRoughnessMap: new THREE.Texture( <Image> ),
+	 *  clearcoatNormalScale: <Vector2>,
+	 *  clearcoatNormalMap: new THREE.Texture( <Image> ),
+	 *
+	 *  reflectivity: <float>,
+	 *
+	 *  sheen: <Color>,
+	 *
+	 *  transparency: <float>
 	 * }
 	 */
 
@@ -32216,14 +33053,27 @@ var Spacekit = (function (exports) {
 
 		MeshStandardMaterial.call( this );
 
-		this.defines = { 'PHYSICAL': '' };
+		this.defines = {
+
+			'STANDARD': '',
+			'PHYSICAL': ''
+
+		};
 
 		this.type = 'MeshPhysicalMaterial';
 
+		this.clearcoat = 0.0;
+		this.clearcoatMap = null;
+		this.clearcoatRoughness = 0.0;
+		this.clearcoatRoughnessMap = null;
+		this.clearcoatNormalScale = new Vector2( 1, 1 );
+		this.clearcoatNormalMap = null;
+
 		this.reflectivity = 0.5; // maps to F0 = 0.04
 
-		this.clearCoat = 0.0;
-		this.clearCoatRoughness = 0.0;
+		this.sheen = null; // null will disable sheen bsdf
+
+		this.transparency = 0.0;
 
 		this.setValues( parameters );
 
@@ -32238,12 +33088,33 @@ var Spacekit = (function (exports) {
 
 		MeshStandardMaterial.prototype.copy.call( this, source );
 
-		this.defines = { 'PHYSICAL': '' };
+		this.defines = {
+
+			'STANDARD': '',
+			'PHYSICAL': ''
+
+		};
+
+		this.clearcoat = source.clearcoat;
+		this.clearcoatMap = source.clearcoatMap;
+		this.clearcoatRoughness = source.clearcoatRoughness;
+		this.clearcoatRoughnessMap = source.clearcoatRoughnessMap;
+		this.clearcoatNormalMap = source.clearcoatNormalMap;
+		this.clearcoatNormalScale.copy( source.clearcoatNormalScale );
 
 		this.reflectivity = source.reflectivity;
 
-		this.clearCoat = source.clearCoat;
-		this.clearCoatRoughness = source.clearCoatRoughness;
+		if ( source.sheen ) {
+
+			this.sheen = ( this.sheen || new Color() ).copy( source.sheen );
+
+		} else {
+
+			this.sheen = null;
+
+		}
+
+		this.transparency = source.transparency;
 
 		return this;
 
@@ -32287,7 +33158,7 @@ var Spacekit = (function (exports) {
 	 *  alphaMap: new THREE.Texture( <Image> ),
 	 *
 	 *  envMap: new THREE.CubeTexture( [posx, negx, posy, negy, posz, negz] ),
-	 *  combine: THREE.Multiply,
+	 *  combine: THREE.MultiplyOperation,
 	 *  reflectivity: <float>,
 	 *  refractionRatio: <float>,
 	 *
@@ -32417,34 +33288,149 @@ var Spacekit = (function (exports) {
 	 * @author takahirox / http://github.com/takahirox
 	 *
 	 * parameters = {
-	 *  gradientMap: new THREE.Texture( <Image> )
+	 *  color: <hex>,
+	 *  specular: <hex>,
+	 *  shininess: <float>,
+	 *
+	 *  map: new THREE.Texture( <Image> ),
+	 *  gradientMap: new THREE.Texture( <Image> ),
+	 *
+	 *  lightMap: new THREE.Texture( <Image> ),
+	 *  lightMapIntensity: <float>
+	 *
+	 *  aoMap: new THREE.Texture( <Image> ),
+	 *  aoMapIntensity: <float>
+	 *
+	 *  emissive: <hex>,
+	 *  emissiveIntensity: <float>
+	 *  emissiveMap: new THREE.Texture( <Image> ),
+	 *
+	 *  bumpMap: new THREE.Texture( <Image> ),
+	 *  bumpScale: <float>,
+	 *
+	 *  normalMap: new THREE.Texture( <Image> ),
+	 *  normalMapType: THREE.TangentSpaceNormalMap,
+	 *  normalScale: <Vector2>,
+	 *
+	 *  displacementMap: new THREE.Texture( <Image> ),
+	 *  displacementScale: <float>,
+	 *  displacementBias: <float>,
+	 *
+	 *  specularMap: new THREE.Texture( <Image> ),
+	 *
+	 *  alphaMap: new THREE.Texture( <Image> ),
+	 *
+	 *  wireframe: <boolean>,
+	 *  wireframeLinewidth: <float>,
+	 *
+	 *  skinning: <bool>,
+	 *  morphTargets: <bool>,
+	 *  morphNormals: <bool>
 	 * }
 	 */
 
 	function MeshToonMaterial( parameters ) {
 
-		MeshPhongMaterial.call( this );
+		Material.call( this );
 
 		this.defines = { 'TOON': '' };
 
 		this.type = 'MeshToonMaterial';
 
+		this.color = new Color( 0xffffff );
+		this.specular = new Color( 0x111111 );
+		this.shininess = 30;
+
+		this.map = null;
 		this.gradientMap = null;
+
+		this.lightMap = null;
+		this.lightMapIntensity = 1.0;
+
+		this.aoMap = null;
+		this.aoMapIntensity = 1.0;
+
+		this.emissive = new Color( 0x000000 );
+		this.emissiveIntensity = 1.0;
+		this.emissiveMap = null;
+
+		this.bumpMap = null;
+		this.bumpScale = 1;
+
+		this.normalMap = null;
+		this.normalMapType = TangentSpaceNormalMap;
+		this.normalScale = new Vector2( 1, 1 );
+
+		this.displacementMap = null;
+		this.displacementScale = 1;
+		this.displacementBias = 0;
+
+		this.specularMap = null;
+
+		this.alphaMap = null;
+
+		this.wireframe = false;
+		this.wireframeLinewidth = 1;
+		this.wireframeLinecap = 'round';
+		this.wireframeLinejoin = 'round';
+
+		this.skinning = false;
+		this.morphTargets = false;
+		this.morphNormals = false;
 
 		this.setValues( parameters );
 
 	}
 
-	MeshToonMaterial.prototype = Object.create( MeshPhongMaterial.prototype );
+	MeshToonMaterial.prototype = Object.create( Material.prototype );
 	MeshToonMaterial.prototype.constructor = MeshToonMaterial;
 
 	MeshToonMaterial.prototype.isMeshToonMaterial = true;
 
 	MeshToonMaterial.prototype.copy = function ( source ) {
 
-		MeshPhongMaterial.prototype.copy.call( this, source );
+		Material.prototype.copy.call( this, source );
 
+		this.color.copy( source.color );
+		this.specular.copy( source.specular );
+		this.shininess = source.shininess;
+
+		this.map = source.map;
 		this.gradientMap = source.gradientMap;
+
+		this.lightMap = source.lightMap;
+		this.lightMapIntensity = source.lightMapIntensity;
+
+		this.aoMap = source.aoMap;
+		this.aoMapIntensity = source.aoMapIntensity;
+
+		this.emissive.copy( source.emissive );
+		this.emissiveMap = source.emissiveMap;
+		this.emissiveIntensity = source.emissiveIntensity;
+
+		this.bumpMap = source.bumpMap;
+		this.bumpScale = source.bumpScale;
+
+		this.normalMap = source.normalMap;
+		this.normalMapType = source.normalMapType;
+		this.normalScale.copy( source.normalScale );
+
+		this.displacementMap = source.displacementMap;
+		this.displacementScale = source.displacementScale;
+		this.displacementBias = source.displacementBias;
+
+		this.specularMap = source.specularMap;
+
+		this.alphaMap = source.alphaMap;
+
+		this.wireframe = source.wireframe;
+		this.wireframeLinewidth = source.wireframeLinewidth;
+		this.wireframeLinecap = source.wireframeLinecap;
+		this.wireframeLinejoin = source.wireframeLinejoin;
+
+		this.skinning = source.skinning;
+		this.morphTargets = source.morphTargets;
+		this.morphNormals = source.morphNormals;
 
 		return this;
 
@@ -32498,7 +33484,6 @@ var Spacekit = (function (exports) {
 		this.wireframeLinewidth = 1;
 
 		this.fog = false;
-		this.lights = false;
 
 		this.skinning = false;
 		this.morphTargets = false;
@@ -32725,8 +33710,6 @@ var Spacekit = (function (exports) {
 		this.morphTargets = false;
 		this.morphNormals = false;
 
-		this.lights = false;
-
 		this.setValues( parameters );
 
 	}
@@ -32815,9 +33798,8 @@ var Spacekit = (function (exports) {
 
 	};
 
-
-
 	var Materials = /*#__PURE__*/Object.freeze({
+		__proto__: null,
 		ShadowMaterial: ShadowMaterial,
 		SpriteMaterial: SpriteMaterial,
 		RawShaderMaterial: RawShaderMaterial,
@@ -32997,6 +33979,185 @@ var Spacekit = (function (exports) {
 				} while ( key !== undefined );
 
 			}
+
+		},
+
+		subclip: function ( sourceClip, name, startFrame, endFrame, fps ) {
+
+			fps = fps || 30;
+
+			var clip = sourceClip.clone();
+
+			clip.name = name;
+
+			var tracks = [];
+
+			for ( var i = 0; i < clip.tracks.length; ++ i ) {
+
+				var track = clip.tracks[ i ];
+				var valueSize = track.getValueSize();
+
+				var times = [];
+				var values = [];
+
+				for ( var j = 0; j < track.times.length; ++ j ) {
+
+					var frame = track.times[ j ] * fps;
+
+					if ( frame < startFrame || frame >= endFrame ) continue;
+
+					times.push( track.times[ j ] );
+
+					for ( var k = 0; k < valueSize; ++ k ) {
+
+						values.push( track.values[ j * valueSize + k ] );
+
+					}
+
+				}
+
+				if ( times.length === 0 ) continue;
+
+				track.times = AnimationUtils.convertArray( times, track.times.constructor );
+				track.values = AnimationUtils.convertArray( values, track.values.constructor );
+
+				tracks.push( track );
+
+			}
+
+			clip.tracks = tracks;
+
+			// find minimum .times value across all tracks in the trimmed clip
+
+			var minStartTime = Infinity;
+
+			for ( var i = 0; i < clip.tracks.length; ++ i ) {
+
+				if ( minStartTime > clip.tracks[ i ].times[ 0 ] ) {
+
+					minStartTime = clip.tracks[ i ].times[ 0 ];
+
+				}
+
+			}
+
+			// shift all tracks such that clip begins at t=0
+
+			for ( var i = 0; i < clip.tracks.length; ++ i ) {
+
+				clip.tracks[ i ].shift( - 1 * minStartTime );
+
+			}
+
+			clip.resetDuration();
+
+			return clip;
+
+		},
+
+		makeClipAdditive: function ( targetClip, referenceFrame, referenceClip, fps ) {
+
+			if ( referenceFrame === undefined ) referenceFrame = 0;
+			if ( referenceClip === undefined ) referenceClip = targetClip;
+			if ( fps === undefined || fps <= 0 ) fps = 30;
+
+			var numTracks = targetClip.tracks.length;
+			var referenceTime = referenceFrame / fps;
+
+			// Make each track's values relative to the values at the reference frame
+			for ( var i = 0; i < numTracks; ++ i ) {
+
+				var referenceTrack = referenceClip.tracks[ i ];
+				var referenceTrackType = referenceTrack.ValueTypeName;
+
+				// Skip this track if it's non-numeric
+				if ( referenceTrackType === 'bool' || referenceTrackType === 'string' ) continue;
+
+				// Find the track in the target clip whose name and type matches the reference track
+				var targetTrack = targetClip.tracks.find( function ( track ) {
+
+					return track.name === referenceTrack.name
+					&& track.ValueTypeName === referenceTrackType;
+
+				} );
+
+				if ( targetTrack === undefined ) continue;
+
+				var valueSize = referenceTrack.getValueSize();
+				var lastIndex = referenceTrack.times.length - 1;
+				var referenceValue;
+
+				// Find the value to subtract out of the track
+				if ( referenceTime <= referenceTrack.times[ 0 ] ) {
+
+					// Reference frame is earlier than the first keyframe, so just use the first keyframe
+					referenceValue = AnimationUtils.arraySlice( referenceTrack.values, 0, referenceTrack.valueSize );
+
+				} else if ( referenceTime >= referenceTrack.times[ lastIndex ] ) {
+
+					// Reference frame is after the last keyframe, so just use the last keyframe
+					var startIndex = lastIndex * valueSize;
+					referenceValue = AnimationUtils.arraySlice( referenceTrack.values, startIndex );
+
+				} else {
+
+					// Interpolate to the reference value
+					var interpolant = referenceTrack.createInterpolant();
+					interpolant.evaluate( referenceTime );
+					referenceValue = interpolant.resultBuffer;
+
+				}
+
+				// Conjugate the quaternion
+				if ( referenceTrackType === 'quaternion' ) {
+
+					var referenceQuat = new Quaternion(
+						referenceValue[ 0 ],
+						referenceValue[ 1 ],
+						referenceValue[ 2 ],
+						referenceValue[ 3 ]
+					).normalize().conjugate();
+					referenceQuat.toArray( referenceValue );
+
+				}
+
+				// Subtract the reference value from all of the track values
+
+				var numTimes = targetTrack.times.length;
+				for ( var j = 0; j < numTimes; ++ j ) {
+
+					var valueStart = j * valueSize;
+
+					if ( referenceTrackType === 'quaternion' ) {
+
+						// Multiply the conjugate for quaternion track types
+						Quaternion.multiplyQuaternionsFlat(
+							targetTrack.values,
+							valueStart,
+							referenceValue,
+							0,
+							targetTrack.values,
+							valueStart
+						);
+
+					} else {
+
+						// Subtract each value for all other numeric track types
+						for ( var k = 0; k < valueSize; ++ k ) {
+
+							targetTrack.values[ valueStart + k ] -= referenceValue[ k ];
+
+						}
+
+					}
+
+				}
+
+			}
+
+			targetClip.blendMode = AdditiveAnimationBlendMode;
+
+			return targetClip;
 
 		}
 
@@ -33248,7 +34409,7 @@ var Spacekit = (function (exports) {
 
 	} );
 
-	//!\ DECLARE ALIAS AFTER assign prototype !
+	// DECLARE ALIAS AFTER assign prototype
 	Object.assign( Interpolant.prototype, {
 
 		//( 0, t, t0 ), returns this.resultBuffer
@@ -33721,7 +34882,12 @@ var Spacekit = (function (exports) {
 			if ( from !== 0 || to !== nKeys ) {
 
 				// empty tracks are forbidden, so keep at least one keyframe
-				if ( from >= to ) to = Math.max( to, 1 ), from = to - 1;
+				if ( from >= to ) {
+
+					to = Math.max( to, 1 );
+					from = to - 1;
+
+				}
 
 				var stride = this.getValueSize();
 				this.times = AnimationUtils.arraySlice( times, from, to );
@@ -33814,8 +34980,9 @@ var Spacekit = (function (exports) {
 		// (0,0,0,0,1,1,1,0,0,0,0,0,0,0) --> (0,0,1,1,0,0)
 		optimize: function () {
 
-			var times = this.times,
-				values = this.values,
+			// times or values may be shared with other tracks, so overwriting is unsafe
+			var times = AnimationUtils.arraySlice( this.times ),
+				values = AnimationUtils.arraySlice( this.values ),
 				stride = this.getValueSize(),
 
 				smoothInterpolation = this.getInterpolation() === InterpolateSmooth,
@@ -33909,6 +35076,11 @@ var Spacekit = (function (exports) {
 
 				this.times = AnimationUtils.arraySlice( times, 0, writeIndex );
 				this.values = AnimationUtils.arraySlice( values, 0, writeIndex * stride );
+
+			} else {
+
+				this.times = times;
+				this.values = values;
 
 			}
 
@@ -34165,13 +35337,14 @@ var Spacekit = (function (exports) {
 	 * @author David Sarno / http://lighthaus.us/
 	 */
 
-	function AnimationClip( name, duration, tracks ) {
+	function AnimationClip( name, duration, tracks, blendMode ) {
 
 		this.name = name;
 		this.tracks = tracks;
 		this.duration = ( duration !== undefined ) ? duration : - 1;
+		this.blendMode = ( blendMode !== undefined ) ? blendMode : NormalAnimationBlendMode;
 
-		this.uuid = _Math.generateUUID();
+		this.uuid = MathUtils.generateUUID();
 
 		// this means it should figure out its duration by scanning the tracks
 		if ( this.duration < 0 ) {
@@ -34273,7 +35446,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			return new AnimationClip( json.name, json.duration, tracks );
+			return new AnimationClip( json.name, json.duration, tracks, json.blendMode );
 
 		},
 
@@ -34287,7 +35460,8 @@ var Spacekit = (function (exports) {
 				'name': clip.name,
 				'duration': clip.duration,
 				'tracks': tracks,
-				'uuid': clip.uuid
+				'uuid': clip.uuid,
+				'blendMode': clip.blendMode
 
 			};
 
@@ -34449,6 +35623,7 @@ var Spacekit = (function (exports) {
 			// automatic length determination in AnimationClip.
 			var duration = animation.length || - 1;
 			var fps = animation.fps || 30;
+			var blendMode = animation.blendMode;
 
 			var hierarchyTracks = animation.hierarchy || [];
 
@@ -34530,7 +35705,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			var clip = new AnimationClip( clipName, duration, tracks );
+			var clip = new AnimationClip( clipName, duration, tracks, blendMode );
 
 			return clip;
 
@@ -34596,7 +35771,6 @@ var Spacekit = (function (exports) {
 
 		},
 
-
 		clone: function () {
 
 			var tracks = [];
@@ -34607,7 +35781,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			return new AnimationClip( this.name, this.duration, tracks );
+			return new AnimationClip( this.name, this.duration, tracks, this.blendMode );
 
 		}
 
@@ -34669,6 +35843,7 @@ var Spacekit = (function (exports) {
 		var itemsLoaded = 0;
 		var itemsTotal = 0;
 		var urlModifier = undefined;
+		var handlers = [];
 
 		// Refer to #5689 for the reason why we don't set .onStart
 		// in the constructor
@@ -34745,13 +35920,112 @@ var Spacekit = (function (exports) {
 		this.setURLModifier = function ( transform ) {
 
 			urlModifier = transform;
+
 			return this;
+
+		};
+
+		this.addHandler = function ( regex, loader ) {
+
+			handlers.push( regex, loader );
+
+			return this;
+
+		};
+
+		this.removeHandler = function ( regex ) {
+
+			var index = handlers.indexOf( regex );
+
+			if ( index !== - 1 ) {
+
+				handlers.splice( index, 2 );
+
+			}
+
+			return this;
+
+		};
+
+		this.getHandler = function ( file ) {
+
+			for ( var i = 0, l = handlers.length; i < l; i += 2 ) {
+
+				var regex = handlers[ i ];
+				var loader = handlers[ i + 1 ];
+
+				if ( regex.global ) regex.lastIndex = 0; // see #17920
+
+				if ( regex.test( file ) ) {
+
+					return loader;
+
+				}
+
+			}
+
+			return null;
 
 		};
 
 	}
 
 	var DefaultLoadingManager = new LoadingManager();
+
+	/**
+	 * @author alteredq / http://alteredqualia.com/
+	 */
+
+	function Loader( manager ) {
+
+		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
+
+		this.crossOrigin = 'anonymous';
+		this.path = '';
+		this.resourcePath = '';
+
+	}
+
+	Object.assign( Loader.prototype, {
+
+		load: function ( /* url, onLoad, onProgress, onError */ ) {},
+
+		loadAsync: function ( url, onProgress ) {
+
+			var scope = this;
+
+			return new Promise( function ( resolve, reject ) {
+
+				scope.load( url, resolve, onProgress, reject );
+
+			} );
+
+		},
+
+		parse: function ( /* data */ ) {},
+
+		setCrossOrigin: function ( crossOrigin ) {
+
+			this.crossOrigin = crossOrigin;
+			return this;
+
+		},
+
+		setPath: function ( path ) {
+
+			this.path = path;
+			return this;
+
+		},
+
+		setResourcePath: function ( resourcePath ) {
+
+			this.resourcePath = resourcePath;
+			return this;
+
+		}
+
+	} );
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -34761,11 +36035,13 @@ var Spacekit = (function (exports) {
 
 	function FileLoader( manager ) {
 
-		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
+		Loader.call( this, manager );
 
 	}
 
-	Object.assign( FileLoader.prototype, {
+	FileLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
+
+		constructor: FileLoader,
 
 		load: function ( url, onLoad, onProgress, onError ) {
 
@@ -34922,8 +36198,6 @@ var Spacekit = (function (exports) {
 
 					var response = this.response;
 
-					Cache.add( url, response );
-
 					var callbacks = loading[ url ];
 
 					delete loading[ url ];
@@ -34934,6 +36208,10 @@ var Spacekit = (function (exports) {
 						// e.g. 'file://' or 'data://'. Handle as success.
 
 						if ( this.status === 0 ) console.warn( 'THREE.FileLoader: HTTP Status 0 received.' );
+
+						// Add to cache only on HTTP success, so that we do not cache
+						// error response bodies as proper responses to requests.
+						Cache.add( url, response );
 
 						for ( var i = 0, il = callbacks.length; i < il; i ++ ) {
 
@@ -35030,13 +36308,6 @@ var Spacekit = (function (exports) {
 
 		},
 
-		setPath: function ( value ) {
-
-			this.path = value;
-			return this;
-
-		},
-
 		setResponseType: function ( value ) {
 
 			this.responseType = value;
@@ -35073,11 +36344,13 @@ var Spacekit = (function (exports) {
 
 	function AnimationLoader( manager ) {
 
-		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
+		Loader.call( this, manager );
 
 	}
 
-	Object.assign( AnimationLoader.prototype, {
+	AnimationLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
+
+		constructor: AnimationLoader,
 
 		load: function ( url, onLoad, onProgress, onError ) {
 
@@ -35107,13 +36380,6 @@ var Spacekit = (function (exports) {
 
 			return animations;
 
-		},
-
-		setPath: function ( value ) {
-
-			this.path = value;
-			return this;
-
 		}
 
 	} );
@@ -35122,18 +36388,19 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 *
 	 * Abstract Base class to block based textures loader (dds, pvr, ...)
+	 *
+	 * Sub classes have to implement the parse() method which will be used in load().
 	 */
 
 	function CompressedTextureLoader( manager ) {
 
-		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
-
-		// override in sub classes
-		this._parser = null;
+		Loader.call( this, manager );
 
 	}
 
-	Object.assign( CompressedTextureLoader.prototype, {
+	CompressedTextureLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
+
+		constructor: CompressedTextureLoader,
 
 		load: function ( url, onLoad, onProgress, onError ) {
 
@@ -35152,7 +36419,7 @@ var Spacekit = (function (exports) {
 
 				loader.load( url[ i ], function ( buffer ) {
 
-					var texDatas = scope._parser( buffer, true );
+					var texDatas = scope.parse( buffer, true );
 
 					images[ i ] = {
 						width: texDatas.width,
@@ -35195,7 +36462,7 @@ var Spacekit = (function (exports) {
 
 				loader.load( url, function ( buffer ) {
 
-					var texDatas = scope._parser( buffer, true );
+					var texDatas = scope.parse( buffer, true );
 
 					if ( texDatas.isCubemap ) {
 
@@ -35241,13 +36508,6 @@ var Spacekit = (function (exports) {
 
 			return texture;
 
-		},
-
-		setPath: function ( value ) {
-
-			this.path = value;
-			return this;
-
 		}
 
 	} );
@@ -35256,18 +36516,19 @@ var Spacekit = (function (exports) {
 	 * @author Nikos M. / https://github.com/foo123/
 	 *
 	 * Abstract Base class to load generic binary textures formats (rgbe, hdr, ...)
+	 *
+	 * Sub classes have to implement the parse() method which will be used in load().
 	 */
 
 	function DataTextureLoader( manager ) {
 
-		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
-
-		// override in sub classes
-		this._parser = null;
+		Loader.call( this, manager );
 
 	}
 
-	Object.assign( DataTextureLoader.prototype, {
+	DataTextureLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
+
+		constructor: DataTextureLoader,
 
 		load: function ( url, onLoad, onProgress, onError ) {
 
@@ -35280,7 +36541,7 @@ var Spacekit = (function (exports) {
 			loader.setPath( this.path );
 			loader.load( url, function ( buffer ) {
 
-				var texData = scope._parser( buffer );
+				var texData = scope.parse( buffer );
 
 				if ( ! texData ) return;
 
@@ -35300,7 +36561,7 @@ var Spacekit = (function (exports) {
 				texture.wrapT = texData.wrapT !== undefined ? texData.wrapT : ClampToEdgeWrapping;
 
 				texture.magFilter = texData.magFilter !== undefined ? texData.magFilter : LinearFilter;
-				texture.minFilter = texData.minFilter !== undefined ? texData.minFilter : LinearMipmapLinearFilter;
+				texture.minFilter = texData.minFilter !== undefined ? texData.minFilter : LinearFilter;
 
 				texture.anisotropy = texData.anisotropy !== undefined ? texData.anisotropy : 1;
 
@@ -35309,6 +36570,7 @@ var Spacekit = (function (exports) {
 					texture.format = texData.format;
 
 				}
+
 				if ( texData.type !== undefined ) {
 
 					texture.type = texData.type;
@@ -35318,6 +36580,7 @@ var Spacekit = (function (exports) {
 				if ( texData.mipmaps !== undefined ) {
 
 					texture.mipmaps = texData.mipmaps;
+					texture.minFilter = LinearMipmapLinearFilter; // presumably...
 
 				}
 
@@ -35336,13 +36599,6 @@ var Spacekit = (function (exports) {
 
 			return texture;
 
-		},
-
-		setPath: function ( value ) {
-
-			this.path = value;
-			return this;
-
 		}
 
 	} );
@@ -35351,20 +36607,17 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-
 	function ImageLoader( manager ) {
 
-		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
+		Loader.call( this, manager );
 
 	}
 
-	Object.assign( ImageLoader.prototype, {
+	ImageLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
-		crossOrigin: 'anonymous',
+		constructor: ImageLoader,
 
 		load: function ( url, onLoad, onProgress, onError ) {
-
-			if ( url === undefined ) url = '';
 
 			if ( this.path !== undefined ) url = this.path + url;
 
@@ -35432,20 +36685,6 @@ var Spacekit = (function (exports) {
 
 			return image;
 
-		},
-
-		setCrossOrigin: function ( value ) {
-
-			this.crossOrigin = value;
-			return this;
-
-		},
-
-		setPath: function ( value ) {
-
-			this.path = value;
-			return this;
-
 		}
 
 	} );
@@ -35457,13 +36696,13 @@ var Spacekit = (function (exports) {
 
 	function CubeTextureLoader( manager ) {
 
-		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
+		Loader.call( this, manager );
 
 	}
 
-	Object.assign( CubeTextureLoader.prototype, {
+	CubeTextureLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
-		crossOrigin: 'anonymous',
+		constructor: CubeTextureLoader,
 
 		load: function ( urls, onLoad, onProgress, onError ) {
 
@@ -35503,20 +36742,6 @@ var Spacekit = (function (exports) {
 
 			return texture;
 
-		},
-
-		setCrossOrigin: function ( value ) {
-
-			this.crossOrigin = value;
-			return this;
-
-		},
-
-		setPath: function ( value ) {
-
-			this.path = value;
-			return this;
-
 		}
 
 	} );
@@ -35525,16 +36750,15 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-
 	function TextureLoader( manager ) {
 
-		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
+		Loader.call( this, manager );
 
 	}
 
-	Object.assign( TextureLoader.prototype, {
+	TextureLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
-		crossOrigin: 'anonymous',
+		constructor: TextureLoader,
 
 		load: function ( url, onLoad, onProgress, onError ) {
 
@@ -35564,20 +36788,6 @@ var Spacekit = (function (exports) {
 
 			return texture;
 
-		},
-
-		setCrossOrigin: function ( value ) {
-
-			this.crossOrigin = value;
-			return this;
-
-		},
-
-		setPath: function ( value ) {
-
-			this.path = value;
-			return this;
-
 		}
 
 	} );
@@ -35587,8 +36797,8 @@ var Spacekit = (function (exports) {
 	 * Extensible curve object
 	 *
 	 * Some common of curve methods:
-	 * .getPoint( t, optionalTarget ), .getTangent( t )
-	 * .getPointAt( u, optionalTarget ), .getTangentAt( u )
+	 * .getPoint( t, optionalTarget ), .getTangent( t, optionalTarget )
+	 * .getPointAt( u, optionalTarget ), .getTangentAt( u, optionalTarget )
 	 * .getPoints(), .getSpacedPoints()
 	 * .getLength()
 	 * .updateArcLengths()
@@ -35817,7 +37027,7 @@ var Spacekit = (function (exports) {
 		// 2 points a small delta apart will be used to find its gradient
 		// which seems to give a reasonable approximation
 
-		getTangent: function ( t ) {
+		getTangent: function ( t, optionalTarget ) {
 
 			var delta = 0.0001;
 			var t1 = t - delta;
@@ -35831,15 +37041,18 @@ var Spacekit = (function (exports) {
 			var pt1 = this.getPoint( t1 );
 			var pt2 = this.getPoint( t2 );
 
-			var vec = pt2.clone().sub( pt1 );
-			return vec.normalize();
+			var tangent = optionalTarget || ( ( pt1.isVector2 ) ? new Vector2() : new Vector3() );
+
+			tangent.copy( pt2 ).sub( pt1 ).normalize();
+
+			return tangent;
 
 		},
 
-		getTangentAt: function ( u ) {
+		getTangentAt: function ( u, optionalTarget ) {
 
 			var t = this.getUtoTmapping( u );
-			return this.getTangent( t );
+			return this.getTangent( t, optionalTarget );
 
 		},
 
@@ -35864,7 +37077,7 @@ var Spacekit = (function (exports) {
 
 				u = i / segments;
 
-				tangents[ i ] = this.getTangentAt( u );
+				tangents[ i ] = this.getTangentAt( u, new Vector3() );
 				tangents[ i ].normalize();
 
 			}
@@ -35919,7 +37132,7 @@ var Spacekit = (function (exports) {
 
 					vec.normalize();
 
-					theta = Math.acos( _Math.clamp( tangents[ i - 1 ].dot( tangents[ i ] ), - 1, 1 ) ); // clamp for floating pt errors
+					theta = Math.acos( MathUtils.clamp( tangents[ i - 1 ].dot( tangents[ i ] ), - 1, 1 ) ); // clamp for floating pt errors
 
 					normals[ i ].applyMatrix4( mat.makeRotationAxis( vec, theta ) );
 
@@ -35933,7 +37146,7 @@ var Spacekit = (function (exports) {
 
 			if ( closed === true ) {
 
-				theta = Math.acos( _Math.clamp( normals[ 0 ].dot( normals[ segments ] ), - 1, 1 ) );
+				theta = Math.acos( MathUtils.clamp( normals[ 0 ].dot( normals[ segments ] ), - 1, 1 ) );
 				theta /= segments;
 
 				if ( tangents[ 0 ].dot( vec.crossVectors( normals[ 0 ], normals[ segments ] ) ) > 0 ) {
@@ -36684,11 +37897,13 @@ var Spacekit = (function (exports) {
 
 	};
 
-	LineCurve.prototype.getTangent = function ( /* t */ ) {
+	LineCurve.prototype.getTangent = function ( t, optionalTarget ) {
 
-		var tangent = this.v2.clone().sub( this.v1 );
+		var tangent = optionalTarget || new Vector2();
 
-		return tangent.normalize();
+		var tangent = tangent.copy( this.v2 ).sub( this.v1 ).normalize();
+
+		return tangent;
 
 	};
 
@@ -37029,9 +38244,8 @@ var Spacekit = (function (exports) {
 
 	};
 
-
-
 	var Curves = /*#__PURE__*/Object.freeze({
+		__proto__: null,
 		ArcCurve: ArcCurve,
 		CatmullRomCurve3: CatmullRomCurve3,
 		CubicBezierCurve: CubicBezierCurve,
@@ -37335,11 +38549,15 @@ var Spacekit = (function (exports) {
 
 			}
 
+			return this;
+
 		},
 
 		moveTo: function ( x, y ) {
 
 			this.currentPoint.set( x, y ); // TODO consider referencing vectors instead of copying?
+
+			return this;
 
 		},
 
@@ -37349,6 +38567,8 @@ var Spacekit = (function (exports) {
 			this.curves.push( curve );
 
 			this.currentPoint.set( x, y );
+
+			return this;
 
 		},
 
@@ -37363,6 +38583,8 @@ var Spacekit = (function (exports) {
 			this.curves.push( curve );
 
 			this.currentPoint.set( aX, aY );
+
+			return this;
 
 		},
 
@@ -37379,6 +38601,8 @@ var Spacekit = (function (exports) {
 
 			this.currentPoint.set( aX, aY );
 
+			return this;
+
 		},
 
 		splineThru: function ( pts /*Array of Vector*/ ) {
@@ -37390,6 +38614,8 @@ var Spacekit = (function (exports) {
 
 			this.currentPoint.copy( pts[ pts.length - 1 ] );
 
+			return this;
+
 		},
 
 		arc: function ( aX, aY, aRadius, aStartAngle, aEndAngle, aClockwise ) {
@@ -37400,11 +38626,15 @@ var Spacekit = (function (exports) {
 			this.absarc( aX + x0, aY + y0, aRadius,
 				aStartAngle, aEndAngle, aClockwise );
 
+			return this;
+
 		},
 
 		absarc: function ( aX, aY, aRadius, aStartAngle, aEndAngle, aClockwise ) {
 
 			this.absellipse( aX, aY, aRadius, aRadius, aStartAngle, aEndAngle, aClockwise );
+
+			return this;
 
 		},
 
@@ -37414,6 +38644,8 @@ var Spacekit = (function (exports) {
 			var y0 = this.currentPoint.y;
 
 			this.absellipse( aX + x0, aY + y0, xRadius, yRadius, aStartAngle, aEndAngle, aClockwise, aRotation );
+
+			return this;
 
 		},
 
@@ -37438,6 +38670,8 @@ var Spacekit = (function (exports) {
 
 			var lastPoint = curve.getPoint( 1 );
 			this.currentPoint.copy( lastPoint );
+
+			return this;
 
 		},
 
@@ -37488,7 +38722,7 @@ var Spacekit = (function (exports) {
 
 		Path.call( this, points );
 
-		this.uuid = _Math.generateUUID();
+		this.uuid = MathUtils.generateUUID();
 
 		this.type = 'Shape';
 
@@ -37691,11 +38925,83 @@ var Spacekit = (function (exports) {
 		this.mapSize = new Vector2( 512, 512 );
 
 		this.map = null;
+		this.mapPass = null;
 		this.matrix = new Matrix4();
+
+		this._frustum = new Frustum();
+		this._frameExtents = new Vector2( 1, 1 );
+
+		this._viewportCount = 1;
+
+		this._viewports = [
+
+			new Vector4( 0, 0, 1, 1 )
+
+		];
 
 	}
 
 	Object.assign( LightShadow.prototype, {
+
+		_projScreenMatrix: new Matrix4(),
+
+		_lightPositionWorld: new Vector3(),
+
+		_lookTarget: new Vector3(),
+
+		getViewportCount: function () {
+
+			return this._viewportCount;
+
+		},
+
+		getFrustum: function () {
+
+			return this._frustum;
+
+		},
+
+		updateMatrices: function ( light ) {
+
+			var shadowCamera = this.camera,
+				shadowMatrix = this.matrix,
+				projScreenMatrix = this._projScreenMatrix,
+				lookTarget = this._lookTarget,
+				lightPositionWorld = this._lightPositionWorld;
+
+			lightPositionWorld.setFromMatrixPosition( light.matrixWorld );
+			shadowCamera.position.copy( lightPositionWorld );
+
+			lookTarget.setFromMatrixPosition( light.target.matrixWorld );
+			shadowCamera.lookAt( lookTarget );
+			shadowCamera.updateMatrixWorld();
+
+			projScreenMatrix.multiplyMatrices( shadowCamera.projectionMatrix, shadowCamera.matrixWorldInverse );
+			this._frustum.setFromProjectionMatrix( projScreenMatrix );
+
+			shadowMatrix.set(
+				0.5, 0.0, 0.0, 0.5,
+				0.0, 0.5, 0.0, 0.5,
+				0.0, 0.0, 0.5, 0.5,
+				0.0, 0.0, 0.0, 1.0
+			);
+
+			shadowMatrix.multiply( shadowCamera.projectionMatrix );
+			shadowMatrix.multiply( shadowCamera.matrixWorldInverse );
+
+		},
+
+		getViewport: function ( viewportIndex ) {
+
+			return this._viewports[ viewportIndex ];
+
+		},
+
+		getFrameExtents: function () {
+
+			return this._frameExtents;
+
+		},
 
 		copy: function ( source ) {
 
@@ -37749,11 +39055,11 @@ var Spacekit = (function (exports) {
 
 		isSpotLightShadow: true,
 
-		update: function ( light ) {
+		updateMatrices: function ( light ) {
 
 			var camera = this.camera;
 
-			var fov = _Math.RAD2DEG * 2 * light.angle;
+			var fov = MathUtils.RAD2DEG * 2 * light.angle;
 			var aspect = this.mapSize.width / this.mapSize.height;
 			var far = light.distance || camera.far;
 
@@ -37765,6 +39071,8 @@ var Spacekit = (function (exports) {
 				camera.updateProjectionMatrix();
 
 			}
+
+			LightShadow.prototype.updateMatrices.call( this, light );
 
 		}
 
@@ -37836,6 +39144,88 @@ var Spacekit = (function (exports) {
 
 	} );
 
+	function PointLightShadow() {
+
+		LightShadow.call( this, new PerspectiveCamera( 90, 1, 0.5, 500 ) );
+
+		this._frameExtents = new Vector2( 4, 2 );
+
+		this._viewportCount = 6;
+
+		this._viewports = [
+			// These viewports map a cube-map onto a 2D texture with the
+			// following orientation:
+			//
+			//  xzXZ
+			//   y Y
+			//
+			// X - Positive x direction
+			// x - Negative x direction
+			// Y - Positive y direction
+			// y - Negative y direction
+			// Z - Positive z direction
+			// z - Negative z direction
+
+			// positive X
+			new Vector4( 2, 1, 1, 1 ),
+			// negative X
+			new Vector4( 0, 1, 1, 1 ),
+			// positive Z
+			new Vector4( 3, 1, 1, 1 ),
+			// negative Z
+			new Vector4( 1, 1, 1, 1 ),
+			// positive Y
+			new Vector4( 3, 0, 1, 1 ),
+			// negative Y
+			new Vector4( 1, 0, 1, 1 )
+		];
+
+		this._cubeDirections = [
+			new Vector3( 1, 0, 0 ), new Vector3( - 1, 0, 0 ), new Vector3( 0, 0, 1 ),
+			new Vector3( 0, 0, - 1 ), new Vector3( 0, 1, 0 ), new Vector3( 0, - 1, 0 )
+		];
+
+		this._cubeUps = [
+			new Vector3( 0, 1, 0 ), new Vector3( 0, 1, 0 ), new Vector3( 0, 1, 0 ),
+			new Vector3( 0, 1, 0 ), new Vector3( 0, 0, 1 ),	new Vector3( 0, 0, - 1 )
+		];
+
+	}
+
+	PointLightShadow.prototype = Object.assign( Object.create( LightShadow.prototype ), {
+
+		constructor: PointLightShadow,
+
+		isPointLightShadow: true,
+
+		updateMatrices: function ( light, viewportIndex ) {
+
+			if ( viewportIndex === undefined ) viewportIndex = 0;
+
+			var camera = this.camera,
+				shadowMatrix = this.matrix,
+				lightPositionWorld = this._lightPositionWorld,
+				lookTarget = this._lookTarget,
+				projScreenMatrix = this._projScreenMatrix;
+
+			lightPositionWorld.setFromMatrixPosition( light.matrixWorld );
+			camera.position.copy( lightPositionWorld );
+
+			lookTarget.copy( camera.position );
+			lookTarget.add( this._cubeDirections[ viewportIndex ] );
+			camera.up.copy( this._cubeUps[ viewportIndex ] );
+			camera.lookAt( lookTarget );
+			camera.updateMatrixWorld();
+
+			shadowMatrix.makeTranslation( - lightPositionWorld.x, - lightPositionWorld.y, - lightPositionWorld.z );
+
+			projScreenMatrix.multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse );
+			this._frustum.setFromProjectionMatrix( projScreenMatrix );
+
+		}
+
+	} );
+
 	/**
 	 * @author mrdoob / http://mrdoob.com/
 	 */
@@ -37867,7 +39257,7 @@ var Spacekit = (function (exports) {
 		this.distance = ( distance !== undefined ) ? distance : 0;
 		this.decay = ( decay !== undefined ) ? decay : 1;	// for physically correct lights, should be 2.
 
-		this.shadow = new LightShadow( new PerspectiveCamera( 90, 1, 0.5, 500 ) );
+		this.shadow = new PointLightShadow();
 
 	}
 
@@ -37996,15 +39386,13 @@ var Spacekit = (function (exports) {
 
 			if ( this.view !== null && this.view.enabled ) {
 
-				var zoomW = this.zoom / ( this.view.width / this.view.fullWidth );
-				var zoomH = this.zoom / ( this.view.height / this.view.fullHeight );
-				var scaleW = ( this.right - this.left ) / this.view.width;
-				var scaleH = ( this.top - this.bottom ) / this.view.height;
+				var scaleW = ( this.right - this.left ) / this.view.fullWidth / this.zoom;
+				var scaleH = ( this.top - this.bottom ) / this.view.fullHeight / this.zoom;
 
-				left += scaleW * ( this.view.offsetX / zoomW );
-				right = left + scaleW * ( this.view.width / zoomW );
-				top -= scaleH * ( this.view.offsetY / zoomH );
-				bottom = top - scaleH * ( this.view.height / zoomH );
+				left += scaleW * this.view.offsetX;
+				right = left + scaleW * this.view.width;
+				top -= scaleH * this.view.offsetY;
+				bottom = top - scaleH * this.view.height;
 
 			}
 
@@ -38038,7 +39426,7 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-	function DirectionalLightShadow( ) {
+	function DirectionalLightShadow() {
 
 		LightShadow.call( this, new OrthographicCamera( - 5, 5, 5, - 5, 0.5, 500 ) );
 
@@ -38046,7 +39434,15 @@ var Spacekit = (function (exports) {
 
 	DirectionalLightShadow.prototype = Object.assign( Object.create( LightShadow.prototype ), {
 
-		constructor: DirectionalLightShadow
+		constructor: DirectionalLightShadow,
+
+		isDirectionalLightShadow: true,
+
+		updateMatrices: function ( light ) {
+
+			LightShadow.prototype.updateMatrices.call( this, light );
+
+		}
 
 	} );
 
@@ -38158,17 +39554,325 @@ var Spacekit = (function (exports) {
 	} );
 
 	/**
+	 * @author bhouston / http://clara.io
+	 * @author WestLangley / http://github.com/WestLangley
+	 *
+	 * Primary reference:
+	 *   https://graphics.stanford.edu/papers/envmap/envmap.pdf
+	 *
+	 * Secondary reference:
+	 *   https://www.ppsloan.org/publications/StupidSH36.pdf
+	 */
+
+	// 3-band SH defined by 9 coefficients
+
+	function SphericalHarmonics3() {
+
+		this.coefficients = [];
+
+		for ( var i = 0; i < 9; i ++ ) {
+
+			this.coefficients.push( new Vector3() );
+
+		}
+
+	}
+
+	Object.assign( SphericalHarmonics3.prototype, {
+
+		isSphericalHarmonics3: true,
+
+		set: function ( coefficients ) {
+
+			for ( var i = 0; i < 9; i ++ ) {
+
+				this.coefficients[ i ].copy( coefficients[ i ] );
+
+			}
+
+			return this;
+
+		},
+
+		zero: function () {
+
+			for ( var i = 0; i < 9; i ++ ) {
+
+				this.coefficients[ i ].set( 0, 0, 0 );
+
+			}
+
+			return this;
+
+		},
+
+		// get the radiance in the direction of the normal
+		// target is a Vector3
+		getAt: function ( normal, target ) {
+
+			// normal is assumed to be unit length
+
+			var x = normal.x, y = normal.y, z = normal.z;
+
+			var coeff = this.coefficients;
+
+			// band 0
+			target.copy( coeff[ 0 ] ).multiplyScalar( 0.282095 );
+
+			// band 1
+			target.addScaledVector( coeff[ 1 ], 0.488603 * y );
+			target.addScaledVector( coeff[ 2 ], 0.488603 * z );
+			target.addScaledVector( coeff[ 3 ], 0.488603 * x );
+
+			// band 2
+			target.addScaledVector( coeff[ 4 ], 1.092548 * ( x * y ) );
+			target.addScaledVector( coeff[ 5 ], 1.092548 * ( y * z ) );
+			target.addScaledVector( coeff[ 6 ], 0.315392 * ( 3.0 * z * z - 1.0 ) );
+			target.addScaledVector( coeff[ 7 ], 1.092548 * ( x * z ) );
+			target.addScaledVector( coeff[ 8 ], 0.546274 * ( x * x - y * y ) );
+
+			return target;
+
+		},
+
+		// get the irradiance (radiance convolved with cosine lobe) in the direction of the normal
+		// target is a Vector3
+		// https://graphics.stanford.edu/papers/envmap/envmap.pdf
+		getIrradianceAt: function ( normal, target ) {
+
+			// normal is assumed to be unit length
+
+			var x = normal.x, y = normal.y, z = normal.z;
+
+			var coeff = this.coefficients;
+
+			// band 0
+			target.copy( coeff[ 0 ] ).multiplyScalar( 0.886227 ); // π * 0.282095
+
+			// band 1
+			target.addScaledVector( coeff[ 1 ], 2.0 * 0.511664 * y ); // ( 2 * π / 3 ) * 0.488603
+			target.addScaledVector( coeff[ 2 ], 2.0 * 0.511664 * z );
+			target.addScaledVector( coeff[ 3 ], 2.0 * 0.511664 * x );
+
+			// band 2
+			target.addScaledVector( coeff[ 4 ], 2.0 * 0.429043 * x * y ); // ( π / 4 ) * 1.092548
+			target.addScaledVector( coeff[ 5 ], 2.0 * 0.429043 * y * z );
+			target.addScaledVector( coeff[ 6 ], 0.743125 * z * z - 0.247708 ); // ( π / 4 ) * 0.315392 * 3
+			target.addScaledVector( coeff[ 7 ], 2.0 * 0.429043 * x * z );
+			target.addScaledVector( coeff[ 8 ], 0.429043 * ( x * x - y * y ) ); // ( π / 4 ) * 0.546274
+
+			return target;
+
+		},
+
+		add: function ( sh ) {
+
+			for ( var i = 0; i < 9; i ++ ) {
+
+				this.coefficients[ i ].add( sh.coefficients[ i ] );
+
+			}
+
+			return this;
+
+		},
+
+		addScaledSH: function ( sh, s ) {
+
+			for ( var i = 0; i < 9; i ++ ) {
+
+				this.coefficients[ i ].addScaledVector( sh.coefficients[ i ], s );
+
+			}
+
+			return this;
+
+		},
+
+		scale: function ( s ) {
+
+			for ( var i = 0; i < 9; i ++ ) {
+
+				this.coefficients[ i ].multiplyScalar( s );
+
+			}
+
+			return this;
+
+		},
+
+		lerp: function ( sh, alpha ) {
+
+			for ( var i = 0; i < 9; i ++ ) {
+
+				this.coefficients[ i ].lerp( sh.coefficients[ i ], alpha );
+
+			}
+
+			return this;
+
+		},
+
+		equals: function ( sh ) {
+
+			for ( var i = 0; i < 9; i ++ ) {
+
+				if ( ! this.coefficients[ i ].equals( sh.coefficients[ i ] ) ) {
+
+					return false;
+
+				}
+
+			}
+
+			return true;
+
+		},
+
+		copy: function ( sh ) {
+
+			return this.set( sh.coefficients );
+
+		},
+
+		clone: function () {
+
+			return new this.constructor().copy( this );
+
+		},
+
+		fromArray: function ( array, offset ) {
+
+			if ( offset === undefined ) offset = 0;
+
+			var coefficients = this.coefficients;
+
+			for ( var i = 0; i < 9; i ++ ) {
+
+				coefficients[ i ].fromArray( array, offset + ( i * 3 ) );
+
+			}
+
+			return this;
+
+		},
+
+		toArray: function ( array, offset ) {
+
+			if ( array === undefined ) array = [];
+			if ( offset === undefined ) offset = 0;
+
+			var coefficients = this.coefficients;
+
+			for ( var i = 0; i < 9; i ++ ) {
+
+				coefficients[ i ].toArray( array, offset + ( i * 3 ) );
+
+			}
+
+			return array;
+
+		}
+
+	} );
+
+	Object.assign( SphericalHarmonics3, {
+
+		// evaluate the basis functions
+		// shBasis is an Array[ 9 ]
+		getBasisAt: function ( normal, shBasis ) {
+
+			// normal is assumed to be unit length
+
+			var x = normal.x, y = normal.y, z = normal.z;
+
+			// band 0
+			shBasis[ 0 ] = 0.282095;
+
+			// band 1
+			shBasis[ 1 ] = 0.488603 * y;
+			shBasis[ 2 ] = 0.488603 * z;
+			shBasis[ 3 ] = 0.488603 * x;
+
+			// band 2
+			shBasis[ 4 ] = 1.092548 * x * y;
+			shBasis[ 5 ] = 1.092548 * y * z;
+			shBasis[ 6 ] = 0.315392 * ( 3 * z * z - 1 );
+			shBasis[ 7 ] = 1.092548 * x * z;
+			shBasis[ 8 ] = 0.546274 * ( x * x - y * y );
+
+		}
+
+	} );
+
+	/**
+	 * @author WestLangley / http://github.com/WestLangley
+	 *
+	 * A LightProbe is a source of indirect-diffuse light
+	 */
+
+	function LightProbe( sh, intensity ) {
+
+		Light.call( this, undefined, intensity );
+
+		this.type = 'LightProbe';
+
+		this.sh = ( sh !== undefined ) ? sh : new SphericalHarmonics3();
+
+	}
+
+	LightProbe.prototype = Object.assign( Object.create( Light.prototype ), {
+
+		constructor: LightProbe,
+
+		isLightProbe: true,
+
+		copy: function ( source ) {
+
+			Light.prototype.copy.call( this, source );
+
+			this.sh.copy( source.sh );
+
+			return this;
+
+		},
+
+		fromJSON: function ( json ) {
+
+			this.intensity = json.intensity; // TODO: Move this bit to Light.fromJSON();
+			this.sh.fromArray( json.sh );
+
+			return this;
+
+		},
+
+		toJSON: function ( meta ) {
+
+			var data = Light.prototype.toJSON.call( this, meta );
+
+			data.object.sh = this.sh.toArray();
+
+			return data;
+
+		}
+
+	} );
+
+	/**
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
 	function MaterialLoader( manager ) {
 
-		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
+		Loader.call( this, manager );
+
 		this.textures = {};
 
 	}
 
-	Object.assign( MaterialLoader.prototype, {
+	MaterialLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
+
+		constructor: MaterialLoader,
 
 		load: function ( url, onLoad, onProgress, onError ) {
 
@@ -38207,12 +39911,12 @@ var Spacekit = (function (exports) {
 			if ( json.color !== undefined ) material.color.setHex( json.color );
 			if ( json.roughness !== undefined ) material.roughness = json.roughness;
 			if ( json.metalness !== undefined ) material.metalness = json.metalness;
+			if ( json.sheen !== undefined ) material.sheen = new Color().setHex( json.sheen );
 			if ( json.emissive !== undefined ) material.emissive.setHex( json.emissive );
 			if ( json.specular !== undefined ) material.specular.setHex( json.specular );
 			if ( json.shininess !== undefined ) material.shininess = json.shininess;
-			if ( json.clearCoat !== undefined ) material.clearCoat = json.clearCoat;
-			if ( json.clearCoatRoughness !== undefined ) material.clearCoatRoughness = json.clearCoatRoughness;
-			if ( json.vertexColors !== undefined ) material.vertexColors = json.vertexColors;
+			if ( json.clearcoat !== undefined ) material.clearcoat = json.clearcoat;
+			if ( json.clearcoatRoughness !== undefined ) material.clearcoatRoughness = json.clearcoatRoughness;
 			if ( json.fog !== undefined ) material.fog = json.fog;
 			if ( json.flatShading !== undefined ) material.flatShading = json.flatShading;
 			if ( json.blending !== undefined ) material.blending = json.blending;
@@ -38224,6 +39928,16 @@ var Spacekit = (function (exports) {
 			if ( json.depthTest !== undefined ) material.depthTest = json.depthTest;
 			if ( json.depthWrite !== undefined ) material.depthWrite = json.depthWrite;
 			if ( json.colorWrite !== undefined ) material.colorWrite = json.colorWrite;
+
+			if ( json.stencilWrite !== undefined ) material.stencilWrite = json.stencilWrite;
+			if ( json.stencilWriteMask !== undefined ) material.stencilWriteMask = json.stencilWriteMask;
+			if ( json.stencilFunc !== undefined ) material.stencilFunc = json.stencilFunc;
+			if ( json.stencilRef !== undefined ) material.stencilRef = json.stencilRef;
+			if ( json.stencilFuncMask !== undefined ) material.stencilFuncMask = json.stencilFuncMask;
+			if ( json.stencilFail !== undefined ) material.stencilFail = json.stencilFail;
+			if ( json.stencilZFail !== undefined ) material.stencilZFail = json.stencilZFail;
+			if ( json.stencilZPass !== undefined ) material.stencilZPass = json.stencilZPass;
+
 			if ( json.wireframe !== undefined ) material.wireframe = json.wireframe;
 			if ( json.wireframeLinewidth !== undefined ) material.wireframeLinewidth = json.wireframeLinewidth;
 			if ( json.wireframeLinecap !== undefined ) material.wireframeLinecap = json.wireframeLinecap;
@@ -38245,8 +39959,27 @@ var Spacekit = (function (exports) {
 			if ( json.morphNormals !== undefined ) material.morphNormals = json.morphNormals;
 			if ( json.dithering !== undefined ) material.dithering = json.dithering;
 
+			if ( json.vertexTangents !== undefined ) material.vertexTangents = json.vertexTangents;
+
 			if ( json.visible !== undefined ) material.visible = json.visible;
+
+			if ( json.toneMapped !== undefined ) material.toneMapped = json.toneMapped;
+
 			if ( json.userData !== undefined ) material.userData = json.userData;
+
+			if ( json.vertexColors !== undefined ) {
+
+				if ( typeof json.vertexColors === 'number' ) {
+
+					material.vertexColors = ( json.vertexColors > 0 ) ? true : false;
+
+				} else {
+
+					material.vertexColors = json.vertexColors;
+
+				}
+
+			}
 
 			// Shader Material
 
@@ -38324,12 +40057,7 @@ var Spacekit = (function (exports) {
 			if ( json.map !== undefined ) material.map = getTexture( json.map );
 			if ( json.matcap !== undefined ) material.matcap = getTexture( json.matcap );
 
-			if ( json.alphaMap !== undefined ) {
-
-				material.alphaMap = getTexture( json.alphaMap );
-				material.transparent = true;
-
-			}
+			if ( json.alphaMap !== undefined ) material.alphaMap = getTexture( json.alphaMap );
 
 			if ( json.bumpMap !== undefined ) material.bumpMap = getTexture( json.bumpMap );
 			if ( json.bumpScale !== undefined ) material.bumpScale = json.bumpScale;
@@ -38378,14 +40106,12 @@ var Spacekit = (function (exports) {
 
 			if ( json.gradientMap !== undefined ) material.gradientMap = getTexture( json.gradientMap );
 
+			if ( json.clearcoatMap !== undefined ) material.clearcoatMap = getTexture( json.clearcoatMap );
+			if ( json.clearcoatRoughnessMap !== undefined ) material.clearcoatRoughnessMap = getTexture( json.clearcoatRoughnessMap );
+			if ( json.clearcoatNormalMap !== undefined ) material.clearcoatNormalMap = getTexture( json.clearcoatNormalMap );
+			if ( json.clearcoatNormalScale !== undefined ) material.clearcoatNormalScale = new Vector2().fromArray( json.clearcoatNormalScale );
+
 			return material;
-
-		},
-
-		setPath: function ( value ) {
-
-			this.path = value;
-			return this;
 
 		},
 
@@ -38557,11 +40283,13 @@ var Spacekit = (function (exports) {
 
 	function BufferGeometryLoader( manager ) {
 
-		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
+		Loader.call( this, manager );
 
 	}
 
-	Object.assign( BufferGeometryLoader.prototype, {
+	BufferGeometryLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
+
+		constructor: BufferGeometryLoader,
 
 		load: function ( url, onLoad, onProgress, onError ) {
 
@@ -38599,7 +40327,7 @@ var Spacekit = (function (exports) {
 				var bufferAttributeConstr = attribute.isInstancedBufferAttribute ? InstancedBufferAttribute : BufferAttribute;
 				var bufferAttribute = new bufferAttributeConstr( typedArray, attribute.itemSize, attribute.normalized );
 				if ( attribute.name !== undefined ) bufferAttribute.name = attribute.name;
-				geometry.addAttribute( key, bufferAttribute );
+				geometry.setAttribute( key, bufferAttribute );
 
 			}
 
@@ -38627,6 +40355,14 @@ var Spacekit = (function (exports) {
 					geometry.morphAttributes[ key ] = array;
 
 				}
+
+			}
+
+			var morphTargetsRelative = json.data.morphTargetsRelative;
+
+			if ( morphTargetsRelative ) {
+
+				geometry.morphTargetsRelative = true;
 
 			}
 
@@ -38665,13 +40401,6 @@ var Spacekit = (function (exports) {
 
 			return geometry;
 
-		},
-
-		setPath: function ( value ) {
-
-			this.path = value;
-			return this;
-
 		}
 
 	} );
@@ -38695,20 +40424,19 @@ var Spacekit = (function (exports) {
 
 	function ObjectLoader( manager ) {
 
-		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
-		this.resourcePath = '';
+		Loader.call( this, manager );
 
 	}
 
-	Object.assign( ObjectLoader.prototype, {
+	ObjectLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
-		crossOrigin: 'anonymous',
+		constructor: ObjectLoader,
 
 		load: function ( url, onLoad, onProgress, onError ) {
 
 			var scope = this;
 
-			var path = ( this.path === undefined ) ? LoaderUtils.extractUrlBase( url ) : this.path;
+			var path = ( this.path === '' ) ? LoaderUtils.extractUrlBase( url ) : this.path;
 			this.resourcePath = this.resourcePath || path;
 
 			var loader = new FileLoader( scope.manager );
@@ -38743,27 +40471,6 @@ var Spacekit = (function (exports) {
 				scope.parse( json, onLoad );
 
 			}, onProgress, onError );
-
-		},
-
-		setPath: function ( value ) {
-
-			this.path = value;
-			return this;
-
-		},
-
-		setResourcePath: function ( value ) {
-
-			this.resourcePath = value;
-			return this;
-
-		},
-
-		setCrossOrigin: function ( value ) {
-
-			this.crossOrigin = value;
-			return this;
 
 		},
 
@@ -39073,17 +40780,7 @@ var Spacekit = (function (exports) {
 
 						case 'Geometry':
 
-							if ( 'THREE' in window && 'LegacyJSONLoader' in THREE ) {
-
-								var geometryLoader = new THREE.LegacyJSONLoader();
-								geometry = geometryLoader.parse( data, this.resourcePath ).geometry;
-
-
-							} else {
-
-								console.error( 'THREE.ObjectLoader: You have to import LegacyJSONLoader in order load geometry data of type "Geometry".' );
-
-							}
+							console.error( 'THREE.ObjectLoader: Loading "Geometry" is not supported anymore.' );
 
 							break;
 
@@ -39482,6 +41179,12 @@ var Spacekit = (function (exports) {
 
 					break;
 
+				case 'LightProbe':
+
+					object = new LightProbe().fromJSON( data );
+
+					break;
+
 				case 'SkinnedMesh':
 
 					console.warn( 'THREE.ObjectLoader.parseObject() does not support SkinnedMesh yet.' );
@@ -39491,17 +41194,19 @@ var Spacekit = (function (exports) {
 					var geometry = getGeometry( data.geometry );
 					var material = getMaterial( data.material );
 
-					if ( geometry.bones && geometry.bones.length > 0 ) {
+					object = new Mesh( geometry, material );
 
-						object = new SkinnedMesh( geometry, material );
+					break;
 
-					} else {
+				case 'InstancedMesh':
 
-						object = new Mesh( geometry, material );
+					var geometry = getGeometry( data.geometry );
+					var material = getMaterial( data.material );
+					var count = data.count;
+					var instanceMatrix = data.instanceMatrix;
 
-					}
-
-					if ( data.drawMode !== undefined ) object.setDrawMode( data.drawMode );
+					object = new InstancedMesh( geometry, material, count );
+					object.instanceMatrix = new BufferAttribute( new Float32Array( instanceMatrix.array ), 16 );
 
 					break;
 
@@ -39606,6 +41311,8 @@ var Spacekit = (function (exports) {
 
 			if ( data.type === 'LOD' ) {
 
+				if ( data.autoUpdate !== undefined ) object.autoUpdate = data.autoUpdate;
+
 				var levels = data.levels;
 
 				for ( var l = 0; l < levels.length; l ++ ) {
@@ -39674,12 +41381,13 @@ var Spacekit = (function (exports) {
 
 		}
 
-		this.manager = manager !== undefined ? manager : DefaultLoadingManager;
+		Loader.call( this, manager );
+
 		this.options = undefined;
 
 	}
 
-	ImageBitmapLoader.prototype = {
+	ImageBitmapLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 		constructor: ImageBitmapLoader,
 
@@ -39755,22 +41463,9 @@ var Spacekit = (function (exports) {
 
 			scope.manager.itemStart( url );
 
-		},
-
-		setCrossOrigin: function ( /* value */ ) {
-
-			return this;
-
-		},
-
-		setPath: function ( value ) {
-
-			this.path = value;
-			return this;
-
 		}
 
-	};
+	} );
 
 	/**
 	 * @author zz85 / http://www.lab4games.net/zz85/blog
@@ -39796,11 +41491,15 @@ var Spacekit = (function (exports) {
 			this.subPaths.push( this.currentPath );
 			this.currentPath.moveTo( x, y );
 
+			return this;
+
 		},
 
 		lineTo: function ( x, y ) {
 
 			this.currentPath.lineTo( x, y );
+
+			return this;
 
 		},
 
@@ -39808,17 +41507,23 @@ var Spacekit = (function (exports) {
 
 			this.currentPath.quadraticCurveTo( aCPx, aCPy, aX, aY );
 
+			return this;
+
 		},
 
 		bezierCurveTo: function ( aCP1x, aCP1y, aCP2x, aCP2y, aX, aY ) {
 
 			this.currentPath.bezierCurveTo( aCP1x, aCP1y, aCP2x, aCP2y, aX, aY );
 
+			return this;
+
 		},
 
 		splineThru: function ( pts ) {
 
 			this.currentPath.splineThru( pts );
+
+			return this;
 
 		},
 
@@ -39869,6 +41574,7 @@ var Spacekit = (function (exports) {
 							edgeHighPt = inPolygon[ p ]; edgeDy = - edgeDy;
 
 						}
+
 						if ( ( inPt.y < edgeLowPt.y ) || ( inPt.y > edgeHighPt.y ) ) 		continue;
 
 						if ( inPt.y === edgeLowPt.y ) {
@@ -40008,6 +41714,7 @@ var Spacekit = (function (exports) {
 							}
 
 						}
+
 						if ( hole_unassigned ) {
 
 							betterShapeHoles[ sIdx ].push( ho );
@@ -40018,6 +41725,7 @@ var Spacekit = (function (exports) {
 
 				}
 				// console.log("ambiguous: ", ambiguous);
+
 				if ( toChange.length > 0 ) {
 
 					// console.log("to change: ", toChange);
@@ -40090,7 +41798,7 @@ var Spacekit = (function (exports) {
 
 	function createPaths( text, size, data ) {
 
-		var chars = Array.from ? Array.from( text ) : String( text ).split( '' ); // see #13988
+		var chars = Array.from ? Array.from( text ) : String( text ).split( '' ); // workaround for IE11, see #13988
 		var scale = size / data.resolution;
 		var line_height = ( data.boundingBox.yMax - data.boundingBox.yMin + data.underlineThickness ) * scale;
 
@@ -40205,11 +41913,13 @@ var Spacekit = (function (exports) {
 
 	function FontLoader( manager ) {
 
-		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
+		Loader.call( this, manager );
 
 	}
 
-	Object.assign( FontLoader.prototype, {
+	FontLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
+
+		constructor: FontLoader,
 
 		load: function ( url, onLoad, onProgress, onError ) {
 
@@ -40244,333 +41954,7 @@ var Spacekit = (function (exports) {
 
 			return new Font( json );
 
-		},
-
-		setPath: function ( value ) {
-
-			this.path = value;
-			return this;
-
 		}
-
-	} );
-
-	/**
-	 * @author alteredq / http://alteredqualia.com/
-	 */
-
-	function Loader() {}
-
-	Loader.Handlers = {
-
-		handlers: [],
-
-		add: function ( regex, loader ) {
-
-			this.handlers.push( regex, loader );
-
-		},
-
-		get: function ( file ) {
-
-			var handlers = this.handlers;
-
-			for ( var i = 0, l = handlers.length; i < l; i += 2 ) {
-
-				var regex = handlers[ i ];
-				var loader = handlers[ i + 1 ];
-
-				if ( regex.test( file ) ) {
-
-					return loader;
-
-				}
-
-			}
-
-			return null;
-
-		}
-
-	};
-
-	Object.assign( Loader.prototype, {
-
-		crossOrigin: 'anonymous',
-
-		onLoadStart: function () {},
-
-		onLoadProgress: function () {},
-
-		onLoadComplete: function () {},
-
-		initMaterials: function ( materials, texturePath, crossOrigin ) {
-
-			var array = [];
-
-			for ( var i = 0; i < materials.length; ++ i ) {
-
-				array[ i ] = this.createMaterial( materials[ i ], texturePath, crossOrigin );
-
-			}
-
-			return array;
-
-		},
-
-		createMaterial: ( function () {
-
-			var BlendingMode = {
-				NoBlending: NoBlending,
-				NormalBlending: NormalBlending,
-				AdditiveBlending: AdditiveBlending,
-				SubtractiveBlending: SubtractiveBlending,
-				MultiplyBlending: MultiplyBlending,
-				CustomBlending: CustomBlending
-			};
-
-			var color = new Color();
-			var textureLoader = new TextureLoader();
-			var materialLoader = new MaterialLoader();
-
-			return function createMaterial( m, texturePath, crossOrigin ) {
-
-				// convert from old material format
-
-				var textures = {};
-
-				function loadTexture( path, repeat, offset, wrap, anisotropy ) {
-
-					var fullPath = texturePath + path;
-					var loader = Loader.Handlers.get( fullPath );
-
-					var texture;
-
-					if ( loader !== null ) {
-
-						texture = loader.load( fullPath );
-
-					} else {
-
-						textureLoader.setCrossOrigin( crossOrigin );
-						texture = textureLoader.load( fullPath );
-
-					}
-
-					if ( repeat !== undefined ) {
-
-						texture.repeat.fromArray( repeat );
-
-						if ( repeat[ 0 ] !== 1 ) texture.wrapS = RepeatWrapping;
-						if ( repeat[ 1 ] !== 1 ) texture.wrapT = RepeatWrapping;
-
-					}
-
-					if ( offset !== undefined ) {
-
-						texture.offset.fromArray( offset );
-
-					}
-
-					if ( wrap !== undefined ) {
-
-						if ( wrap[ 0 ] === 'repeat' ) texture.wrapS = RepeatWrapping;
-						if ( wrap[ 0 ] === 'mirror' ) texture.wrapS = MirroredRepeatWrapping;
-
-						if ( wrap[ 1 ] === 'repeat' ) texture.wrapT = RepeatWrapping;
-						if ( wrap[ 1 ] === 'mirror' ) texture.wrapT = MirroredRepeatWrapping;
-
-					}
-
-					if ( anisotropy !== undefined ) {
-
-						texture.anisotropy = anisotropy;
-
-					}
-
-					var uuid = _Math.generateUUID();
-
-					textures[ uuid ] = texture;
-
-					return uuid;
-
-				}
-
-				//
-
-				var json = {
-					uuid: _Math.generateUUID(),
-					type: 'MeshLambertMaterial'
-				};
-
-				for ( var name in m ) {
-
-					var value = m[ name ];
-
-					switch ( name ) {
-
-						case 'DbgColor':
-						case 'DbgIndex':
-						case 'opticalDensity':
-						case 'illumination':
-							break;
-						case 'DbgName':
-							json.name = value;
-							break;
-						case 'blending':
-							json.blending = BlendingMode[ value ];
-							break;
-						case 'colorAmbient':
-						case 'mapAmbient':
-							console.warn( 'THREE.Loader.createMaterial:', name, 'is no longer supported.' );
-							break;
-						case 'colorDiffuse':
-							json.color = color.fromArray( value ).getHex();
-							break;
-						case 'colorSpecular':
-							json.specular = color.fromArray( value ).getHex();
-							break;
-						case 'colorEmissive':
-							json.emissive = color.fromArray( value ).getHex();
-							break;
-						case 'specularCoef':
-							json.shininess = value;
-							break;
-						case 'shading':
-							if ( value.toLowerCase() === 'basic' ) json.type = 'MeshBasicMaterial';
-							if ( value.toLowerCase() === 'phong' ) json.type = 'MeshPhongMaterial';
-							if ( value.toLowerCase() === 'standard' ) json.type = 'MeshStandardMaterial';
-							break;
-						case 'mapDiffuse':
-							json.map = loadTexture( value, m.mapDiffuseRepeat, m.mapDiffuseOffset, m.mapDiffuseWrap, m.mapDiffuseAnisotropy );
-							break;
-						case 'mapDiffuseRepeat':
-						case 'mapDiffuseOffset':
-						case 'mapDiffuseWrap':
-						case 'mapDiffuseAnisotropy':
-							break;
-						case 'mapEmissive':
-							json.emissiveMap = loadTexture( value, m.mapEmissiveRepeat, m.mapEmissiveOffset, m.mapEmissiveWrap, m.mapEmissiveAnisotropy );
-							break;
-						case 'mapEmissiveRepeat':
-						case 'mapEmissiveOffset':
-						case 'mapEmissiveWrap':
-						case 'mapEmissiveAnisotropy':
-							break;
-						case 'mapLight':
-							json.lightMap = loadTexture( value, m.mapLightRepeat, m.mapLightOffset, m.mapLightWrap, m.mapLightAnisotropy );
-							break;
-						case 'mapLightRepeat':
-						case 'mapLightOffset':
-						case 'mapLightWrap':
-						case 'mapLightAnisotropy':
-							break;
-						case 'mapAO':
-							json.aoMap = loadTexture( value, m.mapAORepeat, m.mapAOOffset, m.mapAOWrap, m.mapAOAnisotropy );
-							break;
-						case 'mapAORepeat':
-						case 'mapAOOffset':
-						case 'mapAOWrap':
-						case 'mapAOAnisotropy':
-							break;
-						case 'mapBump':
-							json.bumpMap = loadTexture( value, m.mapBumpRepeat, m.mapBumpOffset, m.mapBumpWrap, m.mapBumpAnisotropy );
-							break;
-						case 'mapBumpScale':
-							json.bumpScale = value;
-							break;
-						case 'mapBumpRepeat':
-						case 'mapBumpOffset':
-						case 'mapBumpWrap':
-						case 'mapBumpAnisotropy':
-							break;
-						case 'mapNormal':
-							json.normalMap = loadTexture( value, m.mapNormalRepeat, m.mapNormalOffset, m.mapNormalWrap, m.mapNormalAnisotropy );
-							break;
-						case 'mapNormalFactor':
-							json.normalScale = value;
-							break;
-						case 'mapNormalRepeat':
-						case 'mapNormalOffset':
-						case 'mapNormalWrap':
-						case 'mapNormalAnisotropy':
-							break;
-						case 'mapSpecular':
-							json.specularMap = loadTexture( value, m.mapSpecularRepeat, m.mapSpecularOffset, m.mapSpecularWrap, m.mapSpecularAnisotropy );
-							break;
-						case 'mapSpecularRepeat':
-						case 'mapSpecularOffset':
-						case 'mapSpecularWrap':
-						case 'mapSpecularAnisotropy':
-							break;
-						case 'mapMetalness':
-							json.metalnessMap = loadTexture( value, m.mapMetalnessRepeat, m.mapMetalnessOffset, m.mapMetalnessWrap, m.mapMetalnessAnisotropy );
-							break;
-						case 'mapMetalnessRepeat':
-						case 'mapMetalnessOffset':
-						case 'mapMetalnessWrap':
-						case 'mapMetalnessAnisotropy':
-							break;
-						case 'mapRoughness':
-							json.roughnessMap = loadTexture( value, m.mapRoughnessRepeat, m.mapRoughnessOffset, m.mapRoughnessWrap, m.mapRoughnessAnisotropy );
-							break;
-						case 'mapRoughnessRepeat':
-						case 'mapRoughnessOffset':
-						case 'mapRoughnessWrap':
-						case 'mapRoughnessAnisotropy':
-							break;
-						case 'mapAlpha':
-							json.alphaMap = loadTexture( value, m.mapAlphaRepeat, m.mapAlphaOffset, m.mapAlphaWrap, m.mapAlphaAnisotropy );
-							break;
-						case 'mapAlphaRepeat':
-						case 'mapAlphaOffset':
-						case 'mapAlphaWrap':
-						case 'mapAlphaAnisotropy':
-							break;
-						case 'flipSided':
-							json.side = BackSide;
-							break;
-						case 'doubleSided':
-							json.side = DoubleSide;
-							break;
-						case 'transparency':
-							console.warn( 'THREE.Loader.createMaterial: transparency has been renamed to opacity' );
-							json.opacity = value;
-							break;
-						case 'depthTest':
-						case 'depthWrite':
-						case 'colorWrite':
-						case 'opacity':
-						case 'reflectivity':
-						case 'transparent':
-						case 'visible':
-						case 'wireframe':
-							json[ name ] = value;
-							break;
-						case 'vertexColors':
-							if ( value === true ) json.vertexColors = VertexColors;
-							if ( value === 'face' ) json.vertexColors = FaceColors;
-							break;
-						default:
-							console.error( 'THREE.Loader.createMaterial: Unsupported', name, value );
-							break;
-
-					}
-
-				}
-
-				if ( json.type === 'MeshBasicMaterial' ) delete json.emissive;
-				if ( json.type !== 'MeshPhongMaterial' ) delete json.specular;
-
-				if ( json.opacity < 1 ) json.transparent = true;
-
-				materialLoader.setTextures( textures );
-
-				return materialLoader.parse( json );
-
-			};
-
-		} )()
 
 	} );
 
@@ -40578,25 +41962,25 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-	var context;
+	var _context;
 
 	var AudioContext = {
 
 		getContext: function () {
 
-			if ( context === undefined ) {
+			if ( _context === undefined ) {
 
-				context = new ( window.AudioContext || window.webkitAudioContext )();
+				_context = new ( window.AudioContext || window.webkitAudioContext )();
 
 			}
 
-			return context;
+			return _context;
 
 		},
 
 		setContext: function ( value ) {
 
-			context = value;
+			_context = value;
 
 		}
 
@@ -40608,11 +41992,13 @@ var Spacekit = (function (exports) {
 
 	function AudioLoader( manager ) {
 
-		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
+		Loader.call( this, manager );
 
 	}
 
-	Object.assign( AudioLoader.prototype, {
+	AudioLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
+
+		constructor: AudioLoader,
 
 		load: function ( url, onLoad, onProgress, onError ) {
 
@@ -40633,293 +42019,6 @@ var Spacekit = (function (exports) {
 				} );
 
 			}, onProgress, onError );
-
-		},
-
-		setPath: function ( value ) {
-
-			this.path = value;
-			return this;
-
-		}
-
-	} );
-
-	/**
-	 * @author bhouston / http://clara.io
-	 * @author WestLangley / http://github.com/WestLangley
-	 *
-	 * Primary reference:
-	 *   https://graphics.stanford.edu/papers/envmap/envmap.pdf
-	 *
-	 * Secondary reference:
-	 *   https://www.ppsloan.org/publications/StupidSH36.pdf
-	 */
-
-	// 3-band SH defined by 9 coefficients
-
-	function SphericalHarmonics3() {
-
-		this.coefficients = [];
-
-		for ( var i = 0; i < 9; i ++ ) {
-
-			this.coefficients.push( new Vector3() );
-
-		}
-
-	}
-
-	Object.assign( SphericalHarmonics3.prototype, {
-
-		isSphericalHarmonics3: true,
-
-		set: function ( coefficients ) {
-
-			for ( var i = 0; i < 9; i ++ ) {
-
-				this.coefficients[ i ].copy( coefficients[ i ] );
-
-			}
-
-			return this;
-
-		},
-
-		zero: function () {
-
-			for ( var i = 0; i < 9; i ++ ) {
-
-				this.coefficients[ i ].set( 0, 0, 0 );
-
-			}
-
-			return this;
-
-		},
-
-		// get the radiance in the direction of the normal
-		// target is a Vector3
-		getAt: function ( normal, target ) {
-
-			// normal is assumed to be unit length
-
-			var x = normal.x, y = normal.y, z = normal.z;
-
-			var coeff = this.coefficients;
-
-			// band 0
-			target.copy( coeff[ 0 ] ).multiplyScalar( 0.282095 );
-
-			// band 1
-			target.addScale( coeff[ 1 ], 0.488603 * y );
-			target.addScale( coeff[ 2 ], 0.488603 * z );
-			target.addScale( coeff[ 3 ], 0.488603 * x );
-
-			// band 2
-			target.addScale( coeff[ 4 ], 1.092548 * ( x * y ) );
-			target.addScale( coeff[ 5 ], 1.092548 * ( y * z ) );
-			target.addScale( coeff[ 6 ], 0.315392 * ( 3.0 * z * z - 1.0 ) );
-			target.addScale( coeff[ 7 ], 1.092548 * ( x * z ) );
-			target.addScale( coeff[ 8 ], 0.546274 * ( x * x - y * y ) );
-
-			return target;
-
-		},
-
-		// get the irradiance (radiance convolved with cosine lobe) in the direction of the normal
-		// target is a Vector3
-		// https://graphics.stanford.edu/papers/envmap/envmap.pdf
-		getIrradianceAt: function ( normal, target ) {
-
-			// normal is assumed to be unit length
-
-			var x = normal.x, y = normal.y, z = normal.z;
-
-			var coeff = this.coefficients;
-
-			// band 0
-			target.copy( coeff[ 0 ] ).multiplyScalar( 0.886227 ); // π * 0.282095
-
-			// band 1
-			target.addScale( coeff[ 1 ], 2.0 * 0.511664 * y ); // ( 2 * π / 3 ) * 0.488603
-			target.addScale( coeff[ 2 ], 2.0 * 0.511664 * z );
-			target.addScale( coeff[ 3 ], 2.0 * 0.511664 * x );
-
-			// band 2
-			target.addScale( coeff[ 4 ], 2.0 * 0.429043 * x * y ); // ( π / 4 ) * 1.092548
-			target.addScale( coeff[ 5 ], 2.0 * 0.429043 * y * z );
-			target.addScale( coeff[ 6 ], 0.743125 * z * z - 0.247708 ); // ( π / 4 ) * 0.315392 * 3
-			target.addScale( coeff[ 7 ], 2.0 * 0.429043 * x * z );
-			target.addScale( coeff[ 8 ], 0.429043 * ( x * x - y * y ) ); // ( π / 4 ) * 0.546274
-
-			return target;
-
-		},
-
-		add: function ( sh ) {
-
-			for ( var i = 0; i < 9; i ++ ) {
-
-				this.coefficients[ i ].add( sh.coefficients[ i ] );
-
-			}
-
-			return this;
-
-		},
-
-
-		scale: function ( s ) {
-
-			for ( var i = 0; i < 9; i ++ ) {
-
-				this.coefficients[ i ].multiplyScalar( s );
-
-			}
-
-			return this;
-
-		},
-
-		lerp: function ( sh, alpha ) {
-
-			for ( var i = 0; i < 9; i ++ ) {
-
-				this.coefficients[ i ].lerp( sh.coefficients[ i ], alpha );
-
-			}
-
-			return this;
-
-		},
-
-		equals: function ( sh ) {
-
-			for ( var i = 0; i < 9; i ++ ) {
-
-				if ( ! this.coefficients[ i ].equals( sh.coefficients[ i ] ) ) {
-
-					return false;
-
-				}
-
-			}
-
-			return true;
-
-		},
-
-		copy: function ( sh ) {
-
-			return this.set( sh.coefficients );
-
-		},
-
-		clone: function () {
-
-			return new this.constructor().copy( this );
-
-		},
-
-		fromArray: function ( array ) {
-
-			var coefficients = this.coefficients;
-
-			for ( var i = 0; i < 9; i ++ ) {
-
-				coefficients[ i ].fromArray( array, i * 3 );
-
-			}
-
-			return this;
-
-		},
-
-		toArray: function () {
-
-			var array = [];
-			var coefficients = this.coefficients;
-
-			for ( var i = 0; i < 9; i ++ ) {
-
-				coefficients[ i ].toArray( array, i * 3 );
-
-			}
-
-			return array;
-
-		}
-
-	} );
-
-	Object.assign( SphericalHarmonics3, {
-
-		// evaluate the basis functions
-		// shBasis is an Array[ 9 ]
-		getBasisAt: function ( normal, shBasis ) {
-
-			// normal is assumed to be unit length
-
-			var x = normal.x, y = normal.y, z = normal.z;
-
-			// band 0
-			shBasis[ 0 ] = 0.282095;
-
-			// band 1
-			shBasis[ 1 ] = 0.488603 * y;
-			shBasis[ 2 ] = 0.488603 * z;
-			shBasis[ 3 ] = 0.488603 * x;
-
-			// band 2
-			shBasis[ 4 ] = 1.092548 * x * y;
-			shBasis[ 5 ] = 1.092548 * y * z;
-			shBasis[ 6 ] = 0.315392 * ( 3 * z * z - 1 );
-			shBasis[ 7 ] = 1.092548 * x * z;
-			shBasis[ 8 ] = 0.546274 * ( x * x - y * y );
-
-		}
-
-	} );
-
-	/**
-	 * @author WestLangley / http://github.com/WestLangley
-	 *
-	 * A LightProbe is a source of indirect-diffuse light
-	 */
-
-	function LightProbe( sh, intensity ) {
-
-		Light.call( this, undefined, intensity );
-
-		this.sh = ( sh !== undefined ) ? sh : new SphericalHarmonics3();
-
-	}
-
-	LightProbe.prototype = Object.assign( Object.create( Light.prototype ), {
-
-		constructor: LightProbe,
-
-		isLightProbe: true,
-
-		copy: function ( source ) {
-
-			Light.prototype.copy.call( this, source );
-
-			this.sh.copy( source.sh );
-			this.intensity = source.intensity;
-
-			return this;
-
-		},
-
-		toJSON: function ( meta ) {
-
-			var data = Light.prototype.toJSON.call( this, meta );
-
-			// data.sh = this.sh.toArray(); // todo
-
-			return data;
 
 		}
 
@@ -41015,6 +42114,9 @@ var Spacekit = (function (exports) {
 
 	} );
 
+	var _eyeRight = new Matrix4();
+	var _eyeLeft = new Matrix4();
+
 	/**
 	 * @author mrdoob / http://mrdoob.com/
 	 */
@@ -41035,75 +42137,78 @@ var Spacekit = (function (exports) {
 		this.cameraR.layers.enable( 2 );
 		this.cameraR.matrixAutoUpdate = false;
 
+		this._cache = {
+			focus: null,
+			fov: null,
+			aspect: null,
+			near: null,
+			far: null,
+			zoom: null,
+			eyeSep: null
+		};
+
 	}
 
 	Object.assign( StereoCamera.prototype, {
 
-		update: ( function () {
+		update: function ( camera ) {
 
-			var instance, focus, fov, aspect, near, far, zoom, eyeSep;
+			var cache = this._cache;
 
-			var eyeRight = new Matrix4();
-			var eyeLeft = new Matrix4();
+			var needsUpdate = cache.focus !== camera.focus || cache.fov !== camera.fov ||
+				cache.aspect !== camera.aspect * this.aspect || cache.near !== camera.near ||
+				cache.far !== camera.far || cache.zoom !== camera.zoom || cache.eyeSep !== this.eyeSep;
 
-			return function update( camera ) {
+			if ( needsUpdate ) {
 
-				var needsUpdate = instance !== this || focus !== camera.focus || fov !== camera.fov ||
-													aspect !== camera.aspect * this.aspect || near !== camera.near ||
-													far !== camera.far || zoom !== camera.zoom || eyeSep !== this.eyeSep;
+				cache.focus = camera.focus;
+				cache.fov = camera.fov;
+				cache.aspect = camera.aspect * this.aspect;
+				cache.near = camera.near;
+				cache.far = camera.far;
+				cache.zoom = camera.zoom;
+				cache.eyeSep = this.eyeSep;
 
-				if ( needsUpdate ) {
+				// Off-axis stereoscopic effect based on
+				// http://paulbourke.net/stereographics/stereorender/
 
-					instance = this;
-					focus = camera.focus;
-					fov = camera.fov;
-					aspect = camera.aspect * this.aspect;
-					near = camera.near;
-					far = camera.far;
-					zoom = camera.zoom;
+				var projectionMatrix = camera.projectionMatrix.clone();
+				var eyeSepHalf = cache.eyeSep / 2;
+				var eyeSepOnProjection = eyeSepHalf * cache.near / cache.focus;
+				var ymax = ( cache.near * Math.tan( MathUtils.DEG2RAD * cache.fov * 0.5 ) ) / cache.zoom;
+				var xmin, xmax;
 
-					// Off-axis stereoscopic effect based on
-					// http://paulbourke.net/stereographics/stereorender/
+				// translate xOffset
 
-					var projectionMatrix = camera.projectionMatrix.clone();
-					eyeSep = this.eyeSep / 2;
-					var eyeSepOnProjection = eyeSep * near / focus;
-					var ymax = ( near * Math.tan( _Math.DEG2RAD * fov * 0.5 ) ) / zoom;
-					var xmin, xmax;
+				_eyeLeft.elements[ 12 ] = - eyeSepHalf;
+				_eyeRight.elements[ 12 ] = eyeSepHalf;
 
-					// translate xOffset
+				// for left eye
 
-					eyeLeft.elements[ 12 ] = - eyeSep;
-					eyeRight.elements[ 12 ] = eyeSep;
+				xmin = - ymax * cache.aspect + eyeSepOnProjection;
+				xmax = ymax * cache.aspect + eyeSepOnProjection;
 
-					// for left eye
+				projectionMatrix.elements[ 0 ] = 2 * cache.near / ( xmax - xmin );
+				projectionMatrix.elements[ 8 ] = ( xmax + xmin ) / ( xmax - xmin );
 
-					xmin = - ymax * aspect + eyeSepOnProjection;
-					xmax = ymax * aspect + eyeSepOnProjection;
+				this.cameraL.projectionMatrix.copy( projectionMatrix );
 
-					projectionMatrix.elements[ 0 ] = 2 * near / ( xmax - xmin );
-					projectionMatrix.elements[ 8 ] = ( xmax + xmin ) / ( xmax - xmin );
+				// for right eye
 
-					this.cameraL.projectionMatrix.copy( projectionMatrix );
+				xmin = - ymax * cache.aspect - eyeSepOnProjection;
+				xmax = ymax * cache.aspect - eyeSepOnProjection;
 
-					// for right eye
+				projectionMatrix.elements[ 0 ] = 2 * cache.near / ( xmax - xmin );
+				projectionMatrix.elements[ 8 ] = ( xmax + xmin ) / ( xmax - xmin );
 
-					xmin = - ymax * aspect - eyeSepOnProjection;
-					xmax = ymax * aspect - eyeSepOnProjection;
+				this.cameraR.projectionMatrix.copy( projectionMatrix );
 
-					projectionMatrix.elements[ 0 ] = 2 * near / ( xmax - xmin );
-					projectionMatrix.elements[ 8 ] = ( xmax + xmin ) / ( xmax - xmin );
+			}
 
-					this.cameraR.projectionMatrix.copy( projectionMatrix );
+			this.cameraL.matrixWorld.copy( camera.matrixWorld ).multiply( _eyeLeft );
+			this.cameraR.matrixWorld.copy( camera.matrixWorld ).multiply( _eyeRight );
 
-				}
-
-				this.cameraL.matrixWorld.copy( camera.matrixWorld ).multiply( eyeLeft );
-				this.cameraR.matrixWorld.copy( camera.matrixWorld ).multiply( eyeRight );
-
-			};
-
-		} )()
+		}
 
 	} );
 
@@ -41182,6 +42287,11 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
+	var _position$2 = new Vector3();
+	var _quaternion$3 = new Quaternion();
+	var _scale$1 = new Vector3();
+	var _orientation = new Vector3();
+
 	function AudioListener() {
 
 		Object3D.call( this );
@@ -41196,6 +42306,10 @@ var Spacekit = (function (exports) {
 		this.filter = null;
 
 		this.timeDelta = 0;
+
+		// private
+
+		this._clock = new Clock();
 
 	}
 
@@ -41265,54 +42379,43 @@ var Spacekit = (function (exports) {
 
 		},
 
-		updateMatrixWorld: ( function () {
+		updateMatrixWorld: function ( force ) {
 
-			var position = new Vector3();
-			var quaternion = new Quaternion();
-			var scale = new Vector3();
+			Object3D.prototype.updateMatrixWorld.call( this, force );
 
-			var orientation = new Vector3();
-			var clock = new Clock();
+			var listener = this.context.listener;
+			var up = this.up;
 
-			return function updateMatrixWorld( force ) {
+			this.timeDelta = this._clock.getDelta();
 
-				Object3D.prototype.updateMatrixWorld.call( this, force );
+			this.matrixWorld.decompose( _position$2, _quaternion$3, _scale$1 );
 
-				var listener = this.context.listener;
-				var up = this.up;
+			_orientation.set( 0, 0, - 1 ).applyQuaternion( _quaternion$3 );
 
-				this.timeDelta = clock.getDelta();
+			if ( listener.positionX ) {
 
-				this.matrixWorld.decompose( position, quaternion, scale );
+				// code path for Chrome (see #14393)
 
-				orientation.set( 0, 0, - 1 ).applyQuaternion( quaternion );
+				var endTime = this.context.currentTime + this.timeDelta;
 
-				if ( listener.positionX ) {
+				listener.positionX.linearRampToValueAtTime( _position$2.x, endTime );
+				listener.positionY.linearRampToValueAtTime( _position$2.y, endTime );
+				listener.positionZ.linearRampToValueAtTime( _position$2.z, endTime );
+				listener.forwardX.linearRampToValueAtTime( _orientation.x, endTime );
+				listener.forwardY.linearRampToValueAtTime( _orientation.y, endTime );
+				listener.forwardZ.linearRampToValueAtTime( _orientation.z, endTime );
+				listener.upX.linearRampToValueAtTime( up.x, endTime );
+				listener.upY.linearRampToValueAtTime( up.y, endTime );
+				listener.upZ.linearRampToValueAtTime( up.z, endTime );
 
-					// code path for Chrome (see #14393)
+			} else {
 
-					var endTime = this.context.currentTime + this.timeDelta;
+				listener.setPosition( _position$2.x, _position$2.y, _position$2.z );
+				listener.setOrientation( _orientation.x, _orientation.y, _orientation.z, up.x, up.y, up.z );
 
-					listener.positionX.linearRampToValueAtTime( position.x, endTime );
-					listener.positionY.linearRampToValueAtTime( position.y, endTime );
-					listener.positionZ.linearRampToValueAtTime( position.z, endTime );
-					listener.forwardX.linearRampToValueAtTime( orientation.x, endTime );
-					listener.forwardY.linearRampToValueAtTime( orientation.y, endTime );
-					listener.forwardZ.linearRampToValueAtTime( orientation.z, endTime );
-					listener.upX.linearRampToValueAtTime( up.x, endTime );
-					listener.upY.linearRampToValueAtTime( up.y, endTime );
-					listener.upZ.linearRampToValueAtTime( up.z, endTime );
+			}
 
-				} else {
-
-					listener.setPosition( position.x, position.y, position.z );
-					listener.setOrientation( orientation.x, orientation.y, orientation.z, up.x, up.y, up.z );
-
-				}
-
-			};
-
-		} )()
+		}
 
 	} );
 
@@ -41338,12 +42441,17 @@ var Spacekit = (function (exports) {
 		this.buffer = null;
 		this.detune = 0;
 		this.loop = false;
-		this.startTime = 0;
+		this.loopStart = 0;
+		this.loopEnd = 0;
 		this.offset = 0;
+		this.duration = undefined;
 		this.playbackRate = 1;
 		this.isPlaying = false;
 		this.hasPlaybackControl = true;
 		this.sourceType = 'empty';
+
+		this._startedAt = 0;
+		this._progress = 0;
 
 		this.filters = [];
 
@@ -41381,6 +42489,17 @@ var Spacekit = (function (exports) {
 
 		},
 
+		setMediaStreamSource: function ( mediaStream ) {
+
+			this.hasPlaybackControl = false;
+			this.sourceType = 'mediaStreamNode';
+			this.source = this.context.createMediaStreamSource( mediaStream );
+			this.connect();
+
+			return this;
+
+		},
+
 		setBuffer: function ( audioBuffer ) {
 
 			this.buffer = audioBuffer;
@@ -41392,7 +42511,9 @@ var Spacekit = (function (exports) {
 
 		},
 
-		play: function () {
+		play: function ( delay ) {
+
+			if ( delay === undefined ) delay = 0;
 
 			if ( this.isPlaying === true ) {
 
@@ -41408,13 +42529,15 @@ var Spacekit = (function (exports) {
 
 			}
 
-			var source = this.context.createBufferSource();
+			this._startedAt = this.context.currentTime + delay;
 
+			var source = this.context.createBufferSource();
 			source.buffer = this.buffer;
 			source.loop = this.loop;
+			source.loopStart = this.loopStart;
+			source.loopEnd = this.loopEnd;
 			source.onended = this.onEnded.bind( this );
-			this.startTime = this.context.currentTime;
-			source.start( this.startTime, this.offset );
+			source.start( this._startedAt, this._progress + this.offset, this.duration );
 
 			this.isPlaying = true;
 
@@ -41438,9 +42561,21 @@ var Spacekit = (function (exports) {
 
 			if ( this.isPlaying === true ) {
 
+				// update current progress
+
+				this._progress += Math.max( this.context.currentTime - this._startedAt, 0 ) * this.playbackRate;
+
+				if ( this.loop === true ) {
+
+					// ensure _progress does not exceed duration with looped audios
+
+					this._progress = this._progress % ( this.duration || this.buffer.duration );
+
+				}
+
 				this.source.stop();
 				this.source.onended = null;
-				this.offset += ( this.context.currentTime - this.startTime ) * this.playbackRate;
+
 				this.isPlaying = false;
 
 			}
@@ -41458,9 +42593,10 @@ var Spacekit = (function (exports) {
 
 			}
 
+			this._progress = 0;
+
 			this.source.stop();
 			this.source.onended = null;
-			this.offset = 0;
 			this.isPlaying = false;
 
 			return this;
@@ -41642,6 +42778,22 @@ var Spacekit = (function (exports) {
 
 		},
 
+		setLoopStart: function ( value ) {
+
+			this.loopStart = value;
+
+			return this;
+
+		},
+
+		setLoopEnd: function ( value ) {
+
+			this.loopEnd = value;
+
+			return this;
+
+		},
+
 		getVolume: function () {
 
 			return this.gain.gain.value;
@@ -41661,6 +42813,11 @@ var Spacekit = (function (exports) {
 	/**
 	 * @author mrdoob / http://mrdoob.com/
 	 */
+
+	var _position$3 = new Vector3();
+	var _quaternion$4 = new Quaternion();
+	var _scale$2 = new Vector3();
+	var _orientation$1 = new Vector3();
 
 	function PositionalAudio( listener ) {
 
@@ -41748,50 +42905,39 @@ var Spacekit = (function (exports) {
 
 		},
 
-		updateMatrixWorld: ( function () {
+		updateMatrixWorld: function ( force ) {
 
-			var position = new Vector3();
-			var quaternion = new Quaternion();
-			var scale = new Vector3();
+			Object3D.prototype.updateMatrixWorld.call( this, force );
 
-			var orientation = new Vector3();
+			if ( this.hasPlaybackControl === true && this.isPlaying === false ) return;
 
-			return function updateMatrixWorld( force ) {
+			this.matrixWorld.decompose( _position$3, _quaternion$4, _scale$2 );
 
-				Object3D.prototype.updateMatrixWorld.call( this, force );
+			_orientation$1.set( 0, 0, 1 ).applyQuaternion( _quaternion$4 );
 
-				if ( this.hasPlaybackControl === true && this.isPlaying === false ) return;
+			var panner = this.panner;
 
-				this.matrixWorld.decompose( position, quaternion, scale );
+			if ( panner.positionX ) {
 
-				orientation.set( 0, 0, 1 ).applyQuaternion( quaternion );
+				// code path for Chrome and Firefox (see #14393)
 
-				var panner = this.panner;
+				var endTime = this.context.currentTime + this.listener.timeDelta;
 
-				if ( panner.positionX ) {
+				panner.positionX.linearRampToValueAtTime( _position$3.x, endTime );
+				panner.positionY.linearRampToValueAtTime( _position$3.y, endTime );
+				panner.positionZ.linearRampToValueAtTime( _position$3.z, endTime );
+				panner.orientationX.linearRampToValueAtTime( _orientation$1.x, endTime );
+				panner.orientationY.linearRampToValueAtTime( _orientation$1.y, endTime );
+				panner.orientationZ.linearRampToValueAtTime( _orientation$1.z, endTime );
 
-					// code path for Chrome and Firefox (see #14393)
+			} else {
 
-					var endTime = this.context.currentTime + this.listener.timeDelta;
+				panner.setPosition( _position$3.x, _position$3.y, _position$3.z );
+				panner.setOrientation( _orientation$1.x, _orientation$1.y, _orientation$1.z );
 
-					panner.positionX.linearRampToValueAtTime( position.x, endTime );
-					panner.positionY.linearRampToValueAtTime( position.y, endTime );
-					panner.positionZ.linearRampToValueAtTime( position.z, endTime );
-					panner.orientationX.linearRampToValueAtTime( orientation.x, endTime );
-					panner.orientationY.linearRampToValueAtTime( orientation.y, endTime );
-					panner.orientationZ.linearRampToValueAtTime( orientation.z, endTime );
+			}
 
-				} else {
-
-					panner.setPosition( position.x, position.y, position.z );
-					panner.setOrientation( orientation.x, orientation.y, orientation.z );
-
-				}
-
-			};
-
-		} )()
-
+		}
 
 	} );
 
@@ -41851,28 +42997,11 @@ var Spacekit = (function (exports) {
 		this.binding = binding;
 		this.valueSize = valueSize;
 
-		var bufferType = Float64Array,
-			mixFunction;
+		var mixFunction,
+			mixFunctionAdditive,
+			setIdentity;
 
-		switch ( typeName ) {
-
-			case 'quaternion':
-				mixFunction = this._slerp;
-				break;
-
-			case 'string':
-			case 'bool':
-				bufferType = Array;
-				mixFunction = this._select;
-				break;
-
-			default:
-				mixFunction = this._lerp;
-
-		}
-
-		this.buffer = new bufferType( valueSize * 4 );
-		// layout: [ incoming | accu0 | accu1 | orig ]
+		// buffer layout: [ incoming | accu0 | accu1 | orig | addAccu | (optional work) ]
 		//
 		// interpolators can use .buffer as their .result
 		// the data then goes to 'incoming'
@@ -41882,10 +43011,53 @@ var Spacekit = (function (exports) {
 		// changes
 		//
 		// 'orig' stores the original state of the property
+		//
+		// 'add' is used for additive cumulative results
+		//
+		// 'work' is optional and is only present for quaternion types. It is used
+		// to store intermediate quaternion multiplication results
+
+		switch ( typeName ) {
+
+			case 'quaternion':
+				mixFunction = this._slerp;
+				mixFunctionAdditive = this._slerpAdditive;
+				setIdentity = this._setAdditiveIdentityQuaternion;
+
+				this.buffer = new Float64Array( valueSize * 6 );
+				this._workIndex = 5;
+				break;
+
+			case 'string':
+			case 'bool':
+				mixFunction = this._select;
+
+				// Use the regular mix function and for additive on these types,
+				// additive is not relevant for non-numeric types
+				mixFunctionAdditive = this._select;
+
+				setIdentity = this._setAdditiveIdentityOther;
+
+				this.buffer = new Array( valueSize * 5 );
+				break;
+
+			default:
+				mixFunction = this._lerp;
+				mixFunctionAdditive = this._lerpAdditive;
+				setIdentity = this._setAdditiveIdentityNumeric;
+
+				this.buffer = new Float64Array( valueSize * 5 );
+
+		}
 
 		this._mixBufferRegion = mixFunction;
+		this._mixBufferRegionAdditive = mixFunctionAdditive;
+		this._setIdentity = setIdentity;
+		this._origIndex = 3;
+		this._addIndex = 4;
 
 		this.cumulativeWeight = 0;
+		this.cumulativeWeightAdditive = 0;
 
 		this.useCount = 0;
 		this.referenceCount = 0;
@@ -41932,6 +43104,28 @@ var Spacekit = (function (exports) {
 
 		},
 
+		// accumulate data in the 'incoming' region into 'add'
+		accumulateAdditive: function ( weight ) {
+
+			var buffer = this.buffer,
+				stride = this.valueSize,
+				offset = stride * this._addIndex;
+
+			if ( this.cumulativeWeightAdditive === 0 ) {
+
+				// add = identity
+
+				this._setIdentity();
+
+			}
+
+			// add := add + incoming * weight
+
+			this._mixBufferRegionAdditive( buffer, offset, 0, weight, stride );
+			this.cumulativeWeightAdditive += weight;
+
+		},
+
 		// apply the state of 'accu<i>' to the binding when accus differ
 		apply: function ( accuIndex ) {
 
@@ -41940,19 +43134,29 @@ var Spacekit = (function (exports) {
 				offset = accuIndex * stride + stride,
 
 				weight = this.cumulativeWeight,
+				weightAdditive = this.cumulativeWeightAdditive,
 
 				binding = this.binding;
 
 			this.cumulativeWeight = 0;
+			this.cumulativeWeightAdditive = 0;
 
 			if ( weight < 1 ) {
 
 				// accuN := accuN + original * ( 1 - cumulativeWeight )
 
-				var originalValueOffset = stride * 3;
+				var originalValueOffset = stride * this._origIndex;
 
 				this._mixBufferRegion(
 					buffer, offset, originalValueOffset, 1 - weight, stride );
+
+			}
+
+			if ( weightAdditive > 0 ) {
+
+				// accuN := accuN + additive accuN
+
+				this._mixBufferRegionAdditive( buffer, offset, this._addIndex * stride, 1, stride );
 
 			}
 
@@ -41979,7 +43183,7 @@ var Spacekit = (function (exports) {
 			var buffer = this.buffer,
 				stride = this.valueSize,
 
-				originalValueOffset = stride * 3;
+				originalValueOffset = stride * this._origIndex;
 
 			binding.getValue( buffer, originalValueOffset );
 
@@ -41990,7 +43194,11 @@ var Spacekit = (function (exports) {
 
 			}
 
+			// Add to identity for additive
+			this._setIdentity();
+
 			this.cumulativeWeight = 0;
+			this.cumulativeWeightAdditive = 0;
 
 		},
 
@@ -41999,6 +43207,30 @@ var Spacekit = (function (exports) {
 
 			var originalValueOffset = this.valueSize * 3;
 			this.binding.setValue( this.buffer, originalValueOffset );
+
+		},
+
+		_setAdditiveIdentityNumeric: function () {
+
+			var startIndex = this._addIndex * this.valueSize;
+
+			this.buffer.fill( 0, startIndex, startIndex + this.valueSize );
+
+		},
+
+		_setAdditiveIdentityQuaternion: function () {
+
+			this._setAdditiveIdentityNumeric();
+			this.buffer[ this._addIndex * 4 + 3 ] = 1;
+
+		},
+
+		_setAdditiveIdentityOther: function () {
+
+			var startIndex = this._origIndex * this.valueSize;
+			var targetIndex = this._addIndex * this.valueSize;
+
+			this.buffer.copyWithin( targetIndex, startIndex, this.valueSize );
 
 		},
 
@@ -42025,6 +43257,18 @@ var Spacekit = (function (exports) {
 
 		},
 
+		_slerpAdditive: function ( buffer, dstOffset, srcOffset, t, stride ) {
+
+			var workOffset = this._workIndex * stride;
+
+			// Store result in intermediate buffer offset
+			Quaternion.multiplyQuaternionsFlat( buffer, workOffset, buffer, dstOffset, buffer, srcOffset );
+
+			// Slerp to the intermediate result
+			Quaternion.slerpFlat( buffer, dstOffset, buffer, dstOffset, buffer, workOffset, t );
+
+		},
+
 		_lerp: function ( buffer, dstOffset, srcOffset, t, stride ) {
 
 			var s = 1 - t;
@@ -42034,6 +43278,18 @@ var Spacekit = (function (exports) {
 				var j = dstOffset + i;
 
 				buffer[ j ] = buffer[ j ] * s + buffer[ srcOffset + i ] * t;
+
+			}
+
+		},
+
+		_lerpAdditive: function ( buffer, dstOffset, srcOffset, t, stride ) {
+
+			for ( var i = 0; i !== stride; ++ i ) {
+
+				var j = dstOffset + i;
+
+				buffer[ j ] = buffer[ j ] + buffer[ srcOffset + i ] * t;
 
 			}
 
@@ -42052,7 +43308,40 @@ var Spacekit = (function (exports) {
 	 */
 
 	// Characters [].:/ are reserved for track binding syntax.
-	var RESERVED_CHARS_RE = '\\[\\]\\.:\\/';
+	var _RESERVED_CHARS_RE = '\\[\\]\\.:\\/';
+	var _reservedRe = new RegExp( '[' + _RESERVED_CHARS_RE + ']', 'g' );
+
+	// Attempts to allow node names from any language. ES5's `\w` regexp matches
+	// only latin characters, and the unicode \p{L} is not yet supported. So
+	// instead, we exclude reserved characters and match everything else.
+	var _wordChar = '[^' + _RESERVED_CHARS_RE + ']';
+	var _wordCharOrDot = '[^' + _RESERVED_CHARS_RE.replace( '\\.', '' ) + ']';
+
+	// Parent directories, delimited by '/' or ':'. Currently unused, but must
+	// be matched to parse the rest of the track name.
+	var _directoryRe = /((?:WC+[\/:])*)/.source.replace( 'WC', _wordChar );
+
+	// Target node. May contain word characters (a-zA-Z0-9_) and '.' or '-'.
+	var _nodeRe = /(WCOD+)?/.source.replace( 'WCOD', _wordCharOrDot );
+
+	// Object on target node, and accessor. May not contain reserved
+	// characters. Accessor may contain any character except closing bracket.
+	var _objectRe = /(?:\.(WC+)(?:\[(.+)\])?)?/.source.replace( 'WC', _wordChar );
+
+	// Property and accessor. May not contain reserved characters. Accessor may
+	// contain any non-bracket characters.
+	var _propertyRe = /\.(WC+)(?:\[(.+)\])?/.source.replace( 'WC', _wordChar );
+
+	var _trackRe = new RegExp( ''
+		+ '^'
+		+ _directoryRe
+		+ _nodeRe
+		+ _objectRe
+		+ _propertyRe
+		+ '$'
+	);
+
+	var _supportedObjectNames = [ 'material', 'materials', 'bones' ];
 
 	function Composite( targetGroup, path, optionalParsedPath ) {
 
@@ -42152,105 +43441,63 @@ var Spacekit = (function (exports) {
 		 * @param {string} name Node name to be sanitized.
 		 * @return {string}
 		 */
-		sanitizeNodeName: ( function () {
+		sanitizeNodeName: function ( name ) {
 
-			var reservedRe = new RegExp( '[' + RESERVED_CHARS_RE + ']', 'g' );
+			return name.replace( /\s/g, '_' ).replace( _reservedRe, '' );
 
-			return function sanitizeNodeName( name ) {
+		},
 
-				return name.replace( /\s/g, '_' ).replace( reservedRe, '' );
+		parseTrackName: function ( trackName ) {
 
+			var matches = _trackRe.exec( trackName );
+
+			if ( ! matches ) {
+
+				throw new Error( 'PropertyBinding: Cannot parse trackName: ' + trackName );
+
+			}
+
+			var results = {
+				// directoryName: matches[ 1 ], // (tschw) currently unused
+				nodeName: matches[ 2 ],
+				objectName: matches[ 3 ],
+				objectIndex: matches[ 4 ],
+				propertyName: matches[ 5 ], // required
+				propertyIndex: matches[ 6 ]
 			};
 
-		}() ),
+			var lastDot = results.nodeName && results.nodeName.lastIndexOf( '.' );
 
-		parseTrackName: function () {
+			if ( lastDot !== undefined && lastDot !== - 1 ) {
 
-			// Attempts to allow node names from any language. ES5's `\w` regexp matches
-			// only latin characters, and the unicode \p{L} is not yet supported. So
-			// instead, we exclude reserved characters and match everything else.
-			var wordChar = '[^' + RESERVED_CHARS_RE + ']';
-			var wordCharOrDot = '[^' + RESERVED_CHARS_RE.replace( '\\.', '' ) + ']';
+				var objectName = results.nodeName.substring( lastDot + 1 );
 
-			// Parent directories, delimited by '/' or ':'. Currently unused, but must
-			// be matched to parse the rest of the track name.
-			var directoryRe = /((?:WC+[\/:])*)/.source.replace( 'WC', wordChar );
+				// Object names must be checked against a whitelist. Otherwise, there
+				// is no way to parse 'foo.bar.baz': 'baz' must be a property, but
+				// 'bar' could be the objectName, or part of a nodeName (which can
+				// include '.' characters).
+				if ( _supportedObjectNames.indexOf( objectName ) !== - 1 ) {
 
-			// Target node. May contain word characters (a-zA-Z0-9_) and '.' or '-'.
-			var nodeRe = /(WCOD+)?/.source.replace( 'WCOD', wordCharOrDot );
-
-			// Object on target node, and accessor. May not contain reserved
-			// characters. Accessor may contain any character except closing bracket.
-			var objectRe = /(?:\.(WC+)(?:\[(.+)\])?)?/.source.replace( 'WC', wordChar );
-
-			// Property and accessor. May not contain reserved characters. Accessor may
-			// contain any non-bracket characters.
-			var propertyRe = /\.(WC+)(?:\[(.+)\])?/.source.replace( 'WC', wordChar );
-
-			var trackRe = new RegExp( ''
-				+ '^'
-				+ directoryRe
-				+ nodeRe
-				+ objectRe
-				+ propertyRe
-				+ '$'
-			);
-
-			var supportedObjectNames = [ 'material', 'materials', 'bones' ];
-
-			return function parseTrackName( trackName ) {
-
-				var matches = trackRe.exec( trackName );
-
-				if ( ! matches ) {
-
-					throw new Error( 'PropertyBinding: Cannot parse trackName: ' + trackName );
+					results.nodeName = results.nodeName.substring( 0, lastDot );
+					results.objectName = objectName;
 
 				}
 
-				var results = {
-					// directoryName: matches[ 1 ], // (tschw) currently unused
-					nodeName: matches[ 2 ],
-					objectName: matches[ 3 ],
-					objectIndex: matches[ 4 ],
-					propertyName: matches[ 5 ], // required
-					propertyIndex: matches[ 6 ]
-				};
+			}
 
-				var lastDot = results.nodeName && results.nodeName.lastIndexOf( '.' );
+			if ( results.propertyName === null || results.propertyName.length === 0 ) {
 
-				if ( lastDot !== undefined && lastDot !== - 1 ) {
+				throw new Error( 'PropertyBinding: can not parse propertyName from trackName: ' + trackName );
 
-					var objectName = results.nodeName.substring( lastDot + 1 );
+			}
 
-					// Object names must be checked against a whitelist. Otherwise, there
-					// is no way to parse 'foo.bar.baz': 'baz' must be a property, but
-					// 'bar' could be the objectName, or part of a nodeName (which can
-					// include '.' characters).
-					if ( supportedObjectNames.indexOf( objectName ) !== - 1 ) {
+			return results;
 
-						results.nodeName = results.nodeName.substring( 0, lastDot );
-						results.objectName = objectName;
-
-					}
-
-				}
-
-				if ( results.propertyName === null || results.propertyName.length === 0 ) {
-
-					throw new Error( 'PropertyBinding: can not parse propertyName from trackName: ' + trackName );
-
-				}
-
-				return results;
-
-			};
-
-		}(),
+		},
 
 		findNode: function ( root, nodeName ) {
 
-			if ( ! nodeName || nodeName === "" || nodeName === "root" || nodeName === "." || nodeName === - 1 || nodeName === root.name || nodeName === root.uuid ) {
+			if ( ! nodeName || nodeName === "" || nodeName === "." || nodeName === - 1 || nodeName === root.name || nodeName === root.uuid ) {
 
 				return root;
 
@@ -42754,7 +44001,7 @@ var Spacekit = (function (exports) {
 
 	} );
 
-	//!\ DECLARE ALIAS AFTER assign prototype !
+	// DECLARE ALIAS AFTER assign prototype
 	Object.assign( PropertyBinding.prototype, {
 
 		// initial state of these methods that calls 'bind'
@@ -42796,7 +44043,7 @@ var Spacekit = (function (exports) {
 
 	function AnimationObjectGroup() {
 
-		this.uuid = _Math.generateUUID();
+		this.uuid = MathUtils.generateUUID();
 
 		// cached objects followed by the active ones
 		this._objects = Array.prototype.slice.call( arguments );
@@ -43150,11 +44397,12 @@ var Spacekit = (function (exports) {
 	 *
 	 */
 
-	function AnimationAction( mixer, clip, localRoot ) {
+	function AnimationAction( mixer, clip, localRoot, blendMode ) {
 
 		this._mixer = mixer;
 		this._clip = clip;
 		this._localRoot = localRoot || null;
+		this.blendMode = blendMode || clip.blendMode;
 
 		var tracks = clip.tracks,
 			nTracks = tracks.length,
@@ -43513,10 +44761,28 @@ var Spacekit = (function (exports) {
 				var interpolants = this._interpolants;
 				var propertyMixers = this._propertyBindings;
 
-				for ( var j = 0, m = interpolants.length; j !== m; ++ j ) {
+				switch ( this.blendMode ) {
 
-					interpolants[ j ].evaluate( clipTime );
-					propertyMixers[ j ].accumulate( accuIndex, weight );
+					case AdditiveAnimationBlendMode:
+
+						for ( var j = 0, m = interpolants.length; j !== m; ++ j ) {
+
+							interpolants[ j ].evaluate( clipTime );
+							propertyMixers[ j ].accumulateAdditive( weight );
+
+						}
+
+						break;
+
+					case NormalAnimationBlendMode:
+					default:
+
+						for ( var j = 0, m = interpolants.length; j !== m; ++ j ) {
+
+							interpolants[ j ].evaluate( clipTime );
+							propertyMixers[ j ].accumulate( accuIndex, weight );
+
+						}
 
 				}
 
@@ -44334,7 +45600,7 @@ var Spacekit = (function (exports) {
 		// return an action for a clip optionally using a custom root target
 		// object (this method allocates a lot of dynamic memory in case a
 		// previously unknown clip/root combination is specified)
-		clipAction: function ( clip, optionalRoot ) {
+		clipAction: function ( clip, optionalRoot, blendMode ) {
 
 			var root = optionalRoot || this._root,
 				rootUuid = root.uuid,
@@ -44347,12 +45613,26 @@ var Spacekit = (function (exports) {
 				actionsForClip = this._actionsByClip[ clipUuid ],
 				prototypeAction = null;
 
+			if ( blendMode === undefined ) {
+
+				if ( clipObject !== null ) {
+
+					blendMode = clipObject.blendMode;
+
+				} else {
+
+					blendMode = NormalAnimationBlendMode;
+
+				}
+
+			}
+
 			if ( actionsForClip !== undefined ) {
 
 				var existingAction =
 						actionsForClip.actionByRoot[ rootUuid ];
 
-				if ( existingAction !== undefined ) {
+				if ( existingAction !== undefined && existingAction.blendMode === blendMode ) {
 
 					return existingAction;
 
@@ -44372,7 +45652,7 @@ var Spacekit = (function (exports) {
 			if ( clipObject === null ) return null;
 
 			// allocate all resources required to run it
-			var newAction = new AnimationAction( this, clipObject, optionalRoot );
+			var newAction = new AnimationAction( this, clipObject, optionalRoot, blendMode );
 
 			this._bindAction( newAction, prototypeAction );
 
@@ -44468,6 +45748,20 @@ var Spacekit = (function (exports) {
 			}
 
 			return this;
+
+		},
+
+		// Allows you to seek to a specific time in an animation.
+		setTime: function ( timeInSeconds ) {
+
+			this.time = 0; // Zero out time attribute for AnimationMixer object;
+			for ( var i = 0; i < this._actions.length; i ++ ) {
+
+				this._actions[ i ].time = 0; // Zero out time attribute for all associated AnimationAction objects.
+
+			}
+
+			return this.update( timeInSeconds ); // Update used to set exact time. Returns "this" AnimationMixer object.
 
 		},
 
@@ -44639,10 +45933,12 @@ var Spacekit = (function (exports) {
 
 		this.near = near || 0;
 		this.far = far || Infinity;
+		this.camera = null;
+		this.layers = new Layers();
 
 		this.params = {
 			Mesh: {},
-			Line: {},
+			Line: { threshold: 1 },
 			LOD: {},
 			Points: { threshold: 1 },
 			Sprite: {}
@@ -44669,9 +45965,11 @@ var Spacekit = (function (exports) {
 
 	function intersectObject( object, raycaster, intersects, recursive ) {
 
-		if ( object.visible === false ) return;
+		if ( object.layers.test( raycaster.layers ) ) {
 
-		object.raycast( raycaster, intersects );
+			object.raycast( raycaster, intersects );
+
+		}
 
 		if ( recursive === true ) {
 
@@ -44689,8 +45987,6 @@ var Spacekit = (function (exports) {
 
 	Object.assign( Raycaster.prototype, {
 
-		linePrecision: 1,
-
 		set: function ( origin, direction ) {
 
 			// direction is assumed to be normalized (for accurate distance calculations)
@@ -44705,13 +46001,13 @@ var Spacekit = (function (exports) {
 
 				this.ray.origin.setFromMatrixPosition( camera.matrixWorld );
 				this.ray.direction.set( coords.x, coords.y, 0.5 ).unproject( camera ).sub( this.ray.origin ).normalize();
-				this._camera = camera;
+				this.camera = camera;
 
 			} else if ( ( camera && camera.isOrthographicCamera ) ) {
 
 				this.ray.origin.set( coords.x, coords.y, ( camera.near + camera.far ) / ( camera.near - camera.far ) ).unproject( camera ); // set origin in plane of camera
 				this.ray.direction.set( 0, 0, - 1 ).transformDirection( camera.matrixWorld );
-				this._camera = camera;
+				this.camera = camera;
 
 			} else {
 
@@ -44765,7 +46061,7 @@ var Spacekit = (function (exports) {
 	 * Ref: https://en.wikipedia.org/wiki/Spherical_coordinate_system
 	 *
 	 * The polar angle (phi) is measured from the positive y-axis. The positive y-axis is up.
-	 * The azimuthal angle (theta) is measured from the positive z-axiz.
+	 * The azimuthal angle (theta) is measured from the positive z-axis.
 	 */
 
 	function Spherical( radius, phi, theta ) {
@@ -44834,7 +46130,7 @@ var Spacekit = (function (exports) {
 			} else {
 
 				this.theta = Math.atan2( x, z );
-				this.phi = Math.acos( _Math.clamp( y / this.radius, - 1, 1 ) );
+				this.phi = Math.acos( MathUtils.clamp( y / this.radius, - 1, 1 ) );
 
 			}
 
@@ -44911,6 +46207,8 @@ var Spacekit = (function (exports) {
 	 * @author bhouston / http://clara.io
 	 */
 
+	var _vector$7 = new Vector2();
+
 	function Box2( min, max ) {
 
 		this.min = ( min !== undefined ) ? min : new Vector2( + Infinity, + Infinity );
@@ -44943,21 +46241,15 @@ var Spacekit = (function (exports) {
 
 		},
 
-		setFromCenterAndSize: function () {
+		setFromCenterAndSize: function ( center, size ) {
 
-			var v1 = new Vector2();
+			var halfSize = _vector$7.copy( size ).multiplyScalar( 0.5 );
+			this.min.copy( center ).sub( halfSize );
+			this.max.copy( center ).add( halfSize );
 
-			return function setFromCenterAndSize( center, size ) {
+			return this;
 
-				var halfSize = v1.copy( size ).multiplyScalar( 0.5 );
-				this.min.copy( center ).sub( halfSize );
-				this.max.copy( center ).add( halfSize );
-
-				return this;
-
-			};
-
-		}(),
+		},
 
 		clone: function () {
 
@@ -45099,18 +46391,12 @@ var Spacekit = (function (exports) {
 
 		},
 
-		distanceToPoint: function () {
+		distanceToPoint: function ( point ) {
 
-			var v1 = new Vector2();
+			var clampedPoint = _vector$7.copy( point ).clamp( this.min, this.max );
+			return clampedPoint.sub( point ).length();
 
-			return function distanceToPoint( point ) {
-
-				var clampedPoint = v1.copy( point ).clamp( this.min, this.max );
-				return clampedPoint.sub( point ).length();
-
-			};
-
-		}(),
+		},
 
 		intersect: function ( box ) {
 
@@ -45151,7 +46437,8 @@ var Spacekit = (function (exports) {
 	 * @author bhouston / http://clara.io
 	 */
 
-	var _startP, _startEnd;
+	var _startP = new Vector3();
+	var _startEnd = new Vector3();
 
 	function Line3( start, end ) {
 
@@ -45239,13 +46526,6 @@ var Spacekit = (function (exports) {
 
 		closestPointToPointParameter: function ( point, clampToLine ) {
 
-			if ( _startP === undefined ) {
-
-				_startP = new Vector3();
-				_startEnd = new Vector3();
-
-			}
-
 			_startP.subVectors( point, this.start );
 			_startEnd.subVectors( this.end, this.start );
 
@@ -45256,7 +46536,7 @@ var Spacekit = (function (exports) {
 
 			if ( clampToLine ) {
 
-				t = _Math.clamp( t, 0, 1 );
+				t = MathUtils.clamp( t, 0, 1 );
 
 			}
 
@@ -45315,154 +46595,12 @@ var Spacekit = (function (exports) {
 	ImmediateRenderObject.prototype.isImmediateRenderObject = true;
 
 	/**
-	 * @author mrdoob / http://mrdoob.com/
-	 * @author WestLangley / http://github.com/WestLangley
-	 */
-
-	function VertexNormalsHelper( object, size, hex, linewidth ) {
-
-		this.object = object;
-
-		this.size = ( size !== undefined ) ? size : 1;
-
-		var color = ( hex !== undefined ) ? hex : 0xff0000;
-
-		var width = ( linewidth !== undefined ) ? linewidth : 1;
-
-		//
-
-		var nNormals = 0;
-
-		var objGeometry = this.object.geometry;
-
-		if ( objGeometry && objGeometry.isGeometry ) {
-
-			nNormals = objGeometry.faces.length * 3;
-
-		} else if ( objGeometry && objGeometry.isBufferGeometry ) {
-
-			nNormals = objGeometry.attributes.normal.count;
-
-		}
-
-		//
-
-		var geometry = new BufferGeometry();
-
-		var positions = new Float32BufferAttribute( nNormals * 2 * 3, 3 );
-
-		geometry.addAttribute( 'position', positions );
-
-		LineSegments.call( this, geometry, new LineBasicMaterial( { color: color, linewidth: width } ) );
-
-		//
-
-		this.matrixAutoUpdate = false;
-
-		this.update();
-
-	}
-
-	VertexNormalsHelper.prototype = Object.create( LineSegments.prototype );
-	VertexNormalsHelper.prototype.constructor = VertexNormalsHelper;
-
-	VertexNormalsHelper.prototype.update = ( function () {
-
-		var v1 = new Vector3();
-		var v2 = new Vector3();
-		var normalMatrix = new Matrix3();
-
-		return function update() {
-
-			var keys = [ 'a', 'b', 'c' ];
-
-			this.object.updateMatrixWorld( true );
-
-			normalMatrix.getNormalMatrix( this.object.matrixWorld );
-
-			var matrixWorld = this.object.matrixWorld;
-
-			var position = this.geometry.attributes.position;
-
-			//
-
-			var objGeometry = this.object.geometry;
-
-			if ( objGeometry && objGeometry.isGeometry ) {
-
-				var vertices = objGeometry.vertices;
-
-				var faces = objGeometry.faces;
-
-				var idx = 0;
-
-				for ( var i = 0, l = faces.length; i < l; i ++ ) {
-
-					var face = faces[ i ];
-
-					for ( var j = 0, jl = face.vertexNormals.length; j < jl; j ++ ) {
-
-						var vertex = vertices[ face[ keys[ j ] ] ];
-
-						var normal = face.vertexNormals[ j ];
-
-						v1.copy( vertex ).applyMatrix4( matrixWorld );
-
-						v2.copy( normal ).applyMatrix3( normalMatrix ).normalize().multiplyScalar( this.size ).add( v1 );
-
-						position.setXYZ( idx, v1.x, v1.y, v1.z );
-
-						idx = idx + 1;
-
-						position.setXYZ( idx, v2.x, v2.y, v2.z );
-
-						idx = idx + 1;
-
-					}
-
-				}
-
-			} else if ( objGeometry && objGeometry.isBufferGeometry ) {
-
-				var objPos = objGeometry.attributes.position;
-
-				var objNorm = objGeometry.attributes.normal;
-
-				var idx = 0;
-
-				// for simplicity, ignore index and drawcalls, and render every normal
-
-				for ( var j = 0, jl = objPos.count; j < jl; j ++ ) {
-
-					v1.set( objPos.getX( j ), objPos.getY( j ), objPos.getZ( j ) ).applyMatrix4( matrixWorld );
-
-					v2.set( objNorm.getX( j ), objNorm.getY( j ), objNorm.getZ( j ) );
-
-					v2.applyMatrix3( normalMatrix ).normalize().multiplyScalar( this.size ).add( v1 );
-
-					position.setXYZ( idx, v1.x, v1.y, v1.z );
-
-					idx = idx + 1;
-
-					position.setXYZ( idx, v2.x, v2.y, v2.z );
-
-					idx = idx + 1;
-
-				}
-
-			}
-
-			position.needsUpdate = true;
-
-		};
-
-	}() );
-
-	/**
 	 * @author alteredq / http://alteredqualia.com/
 	 * @author mrdoob / http://mrdoob.com/
 	 * @author WestLangley / http://github.com/WestLangley
 	 */
+
+	var _vector$8 = new Vector3();
 
 	function SpotLightHelper( light, color ) {
 
@@ -45498,9 +46636,9 @@ var Spacekit = (function (exports) {
 
 		}
 
-		geometry.addAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
+		geometry.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
 
-		var material = new LineBasicMaterial( { fog: false } );
+		var material = new LineBasicMaterial( { fog: false, toneMapped: false } );
 
 		this.cone = new LineSegments( geometry, material );
 		this.add( this.cone );
@@ -45521,34 +46659,28 @@ var Spacekit = (function (exports) {
 
 	SpotLightHelper.prototype.update = function () {
 
-		var vector = new Vector3();
+		this.light.updateMatrixWorld();
 
-		return function update() {
+		var coneLength = this.light.distance ? this.light.distance : 1000;
+		var coneWidth = coneLength * Math.tan( this.light.angle );
 
-			this.light.updateMatrixWorld();
+		this.cone.scale.set( coneWidth, coneWidth, coneLength );
 
-			var coneLength = this.light.distance ? this.light.distance : 1000;
-			var coneWidth = coneLength * Math.tan( this.light.angle );
+		_vector$8.setFromMatrixPosition( this.light.target.matrixWorld );
 
-			this.cone.scale.set( coneWidth, coneWidth, coneLength );
+		this.cone.lookAt( _vector$8 );
 
-			vector.setFromMatrixPosition( this.light.target.matrixWorld );
+		if ( this.color !== undefined ) {
 
-			this.cone.lookAt( vector );
+			this.cone.material.color.set( this.color );
 
-			if ( this.color !== undefined ) {
+		} else {
 
-				this.cone.material.color.set( this.color );
+			this.cone.material.color.copy( this.light.color );
 
-			} else {
+		}
 
-				this.cone.material.color.copy( this.light.color );
-
-			}
-
-		};
-
-	}();
+	};
 
 	/**
 	 * @author Sean Griffin / http://twitter.com/sgrif
@@ -45557,6 +46689,10 @@ var Spacekit = (function (exports) {
 	 * @author ikerr / http://verold.com
 	 * @author Mugen87 / https://github.com/Mugen87
 	 */
+
+	var _vector$9 = new Vector3();
+	var _boneMatrix = new Matrix4();
+	var _matrixWorldInv = new Matrix4();
 
 	function getBoneList( object ) {
 
@@ -45605,12 +46741,14 @@ var Spacekit = (function (exports) {
 
 		}
 
-		geometry.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		geometry.addAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
+		geometry.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		geometry.setAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
 
-		var material = new LineBasicMaterial( { vertexColors: VertexColors, depthTest: false, depthWrite: false, transparent: true } );
+		var material = new LineBasicMaterial( { vertexColors: true, depthTest: false, depthWrite: false, toneMapped: false, transparent: true } );
 
 		LineSegments.call( this, geometry, material );
+
+		this.type = 'SkeletonHelper';
 
 		this.root = object;
 		this.bones = bones;
@@ -45623,49 +46761,42 @@ var Spacekit = (function (exports) {
 	SkeletonHelper.prototype = Object.create( LineSegments.prototype );
 	SkeletonHelper.prototype.constructor = SkeletonHelper;
 
-	SkeletonHelper.prototype.updateMatrixWorld = function () {
+	SkeletonHelper.prototype.isSkeletonHelper = true;
 
-		var vector = new Vector3();
+	SkeletonHelper.prototype.updateMatrixWorld = function ( force ) {
 
-		var boneMatrix = new Matrix4();
-		var matrixWorldInv = new Matrix4();
+		var bones = this.bones;
 
-		return function updateMatrixWorld( force ) {
+		var geometry = this.geometry;
+		var position = geometry.getAttribute( 'position' );
 
-			var bones = this.bones;
+		_matrixWorldInv.getInverse( this.root.matrixWorld );
 
-			var geometry = this.geometry;
-			var position = geometry.getAttribute( 'position' );
+		for ( var i = 0, j = 0; i < bones.length; i ++ ) {
 
-			matrixWorldInv.getInverse( this.root.matrixWorld );
+			var bone = bones[ i ];
 
-			for ( var i = 0, j = 0; i < bones.length; i ++ ) {
+			if ( bone.parent && bone.parent.isBone ) {
 
-				var bone = bones[ i ];
+				_boneMatrix.multiplyMatrices( _matrixWorldInv, bone.matrixWorld );
+				_vector$9.setFromMatrixPosition( _boneMatrix );
+				position.setXYZ( j, _vector$9.x, _vector$9.y, _vector$9.z );
 
-				if ( bone.parent && bone.parent.isBone ) {
+				_boneMatrix.multiplyMatrices( _matrixWorldInv, bone.parent.matrixWorld );
+				_vector$9.setFromMatrixPosition( _boneMatrix );
+				position.setXYZ( j + 1, _vector$9.x, _vector$9.y, _vector$9.z );
 
-					boneMatrix.multiplyMatrices( matrixWorldInv, bone.matrixWorld );
-					vector.setFromMatrixPosition( boneMatrix );
-					position.setXYZ( j, vector.x, vector.y, vector.z );
-
-					boneMatrix.multiplyMatrices( matrixWorldInv, bone.parent.matrixWorld );
-					vector.setFromMatrixPosition( boneMatrix );
-					position.setXYZ( j + 1, vector.x, vector.y, vector.z );
-
-					j += 2;
-
-				}
+				j += 2;
 
 			}
 
-			geometry.getAttribute( 'position' ).needsUpdate = true;
+		}
 
-			Object3D.prototype.updateMatrixWorld.call( this, force );
+		geometry.getAttribute( 'position' ).needsUpdate = true;
 
-		};
+		Object3D.prototype.updateMatrixWorld.call( this, force );
 
-	}();
+	};
 
 	/**
 	 * @author alteredq / http://alteredqualia.com/
@@ -45680,9 +46811,11 @@ var Spacekit = (function (exports) {
 		this.color = color;
 
 		var geometry = new SphereBufferGeometry( sphereSize, 4, 2 );
-		var material = new MeshBasicMaterial( { wireframe: true, fog: false } );
+		var material = new MeshBasicMaterial( { wireframe: true, fog: false, toneMapped: false } );
 
 		Mesh.call( this, geometry, material );
+
+		this.type = 'PointLightHelper';
 
 		this.matrix = this.light.matrixWorld;
 		this.matrixAutoUpdate = false;
@@ -45754,86 +46887,14 @@ var Spacekit = (function (exports) {
 	};
 
 	/**
-	 * @author abelnation / http://github.com/abelnation
-	 * @author Mugen87 / http://github.com/Mugen87
-	 * @author WestLangley / http://github.com/WestLangley
-	 *
-	 *  This helper must be added as a child of the light
-	 */
-
-	function RectAreaLightHelper( light, color ) {
-
-		this.type = 'RectAreaLightHelper';
-
-		this.light = light;
-
-		this.color = color; // optional hardwired color for the helper
-
-		var positions = [ 1, 1, 0, - 1, 1, 0, - 1, - 1, 0, 1, - 1, 0, 1, 1, 0 ];
-
-		var geometry = new BufferGeometry();
-		geometry.addAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
-		geometry.computeBoundingSphere();
-
-		var material = new LineBasicMaterial( { fog: false } );
-
-		Line.call( this, geometry, material );
-
-		//
-
-		var positions2 = [ 1, 1, 0, - 1, 1, 0, - 1, - 1, 0, 1, 1, 0, - 1, - 1, 0, 1, - 1, 0 ];
-
-		var geometry2 = new BufferGeometry();
-		geometry2.addAttribute( 'position', new Float32BufferAttribute( positions2, 3 ) );
-		geometry2.computeBoundingSphere();
-
-		this.add( new Mesh( geometry2, new MeshBasicMaterial( { side: BackSide, fog: false } ) ) );
-
-		this.update();
-
-	}
-
-	RectAreaLightHelper.prototype = Object.create( Line.prototype );
-	RectAreaLightHelper.prototype.constructor = RectAreaLightHelper;
-
-	RectAreaLightHelper.prototype.update = function () {
-
-		this.scale.set( 0.5 * this.light.width, 0.5 * this.light.height, 1 );
-
-		if ( this.color !== undefined ) {
-
-			this.material.color.set( this.color );
-			this.children[ 0 ].material.color.set( this.color );
-
-		} else {
-
-			this.material.color.copy( this.light.color ).multiplyScalar( this.light.intensity );
-
-			// prevent hue shift
-			var c = this.material.color;
-			var max = Math.max( c.r, c.g, c.b );
-			if ( max > 1 ) c.multiplyScalar( 1 / max );
-
-			this.children[ 0 ].material.color.copy( this.material.color );
-
-		}
-
-	};
-
-	RectAreaLightHelper.prototype.dispose = function () {
-
-		this.geometry.dispose();
-		this.material.dispose();
-		this.children[ 0 ].geometry.dispose();
-		this.children[ 0 ].material.dispose();
-
-	};
-
-	/**
 	 * @author alteredq / http://alteredqualia.com/
 	 * @author mrdoob / http://mrdoob.com/
 	 * @author Mugen87 / https://github.com/Mugen87
 	 */
+
+	var _vector$a = new Vector3();
+	var _color1 = new Color();
+	var _color2 = new Color();
 
 	function HemisphereLightHelper( light, size, color ) {
 
@@ -45850,13 +46911,13 @@ var Spacekit = (function (exports) {
 		var geometry = new OctahedronBufferGeometry( size );
 		geometry.rotateY( Math.PI * 0.5 );
 
-		this.material = new MeshBasicMaterial( { wireframe: true, fog: false } );
-		if ( this.color === undefined ) this.material.vertexColors = VertexColors;
+		this.material = new MeshBasicMaterial( { wireframe: true, fog: false, toneMapped: false } );
+		if ( this.color === undefined ) this.material.vertexColors = true;
 
 		var position = geometry.getAttribute( 'position' );
 		var colors = new Float32Array( position.count * 3 );
 
-		geometry.addAttribute( 'color', new BufferAttribute( colors, 3 ) );
+		geometry.setAttribute( 'color', new BufferAttribute( colors, 3 ) );
 
 		this.add( new Mesh( geometry, this.material ) );
 
@@ -45876,193 +46937,34 @@ var Spacekit = (function (exports) {
 
 	HemisphereLightHelper.prototype.update = function () {
 
-		var vector = new Vector3();
+		var mesh = this.children[ 0 ];
 
-		var color1 = new Color();
-		var color2 = new Color();
+		if ( this.color !== undefined ) {
 
-		return function update() {
+			this.material.color.set( this.color );
 
-			var mesh = this.children[ 0 ];
+		} else {
 
-			if ( this.color !== undefined ) {
+			var colors = mesh.geometry.getAttribute( 'color' );
 
-				this.material.color.set( this.color );
+			_color1.copy( this.light.color );
+			_color2.copy( this.light.groundColor );
 
-			} else {
+			for ( var i = 0, l = colors.count; i < l; i ++ ) {
 
-				var colors = mesh.geometry.getAttribute( 'color' );
+				var color = ( i < ( l / 2 ) ) ? _color1 : _color2;
 
-				color1.copy( this.light.color );
-				color2.copy( this.light.groundColor );
-
-				for ( var i = 0, l = colors.count; i < l; i ++ ) {
-
-					var color = ( i < ( l / 2 ) ) ? color1 : color2;
-
-					colors.setXYZ( i, color.r, color.g, color.b );
-
-				}
-
-				colors.needsUpdate = true;
+				colors.setXYZ( i, color.r, color.g, color.b );
 
 			}
 
-			mesh.lookAt( vector.setFromMatrixPosition( this.light.matrixWorld ).negate() );
+			colors.needsUpdate = true;
 
-		};
+		}
 
-	}();
-
-	/**
-	 * @author WestLangley / http://github.com/WestLangley
-	 */
-
-	function LightProbeHelper( lightProbe, size ) {
-
-		this.lightProbe = lightProbe;
-
-		this.size = size;
-
-		var defines = {};
-		defines[ 'GAMMA_OUTPUT' ] = "";
-
-		// material
-		var material = new ShaderMaterial( {
-
-			defines: defines,
-
-			uniforms: {
-
-				sh: { value: this.lightProbe.sh.coefficients }, // by reference
-
-				intensity: { value: this.lightProbe.intensity }
-
-			},
-
-			vertexShader: [
-
-				'varying vec3 vNormal;',
-
-				'void main() {',
-
-				'	vNormal = normalize( normalMatrix * normal );',
-
-				'	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );',
-
-				'}',
-
-			].join( '\n' ),
-
-			fragmentShader: [
-
-				'#define RECIPROCAL_PI 0.318309886',
-
-				'vec3 inverseTransformDirection( in vec3 normal, in mat4 matrix ) {',
-
-				'	// matrix is assumed to be orthogonal',
-
-				'	return normalize( ( vec4( normal, 0.0 ) * matrix ).xyz );',
-
-				'}',
-
-				'vec3 linearToOutput( in vec3 a ) {',
-
-				'	#ifdef GAMMA_OUTPUT',
-
-				'		return pow( a, vec3( 1.0 / float( GAMMA_FACTOR ) ) );',
-
-				'	#else',
-
-				'		return a;',
-
-				'	#endif',
-
-				'}',
-
-				'// source: https://graphics.stanford.edu/papers/envmap/envmap.pdf',
-				'vec3 shGetIrradianceAt( in vec3 normal, in vec3 shCoefficients[ 9 ] ) {',
-
-				'	// normal is assumed to have unit length',
-
-				'	float x = normal.x, y = normal.y, z = normal.z;',
-
-				'	// band 0',
-				'	vec3 result = shCoefficients[ 0 ] * 0.886227;',
-
-				'	// band 1',
-				'	result += shCoefficients[ 1 ] * 2.0 * 0.511664 * y;',
-				'	result += shCoefficients[ 2 ] * 2.0 * 0.511664 * z;',
-				'	result += shCoefficients[ 3 ] * 2.0 * 0.511664 * x;',
-
-				'	// band 2',
-				'	result += shCoefficients[ 4 ] * 2.0 * 0.429043 * x * y;',
-				'	result += shCoefficients[ 5 ] * 2.0 * 0.429043 * y * z;',
-				'	result += shCoefficients[ 6 ] * ( 0.743125 * z * z - 0.247708 );',
-				'	result += shCoefficients[ 7 ] * 2.0 * 0.429043 * x * z;',
-				'	result += shCoefficients[ 8 ] * 0.429043 * ( x * x - y * y );',
-
-				'	return result;',
-
-				'}',
-
-				'uniform vec3 sh[ 9 ]; // sh coefficients',
-
-				'uniform float intensity; // light probe intensity',
-
-				'varying vec3 vNormal;',
-
-				'void main() {',
-
-				'	vec3 normal = normalize( vNormal );',
-
-				'	vec3 worldNormal = inverseTransformDirection( normal, viewMatrix );',
-
-				'	vec3 irradiance = shGetIrradianceAt( worldNormal, sh );',
-
-				'	vec3 outgoingLight = RECIPROCAL_PI * irradiance * intensity;',
-
-				'	outgoingLight = linearToOutput( outgoingLight );',
-
-				'	gl_FragColor = vec4( outgoingLight, 1.0 );',
-
-				'}'
-
-			].join( '\n' )
-
-		} );
-
-		var geometry = new SphereBufferGeometry( 1, 32, 16 );
-
-		Mesh.call( this, geometry, material );
-
-		this.onBeforeRender();
-
-	}
-
-	LightProbeHelper.prototype = Object.create( Mesh.prototype );
-	LightProbeHelper.prototype.constructor = LightProbeHelper;
-
-	LightProbeHelper.prototype.dispose = function () {
-
-		this.geometry.dispose();
-		this.material.dispose();
+		mesh.lookAt( _vector$a.setFromMatrixPosition( this.light.matrixWorld ).negate() );
 
 	};
-
-	LightProbeHelper.prototype.onBeforeRender = function () {
-
-		return function update() {
-
-			this.position.copy( this.lightProbe.position );
-
-			this.scale.set( 1, 1, 1 ).multiplyScalar( this.size );
-
-			this.material.uniforms.intensity.value = this.lightProbe.intensity;
-
-		};
-
-	}();
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -46096,12 +46998,14 @@ var Spacekit = (function (exports) {
 		}
 
 		var geometry = new BufferGeometry();
-		geometry.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		geometry.addAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
+		geometry.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		geometry.setAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
 
-		var material = new LineBasicMaterial( { vertexColors: VertexColors } );
+		var material = new LineBasicMaterial( { vertexColors: true, toneMapped: false } );
 
 		LineSegments.call( this, geometry, material );
+
+		this.type = 'GridHelper';
 
 	}
 
@@ -46203,12 +47107,14 @@ var Spacekit = (function (exports) {
 		}
 
 		var geometry = new BufferGeometry();
-		geometry.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		geometry.addAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
+		geometry.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		geometry.setAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
 
-		var material = new LineBasicMaterial( { vertexColors: VertexColors } );
+		var material = new LineBasicMaterial( { vertexColors: true, toneMapped: false } );
 
 		LineSegments.call( this, geometry, material );
+
+		this.type = 'PolarGridHelper';
 
 	}
 
@@ -46216,219 +47122,14 @@ var Spacekit = (function (exports) {
 	PolarGridHelper.prototype.constructor = PolarGridHelper;
 
 	/**
-	 * @author Mugen87 / http://github.com/Mugen87
-	 */
-
-	function PositionalAudioHelper( audio, range, divisionsInnerAngle, divisionsOuterAngle ) {
-
-		this.audio = audio;
-		this.range = range || 1;
-		this.divisionsInnerAngle = divisionsInnerAngle || 16;
-		this.divisionsOuterAngle = divisionsOuterAngle || 2;
-
-		var geometry = new BufferGeometry();
-		var divisions = this.divisionsInnerAngle + this.divisionsOuterAngle * 2;
-		var positions = new Float32Array( ( divisions * 3 + 3 ) * 3 );
-		geometry.addAttribute( 'position', new BufferAttribute( positions, 3 ) );
-
-		var materialInnerAngle = new LineBasicMaterial( { color: 0x00ff00 } );
-		var materialOuterAngle = new LineBasicMaterial( { color: 0xffff00 } );
-
-		Line.call( this, geometry, [ materialOuterAngle, materialInnerAngle ] );
-
-		this.update();
-
-	}
-
-	PositionalAudioHelper.prototype = Object.create( Line.prototype );
-	PositionalAudioHelper.prototype.constructor = PositionalAudioHelper;
-
-	PositionalAudioHelper.prototype.update = function () {
-
-		var audio = this.audio;
-		var range = this.range;
-		var divisionsInnerAngle = this.divisionsInnerAngle;
-		var divisionsOuterAngle = this.divisionsOuterAngle;
-
-		var coneInnerAngle = _Math.degToRad( audio.panner.coneInnerAngle );
-		var coneOuterAngle = _Math.degToRad( audio.panner.coneOuterAngle );
-
-		var halfConeInnerAngle = coneInnerAngle / 2;
-		var halfConeOuterAngle = coneOuterAngle / 2;
-
-		var start = 0;
-		var count = 0;
-		var i, stride;
-
-		var geometry = this.geometry;
-		var positionAttribute = geometry.attributes.position;
-
-		geometry.clearGroups();
-
-		//
-
-		function generateSegment( from, to, divisions, materialIndex ) {
-
-			var step = ( to - from ) / divisions;
-
-			positionAttribute.setXYZ( start, 0, 0, 0 );
-			count ++;
-
-			for ( i = from; i < to; i += step ) {
-
-				stride = start + count;
-
-				positionAttribute.setXYZ( stride, Math.sin( i ) * range, 0, Math.cos( i ) * range );
-				positionAttribute.setXYZ( stride + 1, Math.sin( Math.min( i + step, to ) ) * range, 0, Math.cos( Math.min( i + step, to ) ) * range );
-				positionAttribute.setXYZ( stride + 2, 0, 0, 0 );
-
-				count += 3;
-
-			}
-
-			geometry.addGroup( start, count, materialIndex );
-
-			start += count;
-			count = 0;
-
-		}
-
-		//
-
-		generateSegment( - halfConeOuterAngle, - halfConeInnerAngle, divisionsOuterAngle, 0 );
-		generateSegment( - halfConeInnerAngle, halfConeInnerAngle, divisionsInnerAngle, 1 );
-		generateSegment( halfConeInnerAngle, halfConeOuterAngle, divisionsOuterAngle, 0 );
-
-		//
-
-		positionAttribute.needsUpdate = true;
-
-		if ( coneInnerAngle === coneOuterAngle ) this.material[ 0 ].visible = false;
-
-	};
-
-	PositionalAudioHelper.prototype.dispose = function () {
-
-		this.geometry.dispose();
-		this.material[ 0 ].dispose();
-		this.material[ 1 ].dispose();
-
-	};
-
-	/**
-	 * @author mrdoob / http://mrdoob.com/
-	 * @author WestLangley / http://github.com/WestLangley
-	 */
-
-	function FaceNormalsHelper( object, size, hex, linewidth ) {
-
-		// FaceNormalsHelper only supports THREE.Geometry
-
-		this.object = object;
-
-		this.size = ( size !== undefined ) ? size : 1;
-
-		var color = ( hex !== undefined ) ? hex : 0xffff00;
-
-		var width = ( linewidth !== undefined ) ? linewidth : 1;
-
-		//
-
-		var nNormals = 0;
-
-		var objGeometry = this.object.geometry;
-
-		if ( objGeometry && objGeometry.isGeometry ) {
-
-			nNormals = objGeometry.faces.length;
-
-		} else {
-
-			console.warn( 'THREE.FaceNormalsHelper: only THREE.Geometry is supported. Use THREE.VertexNormalsHelper, instead.' );
-
-		}
-
-		//
-
-		var geometry = new BufferGeometry();
-
-		var positions = new Float32BufferAttribute( nNormals * 2 * 3, 3 );
-
-		geometry.addAttribute( 'position', positions );
-
-		LineSegments.call( this, geometry, new LineBasicMaterial( { color: color, linewidth: width } ) );
-
-		//
-
-		this.matrixAutoUpdate = false;
-		this.update();
-
-	}
-
-	FaceNormalsHelper.prototype = Object.create( LineSegments.prototype );
-	FaceNormalsHelper.prototype.constructor = FaceNormalsHelper;
-
-	FaceNormalsHelper.prototype.update = ( function () {
-
-		var v1 = new Vector3();
-		var v2 = new Vector3();
-		var normalMatrix = new Matrix3();
-
-		return function update() {
-
-			this.object.updateMatrixWorld( true );
-
-			normalMatrix.getNormalMatrix( this.object.matrixWorld );
-
-			var matrixWorld = this.object.matrixWorld;
-
-			var position = this.geometry.attributes.position;
-
-			//
-
-			var objGeometry = this.object.geometry;
-
-			var vertices = objGeometry.vertices;
-
-			var faces = objGeometry.faces;
-
-			var idx = 0;
-
-			for ( var i = 0, l = faces.length; i < l; i ++ ) {
-
-				var face = faces[ i ];
-
-				var normal = face.normal;
-
-				v1.copy( vertices[ face.a ] )
-					.add( vertices[ face.b ] )
-					.add( vertices[ face.c ] )
-					.divideScalar( 3 )
-					.applyMatrix4( matrixWorld );
-
-				v2.copy( normal ).applyMatrix3( normalMatrix ).normalize().multiplyScalar( this.size ).add( v1 );
-
-				position.setXYZ( idx, v1.x, v1.y, v1.z );
-
-				idx = idx + 1;
-
-				position.setXYZ( idx, v2.x, v2.y, v2.z );
-
-				idx = idx + 1;
-
-			}
-
-			position.needsUpdate = true;
-
-		};
-
-	}() );
-
-	/**
 	 * @author alteredq / http://alteredqualia.com/
 	 * @author mrdoob / http://mrdoob.com/
 	 * @author WestLangley / http://github.com/WestLangley
 	 */
+
+	var _v1$5 = new Vector3();
+	var _v2$3 = new Vector3();
+	var _v3$1 = new Vector3();
 
 	function DirectionalLightHelper( light, size, color ) {
 
@@ -46445,7 +47146,7 @@ var Spacekit = (function (exports) {
 		if ( size === undefined ) size = 1;
 
 		var geometry = new BufferGeometry();
-		geometry.addAttribute( 'position', new Float32BufferAttribute( [
+		geometry.setAttribute( 'position', new Float32BufferAttribute( [
 			- size, size, 0,
 			size, size, 0,
 			size, - size, 0,
@@ -46453,13 +47154,13 @@ var Spacekit = (function (exports) {
 			- size, size, 0
 		], 3 ) );
 
-		var material = new LineBasicMaterial( { fog: false } );
+		var material = new LineBasicMaterial( { fog: false, toneMapped: false } );
 
 		this.lightPlane = new Line( geometry, material );
 		this.add( this.lightPlane );
 
 		geometry = new BufferGeometry();
-		geometry.addAttribute( 'position', new Float32BufferAttribute( [ 0, 0, 0, 0, 0, 1 ], 3 ) );
+		geometry.setAttribute( 'position', new Float32BufferAttribute( [ 0, 0, 0, 0, 0, 1 ], 3 ) );
 
 		this.targetLine = new Line( geometry, material );
 		this.add( this.targetLine );
@@ -46482,36 +47183,28 @@ var Spacekit = (function (exports) {
 
 	DirectionalLightHelper.prototype.update = function () {
 
-		var v1 = new Vector3();
-		var v2 = new Vector3();
-		var v3 = new Vector3();
+		_v1$5.setFromMatrixPosition( this.light.matrixWorld );
+		_v2$3.setFromMatrixPosition( this.light.target.matrixWorld );
+		_v3$1.subVectors( _v2$3, _v1$5 );
 
-		return function update() {
+		this.lightPlane.lookAt( _v2$3 );
 
-			v1.setFromMatrixPosition( this.light.matrixWorld );
-			v2.setFromMatrixPosition( this.light.target.matrixWorld );
-			v3.subVectors( v2, v1 );
+		if ( this.color !== undefined ) {
 
-			this.lightPlane.lookAt( v2 );
+			this.lightPlane.material.color.set( this.color );
+			this.targetLine.material.color.set( this.color );
 
-			if ( this.color !== undefined ) {
+		} else {
 
-				this.lightPlane.material.color.set( this.color );
-				this.targetLine.material.color.set( this.color );
+			this.lightPlane.material.color.copy( this.light.color );
+			this.targetLine.material.color.copy( this.light.color );
 
-			} else {
+		}
 
-				this.lightPlane.material.color.copy( this.light.color );
-				this.targetLine.material.color.copy( this.light.color );
+		this.targetLine.lookAt( _v2$3 );
+		this.targetLine.scale.z = _v3$1.length();
 
-			}
-
-			this.targetLine.lookAt( v2 );
-			this.targetLine.scale.z = v3.length();
-
-		};
-
-	}();
+	};
 
 	/**
 	 * @author alteredq / http://alteredqualia.com/
@@ -46523,10 +47216,13 @@ var Spacekit = (function (exports) {
 	 *		http://evanw.github.com/lightgl.js/tests/shadowmap.html
 	 */
 
+	var _vector$b = new Vector3();
+	var _camera = new Camera();
+
 	function CameraHelper( camera ) {
 
 		var geometry = new BufferGeometry();
-		var material = new LineBasicMaterial( { color: 0xffffff, vertexColors: FaceColors } );
+		var material = new LineBasicMaterial( { color: 0xffffff, vertexColors: true, toneMapped: false } );
 
 		var vertices = [];
 		var colors = [];
@@ -46610,10 +47306,12 @@ var Spacekit = (function (exports) {
 
 		}
 
-		geometry.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		geometry.addAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
+		geometry.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		geometry.setAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
 
 		LineSegments.call( this, geometry, material );
+
+		this.type = 'CameraHelper';
 
 		this.camera = camera;
 		if ( this.camera.updateProjectionMatrix ) this.camera.updateProjectionMatrix();
@@ -46632,90 +47330,83 @@ var Spacekit = (function (exports) {
 
 	CameraHelper.prototype.update = function () {
 
-		var geometry, pointMap;
+		var geometry = this.geometry;
+		var pointMap = this.pointMap;
 
-		var vector = new Vector3();
-		var camera = new Camera();
+		var w = 1, h = 1;
 
-		function setPoint( point, x, y, z ) {
+		// we need just camera projection matrix inverse
+		// world matrix must be identity
 
-			vector.set( x, y, z ).unproject( camera );
+		_camera.projectionMatrixInverse.copy( this.camera.projectionMatrixInverse );
 
-			var points = pointMap[ point ];
+		// center / target
 
-			if ( points !== undefined ) {
+		setPoint( 'c', pointMap, geometry, _camera, 0, 0, - 1 );
+		setPoint( 't', pointMap, geometry, _camera, 0, 0, 1 );
 
-				var position = geometry.getAttribute( 'position' );
+		// near
 
-				for ( var i = 0, l = points.length; i < l; i ++ ) {
+		setPoint( 'n1', pointMap, geometry, _camera, - w, - h, - 1 );
+		setPoint( 'n2', pointMap, geometry, _camera, w, - h, - 1 );
+		setPoint( 'n3', pointMap, geometry, _camera, - w, h, - 1 );
+		setPoint( 'n4', pointMap, geometry, _camera, w, h, - 1 );
 
-					position.setXYZ( points[ i ], vector.x, vector.y, vector.z );
+		// far
 
-				}
+		setPoint( 'f1', pointMap, geometry, _camera, - w, - h, 1 );
+		setPoint( 'f2', pointMap, geometry, _camera, w, - h, 1 );
+		setPoint( 'f3', pointMap, geometry, _camera, - w, h, 1 );
+		setPoint( 'f4', pointMap, geometry, _camera, w, h, 1 );
+
+		// up
+
+		setPoint( 'u1', pointMap, geometry, _camera, w * 0.7, h * 1.1, - 1 );
+		setPoint( 'u2', pointMap, geometry, _camera, - w * 0.7, h * 1.1, - 1 );
+		setPoint( 'u3', pointMap, geometry, _camera, 0, h * 2, - 1 );
+
+		// cross
+
+		setPoint( 'cf1', pointMap, geometry, _camera, - w, 0, 1 );
+		setPoint( 'cf2', pointMap, geometry, _camera, w, 0, 1 );
+		setPoint( 'cf3', pointMap, geometry, _camera, 0, - h, 1 );
+		setPoint( 'cf4', pointMap, geometry, _camera, 0, h, 1 );
+
+		setPoint( 'cn1', pointMap, geometry, _camera, - w, 0, - 1 );
+		setPoint( 'cn2', pointMap, geometry, _camera, w, 0, - 1 );
+		setPoint( 'cn3', pointMap, geometry, _camera, 0, - h, - 1 );
+		setPoint( 'cn4', pointMap, geometry, _camera, 0, h, - 1 );
+
+		geometry.getAttribute( 'position' ).needsUpdate = true;
+
+	};
+
+	function setPoint( point, pointMap, geometry, camera, x, y, z ) {
+
+		_vector$b.set( x, y, z ).unproject( camera );
+
+		var points = pointMap[ point ];
+
+		if ( points !== undefined ) {
+
+			var position = geometry.getAttribute( 'position' );
+
+			for ( var i = 0, l = points.length; i < l; i ++ ) {
+
+				position.setXYZ( points[ i ], _vector$b.x, _vector$b.y, _vector$b.z );
 
 			}
 
 		}
 
-		return function update() {
-
-			geometry = this.geometry;
-			pointMap = this.pointMap;
-
-			var w = 1, h = 1;
-
-			// we need just camera projection matrix inverse
-			// world matrix must be identity
-
-			camera.projectionMatrixInverse.copy( this.camera.projectionMatrixInverse );
-
-			// center / target
-
-			setPoint( 'c', 0, 0, - 1 );
-			setPoint( 't', 0, 0, 1 );
-
-			// near
-
-			setPoint( 'n1', - w, - h, - 1 );
-			setPoint( 'n2', w, - h, - 1 );
-			setPoint( 'n3', - w, h, - 1 );
-			setPoint( 'n4', w, h, - 1 );
-
-			// far
-
-			setPoint( 'f1', - w, - h, 1 );
-			setPoint( 'f2', w, - h, 1 );
-			setPoint( 'f3', - w, h, 1 );
-			setPoint( 'f4', w, h, 1 );
-
-			// up
-
-			setPoint( 'u1', w * 0.7, h * 1.1, - 1 );
-			setPoint( 'u2', - w * 0.7, h * 1.1, - 1 );
-			setPoint( 'u3', 0, h * 2, - 1 );
-
-			// cross
-
-			setPoint( 'cf1', - w, 0, 1 );
-			setPoint( 'cf2', w, 0, 1 );
-			setPoint( 'cf3', 0, - h, 1 );
-			setPoint( 'cf4', 0, h, 1 );
-
-			setPoint( 'cn1', - w, 0, - 1 );
-			setPoint( 'cn2', w, 0, - 1 );
-			setPoint( 'cn3', 0, - h, - 1 );
-			setPoint( 'cn4', 0, h, - 1 );
-
-			geometry.getAttribute( 'position' ).needsUpdate = true;
-
-		};
-
-	}();
+	}
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
 	 * @author Mugen87 / http://github.com/Mugen87
 	 */
+
+	var _box$3 = new Box3();
 
 	function BoxHelper( object, color ) {
 
@@ -46728,9 +47419,11 @@ var Spacekit = (function (exports) {
 
 		var geometry = new BufferGeometry();
 		geometry.setIndex( new BufferAttribute( indices, 1 ) );
-		geometry.addAttribute( 'position', new BufferAttribute( positions, 3 ) );
+		geometry.setAttribute( 'position', new BufferAttribute( positions, 3 ) );
 
-		LineSegments.call( this, geometry, new LineBasicMaterial( { color: color } ) );
+		LineSegments.call( this, geometry, new LineBasicMaterial( { color: color, toneMapped: false } ) );
+
+		this.type = 'BoxHelper';
 
 		this.matrixAutoUpdate = false;
 
@@ -46741,64 +47434,59 @@ var Spacekit = (function (exports) {
 	BoxHelper.prototype = Object.create( LineSegments.prototype );
 	BoxHelper.prototype.constructor = BoxHelper;
 
-	BoxHelper.prototype.update = ( function () {
+	BoxHelper.prototype.update = function ( object ) {
 
-		var box = new Box3();
+		if ( object !== undefined ) {
 
-		return function update( object ) {
+			console.warn( 'THREE.BoxHelper: .update() has no longer arguments.' );
 
-			if ( object !== undefined ) {
+		}
 
-				console.warn( 'THREE.BoxHelper: .update() has no longer arguments.' );
+		if ( this.object !== undefined ) {
 
-			}
+			_box$3.setFromObject( this.object );
 
-			if ( this.object !== undefined ) {
+		}
 
-				box.setFromObject( this.object );
+		if ( _box$3.isEmpty() ) return;
 
-			}
+		var min = _box$3.min;
+		var max = _box$3.max;
 
-			if ( box.isEmpty() ) return;
+		/*
+		  5____4
+		1/___0/|
+		| 6__|_7
+		2/___3/
 
-			var min = box.min;
-			var max = box.max;
+		0: max.x, max.y, max.z
+		1: min.x, max.y, max.z
+		2: min.x, min.y, max.z
+		3: max.x, min.y, max.z
+		4: max.x, max.y, min.z
+		5: min.x, max.y, min.z
+		6: min.x, min.y, min.z
+		7: max.x, min.y, min.z
+		*/
 
-			/*
-			  5____4
-			1/___0/|
-			| 6__|_7
-			2/___3/
+		var position = this.geometry.attributes.position;
+		var array = position.array;
 
-			0: max.x, max.y, max.z
-			1: min.x, max.y, max.z
-			2: min.x, min.y, max.z
-			3: max.x, min.y, max.z
-			4: max.x, max.y, min.z
-			5: min.x, max.y, min.z
-			6: min.x, min.y, min.z
-			7: max.x, min.y, min.z
-			*/
+		array[ 0 ] = max.x; array[ 1 ] = max.y; array[ 2 ] = max.z;
+		array[ 3 ] = min.x; array[ 4 ] = max.y; array[ 5 ] = max.z;
+		array[ 6 ] = min.x; array[ 7 ] = min.y; array[ 8 ] = max.z;
+		array[ 9 ] = max.x; array[ 10 ] = min.y; array[ 11 ] = max.z;
+		array[ 12 ] = max.x; array[ 13 ] = max.y; array[ 14 ] = min.z;
+		array[ 15 ] = min.x; array[ 16 ] = max.y; array[ 17 ] = min.z;
+		array[ 18 ] = min.x; array[ 19 ] = min.y; array[ 20 ] = min.z;
+		array[ 21 ] = max.x; array[ 22 ] = min.y; array[ 23 ] = min.z;
 
-			var position = this.geometry.attributes.position;
-			var array = position.array;
+		position.needsUpdate = true;
 
-			array[ 0 ] = max.x; array[ 1 ] = max.y; array[ 2 ] = max.z;
-			array[ 3 ] = min.x; array[ 4 ] = max.y; array[ 5 ] = max.z;
-			array[ 6 ] = min.x; array[ 7 ] = min.y; array[ 8 ] = max.z;
-			array[ 9 ] = max.x; array[ 10 ] = min.y; array[ 11 ] = max.z;
-			array[ 12 ] = max.x; array[ 13 ] = max.y; array[ 14 ] = min.z;
-			array[ 15 ] = min.x; array[ 16 ] = max.y; array[ 17 ] = min.z;
-			array[ 18 ] = min.x; array[ 19 ] = min.y; array[ 20 ] = min.z;
-			array[ 21 ] = max.x; array[ 22 ] = min.y; array[ 23 ] = min.z;
+		this.geometry.computeBoundingSphere();
 
-			position.needsUpdate = true;
 
-			this.geometry.computeBoundingSphere();
-
-		};
-
-	} )();
+	};
 
 	BoxHelper.prototype.setFromObject = function ( object ) {
 
@@ -46845,9 +47533,11 @@ var Spacekit = (function (exports) {
 
 		geometry.setIndex( new BufferAttribute( indices, 1 ) );
 
-		geometry.addAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
+		geometry.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
 
-		LineSegments.call( this, geometry, new LineBasicMaterial( { color: color } ) );
+		LineSegments.call( this, geometry, new LineBasicMaterial( { color: color, toneMapped: false } ) );
+
+		this.type = 'Box3Helper';
 
 		this.geometry.computeBoundingSphere();
 
@@ -46878,8 +47568,6 @@ var Spacekit = (function (exports) {
 
 	function PlaneHelper( plane, size, hex ) {
 
-		this.type = 'PlaneHelper';
-
 		this.plane = plane;
 
 		this.size = ( size === undefined ) ? 1 : size;
@@ -46889,20 +47577,22 @@ var Spacekit = (function (exports) {
 		var positions = [ 1, - 1, 1, - 1, 1, 1, - 1, - 1, 1, 1, 1, 1, - 1, 1, 1, - 1, - 1, 1, 1, - 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0 ];
 
 		var geometry = new BufferGeometry();
-		geometry.addAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
+		geometry.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
 		geometry.computeBoundingSphere();
 
-		Line.call( this, geometry, new LineBasicMaterial( { color: color } ) );
+		Line.call( this, geometry, new LineBasicMaterial( { color: color, toneMapped: false } ) );
+
+		this.type = 'PlaneHelper';
 
 		//
 
 		var positions2 = [ 1, 1, 1, - 1, 1, 1, - 1, - 1, 1, 1, 1, 1, - 1, - 1, 1, 1, - 1, 1 ];
 
 		var geometry2 = new BufferGeometry();
-		geometry2.addAttribute( 'position', new Float32BufferAttribute( positions2, 3 ) );
+		geometry2.setAttribute( 'position', new Float32BufferAttribute( positions2, 3 ) );
 		geometry2.computeBoundingSphere();
 
-		this.add( new Mesh( geometry2, new MeshBasicMaterial( { color: color, opacity: 0.2, transparent: true, depthWrite: false } ) ) );
+		this.add( new Mesh( geometry2, new MeshBasicMaterial( { color: color, opacity: 0.2, transparent: true, depthWrite: false, toneMapped: false } ) ) );
 
 	}
 
@@ -46941,13 +47631,16 @@ var Spacekit = (function (exports) {
 	 *  headWidth - Number
 	 */
 
-	var lineGeometry, coneGeometry;
+	var _axis = new Vector3();
+	var _lineGeometry, _coneGeometry;
 
 	function ArrowHelper( dir, origin, length, color, headLength, headWidth ) {
 
 		// dir is assumed to be normalized
 
 		Object3D.call( this );
+
+		this.type = 'ArrowHelper';
 
 		if ( dir === undefined ) dir = new Vector3( 0, 0, 1 );
 		if ( origin === undefined ) origin = new Vector3( 0, 0, 0 );
@@ -46956,23 +47649,23 @@ var Spacekit = (function (exports) {
 		if ( headLength === undefined ) headLength = 0.2 * length;
 		if ( headWidth === undefined ) headWidth = 0.2 * headLength;
 
-		if ( lineGeometry === undefined ) {
+		if ( _lineGeometry === undefined ) {
 
-			lineGeometry = new BufferGeometry();
-			lineGeometry.addAttribute( 'position', new Float32BufferAttribute( [ 0, 0, 0, 0, 1, 0 ], 3 ) );
+			_lineGeometry = new BufferGeometry();
+			_lineGeometry.setAttribute( 'position', new Float32BufferAttribute( [ 0, 0, 0, 0, 1, 0 ], 3 ) );
 
-			coneGeometry = new CylinderBufferGeometry( 0, 0.5, 1, 5, 1 );
-			coneGeometry.translate( 0, - 0.5, 0 );
+			_coneGeometry = new CylinderBufferGeometry( 0, 0.5, 1, 5, 1 );
+			_coneGeometry.translate( 0, - 0.5, 0 );
 
 		}
 
 		this.position.copy( origin );
 
-		this.line = new Line( lineGeometry, new LineBasicMaterial( { color: color } ) );
+		this.line = new Line( _lineGeometry, new LineBasicMaterial( { color: color, toneMapped: false } ) );
 		this.line.matrixAutoUpdate = false;
 		this.add( this.line );
 
-		this.cone = new Mesh( coneGeometry, new MeshBasicMaterial( { color: color } ) );
+		this.cone = new Mesh( _coneGeometry, new MeshBasicMaterial( { color: color, toneMapped: false } ) );
 		this.cone.matrixAutoUpdate = false;
 		this.add( this.cone );
 
@@ -46984,43 +47677,36 @@ var Spacekit = (function (exports) {
 	ArrowHelper.prototype = Object.create( Object3D.prototype );
 	ArrowHelper.prototype.constructor = ArrowHelper;
 
-	ArrowHelper.prototype.setDirection = ( function () {
+	ArrowHelper.prototype.setDirection = function ( dir ) {
 
-		var axis = new Vector3();
-		var radians;
+		// dir is assumed to be normalized
 
-		return function setDirection( dir ) {
+		if ( dir.y > 0.99999 ) {
 
-			// dir is assumed to be normalized
+			this.quaternion.set( 0, 0, 0, 1 );
 
-			if ( dir.y > 0.99999 ) {
+		} else if ( dir.y < - 0.99999 ) {
 
-				this.quaternion.set( 0, 0, 0, 1 );
+			this.quaternion.set( 1, 0, 0, 0 );
 
-			} else if ( dir.y < - 0.99999 ) {
+		} else {
 
-				this.quaternion.set( 1, 0, 0, 0 );
+			_axis.set( dir.z, 0, - dir.x ).normalize();
 
-			} else {
+			var radians = Math.acos( dir.y );
 
-				axis.set( dir.z, 0, - dir.x ).normalize();
+			this.quaternion.setFromAxisAngle( _axis, radians );
 
-				radians = Math.acos( dir.y );
+		}
 
-				this.quaternion.setFromAxisAngle( axis, radians );
-
-			}
-
-		};
-
-	}() );
+	};
 
 	ArrowHelper.prototype.setLength = function ( length, headLength, headWidth ) {
 
 		if ( headLength === undefined ) headLength = 0.2 * length;
 		if ( headWidth === undefined ) headWidth = 0.2 * headLength;
 
-		this.line.scale.set( 1, Math.max( 0, length - headLength ), 1 );
+		this.line.scale.set( 1, Math.max( 0.0001, length - headLength ), 1 ); // see #17458
 		this.line.updateMatrix();
 
 		this.cone.scale.set( headWidth, headLength, headWidth );
@@ -47075,17 +47761,867 @@ var Spacekit = (function (exports) {
 		];
 
 		var geometry = new BufferGeometry();
-		geometry.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		geometry.addAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
+		geometry.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		geometry.setAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
 
-		var material = new LineBasicMaterial( { vertexColors: VertexColors } );
+		var material = new LineBasicMaterial( { vertexColors: true, toneMapped: false } );
 
 		LineSegments.call( this, geometry, material );
+
+		this.type = 'AxesHelper';
 
 	}
 
 	AxesHelper.prototype = Object.create( LineSegments.prototype );
 	AxesHelper.prototype.constructor = AxesHelper;
+
+	/**
+	 * @author Emmett Lalish / elalish
+	 *
+	 * This class generates a Prefiltered, Mipmapped Radiance Environment Map
+	 * (PMREM) from a cubeMap environment texture. This allows different levels of
+	 * blur to be quickly accessed based on material roughness. It is packed into a
+	 * special CubeUV format that allows us to perform custom interpolation so that
+	 * we can support nonlinear formats such as RGBE. Unlike a traditional mipmap
+	 * chain, it only goes down to the LOD_MIN level (above), and then creates extra
+	 * even more filtered 'mips' at the same LOD_MIN resolution, associated with
+	 * higher roughness levels. In this way we maintain resolution to smoothly
+	 * interpolate diffuse lighting while limiting sampling computation.
+	 */
+
+	var LOD_MIN = 4;
+	var LOD_MAX = 8;
+	var SIZE_MAX = Math.pow( 2, LOD_MAX );
+
+	// The standard deviations (radians) associated with the extra mips. These are
+	// chosen to approximate a Trowbridge-Reitz distribution function times the
+	// geometric shadowing function. These sigma values squared must match the
+	// variance #defines in cube_uv_reflection_fragment.glsl.js.
+	var EXTRA_LOD_SIGMA = [ 0.125, 0.215, 0.35, 0.446, 0.526, 0.582 ];
+
+	var TOTAL_LODS = LOD_MAX - LOD_MIN + 1 + EXTRA_LOD_SIGMA.length;
+
+	// The maximum length of the blur for loop. Smaller sigmas will use fewer
+	// samples and exit early, but not recompile the shader.
+	var MAX_SAMPLES = 20;
+
+	var ENCODINGS = {
+		[ LinearEncoding ]: 0,
+		[ sRGBEncoding ]: 1,
+		[ RGBEEncoding ]: 2,
+		[ RGBM7Encoding ]: 3,
+		[ RGBM16Encoding ]: 4,
+		[ RGBDEncoding ]: 5,
+		[ GammaEncoding ]: 6
+	};
+
+	var _flatCamera = new OrthographicCamera();
+	var { _lodPlanes, _sizeLods, _sigmas } = _createPlanes();
+	var _oldTarget = null;
+
+	// Golden Ratio
+	var PHI = ( 1 + Math.sqrt( 5 ) ) / 2;
+	var INV_PHI = 1 / PHI;
+
+	// Vertices of a dodecahedron (except the opposites, which represent the
+	// same axis), used as axis directions evenly spread on a sphere.
+	var _axisDirections = [
+		new Vector3( 1, 1, 1 ),
+		new Vector3( - 1, 1, 1 ),
+		new Vector3( 1, 1, - 1 ),
+		new Vector3( - 1, 1, - 1 ),
+		new Vector3( 0, PHI, INV_PHI ),
+		new Vector3( 0, PHI, - INV_PHI ),
+		new Vector3( INV_PHI, 0, PHI ),
+		new Vector3( - INV_PHI, 0, PHI ),
+		new Vector3( PHI, INV_PHI, 0 ),
+		new Vector3( - PHI, INV_PHI, 0 ) ];
+
+	function PMREMGenerator( renderer ) {
+
+		this._renderer = renderer;
+		this._pingPongRenderTarget = null;
+
+		this._blurMaterial = _getBlurShader( MAX_SAMPLES );
+		this._equirectShader = null;
+		this._cubemapShader = null;
+
+		this._compileMaterial( this._blurMaterial );
+
+	}
+
+	PMREMGenerator.prototype = {
+
+		constructor: PMREMGenerator,
+
+		/**
+		 * Generates a PMREM from a supplied Scene, which can be faster than using an
+		 * image if networking bandwidth is low. Optional sigma specifies a blur radius
+		 * in radians to be applied to the scene before PMREM generation. Optional near
+		 * and far planes ensure the scene is rendered in its entirety (the cubeCamera
+		 * is placed at the origin).
+		 */
+		fromScene: function ( scene, sigma = 0, near = 0.1, far = 100 ) {
+
+			_oldTarget = this._renderer.getRenderTarget();
+			var cubeUVRenderTarget = this._allocateTargets();
+
+			this._sceneToCubeUV( scene, near, far, cubeUVRenderTarget );
+			if ( sigma > 0 ) {
+
+				this._blur( cubeUVRenderTarget, 0, 0, sigma );
+
+			}
+
+			this._applyPMREM( cubeUVRenderTarget );
+			this._cleanup( cubeUVRenderTarget );
+
+			return cubeUVRenderTarget;
+
+		},
+
+		/**
+		 * Generates a PMREM from an equirectangular texture, which can be either LDR
+		 * (RGBFormat) or HDR (RGBEFormat). The ideal input image size is 1k (1024 x 512),
+		 * as this matches best with the 256 x 256 cubemap output.
+		 */
+		fromEquirectangular: function ( equirectangular ) {
+
+			equirectangular.magFilter = NearestFilter;
+			equirectangular.minFilter = NearestFilter;
+			equirectangular.generateMipmaps = false;
+
+			return this.fromCubemap( equirectangular );
+
+		},
+
+		/**
+		 * Generates a PMREM from an cubemap texture, which can be either LDR
+		 * (RGBFormat) or HDR (RGBEFormat). The ideal input cube size is 256 x 256,
+		 * as this matches best with the 256 x 256 cubemap output.
+		 */
+		fromCubemap: function ( cubemap ) {
+
+			_oldTarget = this._renderer.getRenderTarget();
+			var cubeUVRenderTarget = this._allocateTargets( cubemap );
+			this._textureToCubeUV( cubemap, cubeUVRenderTarget );
+			this._applyPMREM( cubeUVRenderTarget );
+			this._cleanup( cubeUVRenderTarget );
+
+			return cubeUVRenderTarget;
+
+		},
+
+		/**
+		 * Pre-compiles the cubemap shader. You can get faster start-up by invoking this method during
+		 * your texture's network fetch for increased concurrency.
+		 */
+		compileCubemapShader: function () {
+
+			if ( this._cubemapShader === null ) {
+
+				this._cubemapShader = _getCubemapShader();
+				this._compileMaterial( this._cubemapShader );
+
+			}
+
+		},
+
+		/**
+		 * Pre-compiles the equirectangular shader. You can get faster start-up by invoking this method during
+		 * your texture's network fetch for increased concurrency.
+		 */
+		compileEquirectangularShader: function () {
+
+			if ( this._equirectShader === null ) {
+
+				this._equirectShader = _getEquirectShader();
+				this._compileMaterial( this._equirectShader );
+
+			}
+
+		},
+
+		/**
+		 * Disposes of the PMREMGenerator's internal memory. Note that PMREMGenerator is a static class,
+		 * so you should not need more than one PMREMGenerator object. If you do, calling dispose() on
+		 * one of them will cause any others to also become unusable.
+		 */
+		dispose: function () {
+
+			this._blurMaterial.dispose();
+
+			if ( this._cubemapShader !== null ) this._cubemapShader.dispose();
+			if ( this._equirectShader !== null ) this._equirectShader.dispose();
+
+			for ( var i = 0; i < _lodPlanes.length; i ++ ) {
+
+				_lodPlanes[ i ].dispose();
+
+			}
+
+		},
+
+		// private interface
+
+		_cleanup: function ( outputTarget ) {
+
+			this._pingPongRenderTarget.dispose();
+			this._renderer.setRenderTarget( _oldTarget );
+			outputTarget.scissorTest = false;
+			// reset viewport and scissor
+			outputTarget.setSize( outputTarget.width, outputTarget.height );
+
+		},
+
+		_allocateTargets: function ( equirectangular ) {
+
+			var params = {
+				magFilter: NearestFilter,
+				minFilter: NearestFilter,
+				generateMipmaps: false,
+				type: UnsignedByteType,
+				format: RGBEFormat,
+				encoding: _isLDR( equirectangular ) ? equirectangular.encoding : RGBEEncoding,
+				depthBuffer: false,
+				stencilBuffer: false
+			};
+
+			var cubeUVRenderTarget = _createRenderTarget( params );
+			cubeUVRenderTarget.depthBuffer = equirectangular ? false : true;
+			this._pingPongRenderTarget = _createRenderTarget( params );
+			return cubeUVRenderTarget;
+
+		},
+
+		_compileMaterial: function ( material ) {
+
+			var tmpScene = new Scene();
+			tmpScene.add( new Mesh( _lodPlanes[ 0 ], material ) );
+			this._renderer.compile( tmpScene, _flatCamera );
+
+		},
+
+		_sceneToCubeUV: function ( scene, near, far, cubeUVRenderTarget ) {
+
+			var fov = 90;
+			var aspect = 1;
+			var cubeCamera = new PerspectiveCamera( fov, aspect, near, far );
+			var upSign = [ 1, 1, 1, 1, - 1, 1 ];
+			var forwardSign = [ 1, 1, - 1, - 1, - 1, 1 ];
+			var renderer = this._renderer;
+
+			var outputEncoding = renderer.outputEncoding;
+			var toneMapping = renderer.toneMapping;
+			var toneMappingExposure = renderer.toneMappingExposure;
+			var clearColor = renderer.getClearColor();
+			var clearAlpha = renderer.getClearAlpha();
+
+			renderer.toneMapping = LinearToneMapping;
+			renderer.toneMappingExposure = 1.0;
+			renderer.outputEncoding = LinearEncoding;
+			scene.scale.z *= - 1;
+
+			var background = scene.background;
+			if ( background && background.isColor ) {
+
+				background.convertSRGBToLinear();
+				// Convert linear to RGBE
+				var maxComponent = Math.max( background.r, background.g, background.b );
+				var fExp = Math.min( Math.max( Math.ceil( Math.log2( maxComponent ) ), - 128.0 ), 127.0 );
+				background = background.multiplyScalar( Math.pow( 2.0, - fExp ) );
+				var alpha = ( fExp + 128.0 ) / 255.0;
+				renderer.setClearColor( background, alpha );
+				scene.background = null;
+
+			}
+
+			for ( var i = 0; i < 6; i ++ ) {
+
+				var col = i % 3;
+				if ( col == 0 ) {
+
+					cubeCamera.up.set( 0, upSign[ i ], 0 );
+					cubeCamera.lookAt( forwardSign[ i ], 0, 0 );
+
+				} else if ( col == 1 ) {
+
+					cubeCamera.up.set( 0, 0, upSign[ i ] );
+					cubeCamera.lookAt( 0, forwardSign[ i ], 0 );
+
+				} else {
+
+					cubeCamera.up.set( 0, upSign[ i ], 0 );
+					cubeCamera.lookAt( 0, 0, forwardSign[ i ] );
+
+				}
+
+				_setViewport( cubeUVRenderTarget,
+					col * SIZE_MAX, i > 2 ? SIZE_MAX : 0, SIZE_MAX, SIZE_MAX );
+				renderer.setRenderTarget( cubeUVRenderTarget );
+				renderer.render( scene, cubeCamera );
+
+			}
+
+			renderer.toneMapping = toneMapping;
+			renderer.toneMappingExposure = toneMappingExposure;
+			renderer.outputEncoding = outputEncoding;
+			renderer.setClearColor( clearColor, clearAlpha );
+			scene.scale.z *= - 1;
+
+		},
+
+		_textureToCubeUV: function ( texture, cubeUVRenderTarget ) {
+
+			var scene = new Scene();
+			var renderer = this._renderer;
+
+			if ( texture.isCubeTexture ) {
+
+				if ( this._cubemapShader == null ) {
+
+					this._cubemapShader = _getCubemapShader();
+
+				}
+
+			} else {
+
+				if ( this._equirectShader == null ) {
+
+					this._equirectShader = _getEquirectShader();
+
+				}
+
+			}
+
+			var material = texture.isCubeTexture ? this._cubemapShader : this._equirectShader;
+			scene.add( new Mesh( _lodPlanes[ 0 ], material ) );
+
+			var uniforms = material.uniforms;
+
+			uniforms[ 'envMap' ].value = texture;
+
+			if ( ! texture.isCubeTexture ) {
+
+				uniforms[ 'texelSize' ].value.set( 1.0 / texture.image.width, 1.0 / texture.image.height );
+
+			}
+
+			uniforms[ 'inputEncoding' ].value = ENCODINGS[ texture.encoding ];
+			uniforms[ 'outputEncoding' ].value = ENCODINGS[ cubeUVRenderTarget.texture.encoding ];
+
+			_setViewport( cubeUVRenderTarget, 0, 0, 3 * SIZE_MAX, 2 * SIZE_MAX );
+
+			renderer.setRenderTarget( cubeUVRenderTarget );
+			renderer.render( scene, _flatCamera );
+
+		},
+
+		_applyPMREM: function ( cubeUVRenderTarget ) {
+
+			var renderer = this._renderer;
+			var autoClear = renderer.autoClear;
+			renderer.autoClear = false;
+
+			for ( var i = 1; i < TOTAL_LODS; i ++ ) {
+
+				var sigma = Math.sqrt( _sigmas[ i ] * _sigmas[ i ] - _sigmas[ i - 1 ] * _sigmas[ i - 1 ] );
+
+				var poleAxis = _axisDirections[ ( i - 1 ) % _axisDirections.length ];
+
+				this._blur( cubeUVRenderTarget, i - 1, i, sigma, poleAxis );
+
+			}
+
+			renderer.autoClear = autoClear;
+
+		},
+
+		/**
+		 * This is a two-pass Gaussian blur for a cubemap. Normally this is done
+		 * vertically and horizontally, but this breaks down on a cube. Here we apply
+		 * the blur latitudinally (around the poles), and then longitudinally (towards
+		 * the poles) to approximate the orthogonally-separable blur. It is least
+		 * accurate at the poles, but still does a decent job.
+		 */
+		_blur: function ( cubeUVRenderTarget, lodIn, lodOut, sigma, poleAxis ) {
+
+			var pingPongRenderTarget = this._pingPongRenderTarget;
+
+			this._halfBlur(
+				cubeUVRenderTarget,
+				pingPongRenderTarget,
+				lodIn,
+				lodOut,
+				sigma,
+				'latitudinal',
+				poleAxis );
+
+			this._halfBlur(
+				pingPongRenderTarget,
+				cubeUVRenderTarget,
+				lodOut,
+				lodOut,
+				sigma,
+				'longitudinal',
+				poleAxis );
+
+		},
+
+		_halfBlur: function ( targetIn, targetOut, lodIn, lodOut, sigmaRadians, direction, poleAxis ) {
+
+			var renderer = this._renderer;
+			var blurMaterial = this._blurMaterial;
+
+			if ( direction !== 'latitudinal' && direction !== 'longitudinal' ) {
+
+				console.error(
+					'blur direction must be either latitudinal or longitudinal!' );
+
+			}
+
+			// Number of standard deviations at which to cut off the discrete approximation.
+			var STANDARD_DEVIATIONS = 3;
+
+			var blurScene = new Scene();
+			blurScene.add( new Mesh( _lodPlanes[ lodOut ], blurMaterial ) );
+			var blurUniforms = blurMaterial.uniforms;
+
+			var pixels = _sizeLods[ lodIn ] - 1;
+			var radiansPerPixel = isFinite( sigmaRadians ) ? Math.PI / ( 2 * pixels ) : 2 * Math.PI / ( 2 * MAX_SAMPLES - 1 );
+			var sigmaPixels = sigmaRadians / radiansPerPixel;
+			var samples = isFinite( sigmaRadians ) ? 1 + Math.floor( STANDARD_DEVIATIONS * sigmaPixels ) : MAX_SAMPLES;
+
+			if ( samples > MAX_SAMPLES ) {
+
+				console.warn( `sigmaRadians, ${
+				sigmaRadians}, is too large and will clip, as it requested ${
+				samples} samples when the maximum is set to ${MAX_SAMPLES}` );
+
+			}
+
+			var weights = [];
+			var sum = 0;
+
+			for ( var i = 0; i < MAX_SAMPLES; ++ i ) {
+
+				var x = i / sigmaPixels;
+				var weight = Math.exp( - x * x / 2 );
+				weights.push( weight );
+
+				if ( i == 0 ) {
+
+					sum += weight;
+
+				} else if ( i < samples ) {
+
+					sum += 2 * weight;
+
+				}
+
+			}
+
+			for ( var i = 0; i < weights.length; i ++ ) {
+
+				weights[ i ] = weights[ i ] / sum;
+
+			}
+
+			blurUniforms[ 'envMap' ].value = targetIn.texture;
+			blurUniforms[ 'samples' ].value = samples;
+			blurUniforms[ 'weights' ].value = weights;
+			blurUniforms[ 'latitudinal' ].value = direction === 'latitudinal';
+
+			if ( poleAxis ) {
+
+				blurUniforms[ 'poleAxis' ].value = poleAxis;
+
+			}
+
+			blurUniforms[ 'dTheta' ].value = radiansPerPixel;
+			blurUniforms[ 'mipInt' ].value = LOD_MAX - lodIn;
+			blurUniforms[ 'inputEncoding' ].value = ENCODINGS[ targetIn.texture.encoding ];
+			blurUniforms[ 'outputEncoding' ].value = ENCODINGS[ targetIn.texture.encoding ];
+
+			var outputSize = _sizeLods[ lodOut ];
+			var x = 3 * Math.max( 0, SIZE_MAX - 2 * outputSize );
+			var y = ( lodOut === 0 ? 0 : 2 * SIZE_MAX ) + 2 * outputSize * ( lodOut > LOD_MAX - LOD_MIN ? lodOut - LOD_MAX + LOD_MIN : 0 );
+
+			_setViewport( targetOut, x, y, 3 * outputSize, 2 * outputSize );
+			renderer.setRenderTarget( targetOut );
+			renderer.render( blurScene, _flatCamera );
+
+		}
+
+	};
+
+	function _isLDR( texture ) {
+
+		if ( texture === undefined || texture.type !== UnsignedByteType ) return false;
+
+		return texture.encoding === LinearEncoding || texture.encoding === sRGBEncoding || texture.encoding === GammaEncoding;
+
+	}
+
+	function _createPlanes() {
+
+		var _lodPlanes = [];
+		var _sizeLods = [];
+		var _sigmas = [];
+
+		var lod = LOD_MAX;
+
+		for ( var i = 0; i < TOTAL_LODS; i ++ ) {
+
+			var sizeLod = Math.pow( 2, lod );
+			_sizeLods.push( sizeLod );
+			var sigma = 1.0 / sizeLod;
+
+			if ( i > LOD_MAX - LOD_MIN ) {
+
+				sigma = EXTRA_LOD_SIGMA[ i - LOD_MAX + LOD_MIN - 1 ];
+
+			} else if ( i == 0 ) {
+
+				sigma = 0;
+
+			}
+
+			_sigmas.push( sigma );
+
+			var texelSize = 1.0 / ( sizeLod - 1 );
+			var min = - texelSize / 2;
+			var max = 1 + texelSize / 2;
+			var uv1 = [ min, min, max, min, max, max, min, min, max, max, min, max ];
+
+			var cubeFaces = 6;
+			var vertices = 6;
+			var positionSize = 3;
+			var uvSize = 2;
+			var faceIndexSize = 1;
+
+			var position = new Float32Array( positionSize * vertices * cubeFaces );
+			var uv = new Float32Array( uvSize * vertices * cubeFaces );
+			var faceIndex = new Float32Array( faceIndexSize * vertices * cubeFaces );
+
+			for ( var face = 0; face < cubeFaces; face ++ ) {
+
+				var x = ( face % 3 ) * 2 / 3 - 1;
+				var y = face > 2 ? 0 : - 1;
+				var coordinates = [
+					x, y, 0,
+					x + 2 / 3, y, 0,
+					x + 2 / 3, y + 1, 0,
+					x, y, 0,
+					x + 2 / 3, y + 1, 0,
+					x, y + 1, 0
+				];
+				position.set( coordinates, positionSize * vertices * face );
+				uv.set( uv1, uvSize * vertices * face );
+				var fill = [ face, face, face, face, face, face ];
+				faceIndex.set( fill, faceIndexSize * vertices * face );
+
+			}
+
+			var planes = new BufferGeometry();
+			planes.setAttribute( 'position', new BufferAttribute( position, positionSize ) );
+			planes.setAttribute( 'uv', new BufferAttribute( uv, uvSize ) );
+			planes.setAttribute( 'faceIndex', new BufferAttribute( faceIndex, faceIndexSize ) );
+			_lodPlanes.push( planes );
+
+			if ( lod > LOD_MIN ) {
+
+				lod --;
+
+			}
+
+		}
+
+		return { _lodPlanes, _sizeLods, _sigmas };
+
+	}
+
+	function _createRenderTarget( params ) {
+
+		var cubeUVRenderTarget = new WebGLRenderTarget( 3 * SIZE_MAX, 3 * SIZE_MAX, params );
+		cubeUVRenderTarget.texture.mapping = CubeUVReflectionMapping;
+		cubeUVRenderTarget.texture.name = 'PMREM.cubeUv';
+		cubeUVRenderTarget.scissorTest = true;
+		return cubeUVRenderTarget;
+
+	}
+
+	function _setViewport( target, x, y, width, height ) {
+
+		target.viewport.set( x, y, width, height );
+		target.scissor.set( x, y, width, height );
+
+	}
+
+	function _getBlurShader( maxSamples ) {
+
+		var weights = new Float32Array( maxSamples );
+		var poleAxis = new Vector3( 0, 1, 0 );
+		var shaderMaterial = new RawShaderMaterial( {
+
+			defines: { 'n': maxSamples },
+
+			uniforms: {
+				'envMap': { value: null },
+				'samples': { value: 1 },
+				'weights': { value: weights },
+				'latitudinal': { value: false },
+				'dTheta': { value: 0 },
+				'mipInt': { value: 0 },
+				'poleAxis': { value: poleAxis },
+				'inputEncoding': { value: ENCODINGS[ LinearEncoding ] },
+				'outputEncoding': { value: ENCODINGS[ LinearEncoding ] }
+			},
+
+			vertexShader: _getCommonVertexShader(),
+
+			fragmentShader: `
+precision mediump float;
+precision mediump int;
+varying vec3 vOutputDirection;
+uniform sampler2D envMap;
+uniform int samples;
+uniform float weights[n];
+uniform bool latitudinal;
+uniform float dTheta;
+uniform float mipInt;
+uniform vec3 poleAxis;
+
+${_getEncodings()}
+
+#define ENVMAP_TYPE_CUBE_UV
+#include <cube_uv_reflection_fragment>
+
+vec3 getSample(float theta, vec3 axis) {
+	float cosTheta = cos(theta);
+	// Rodrigues' axis-angle rotation
+	vec3 sampleDirection = vOutputDirection * cosTheta
+		+ cross(axis, vOutputDirection) * sin(theta)
+		+ axis * dot(axis, vOutputDirection) * (1.0 - cosTheta);
+	return bilinearCubeUV(envMap, sampleDirection, mipInt);
+}
+
+void main() {
+	vec3 axis = latitudinal ? poleAxis : cross(poleAxis, vOutputDirection);
+	if (all(equal(axis, vec3(0.0))))
+		axis = vec3(vOutputDirection.z, 0.0, - vOutputDirection.x);
+	axis = normalize(axis);
+	gl_FragColor = vec4(0.0);
+	gl_FragColor.rgb += weights[0] * getSample(0.0, axis);
+	for (int i = 1; i < n; i++) {
+		if (i >= samples)
+			break;
+		float theta = dTheta * float(i);
+		gl_FragColor.rgb += weights[i] * getSample(-1.0 * theta, axis);
+		gl_FragColor.rgb += weights[i] * getSample(theta, axis);
+	}
+	gl_FragColor = linearToOutputTexel(gl_FragColor);
+}
+		`,
+
+			blending: NoBlending,
+			depthTest: false,
+			depthWrite: false
+
+		} );
+
+		shaderMaterial.type = 'SphericalGaussianBlur';
+
+		return shaderMaterial;
+
+	}
+
+	function _getEquirectShader() {
+
+		var texelSize = new Vector2( 1, 1 );
+		var shaderMaterial = new RawShaderMaterial( {
+
+			uniforms: {
+				'envMap': { value: null },
+				'texelSize': { value: texelSize },
+				'inputEncoding': { value: ENCODINGS[ LinearEncoding ] },
+				'outputEncoding': { value: ENCODINGS[ LinearEncoding ] }
+			},
+
+			vertexShader: _getCommonVertexShader(),
+
+			fragmentShader: `
+precision mediump float;
+precision mediump int;
+varying vec3 vOutputDirection;
+uniform sampler2D envMap;
+uniform vec2 texelSize;
+
+${_getEncodings()}
+
+#define RECIPROCAL_PI 0.31830988618
+#define RECIPROCAL_PI2 0.15915494
+
+void main() {
+	gl_FragColor = vec4(0.0);
+	vec3 outputDirection = normalize(vOutputDirection);
+	vec2 uv;
+	uv.y = asin(clamp(outputDirection.y, -1.0, 1.0)) * RECIPROCAL_PI + 0.5;
+	uv.x = atan(outputDirection.z, outputDirection.x) * RECIPROCAL_PI2 + 0.5;
+	vec2 f = fract(uv / texelSize - 0.5);
+	uv -= f * texelSize;
+	vec3 tl = envMapTexelToLinear(texture2D(envMap, uv)).rgb;
+	uv.x += texelSize.x;
+	vec3 tr = envMapTexelToLinear(texture2D(envMap, uv)).rgb;
+	uv.y += texelSize.y;
+	vec3 br = envMapTexelToLinear(texture2D(envMap, uv)).rgb;
+	uv.x -= texelSize.x;
+	vec3 bl = envMapTexelToLinear(texture2D(envMap, uv)).rgb;
+	vec3 tm = mix(tl, tr, f.x);
+	vec3 bm = mix(bl, br, f.x);
+	gl_FragColor.rgb = mix(tm, bm, f.y);
+	gl_FragColor = linearToOutputTexel(gl_FragColor);
+}
+		`,
+
+			blending: NoBlending,
+			depthTest: false,
+			depthWrite: false
+
+		} );
+
+		shaderMaterial.type = 'EquirectangularToCubeUV';
+
+		return shaderMaterial;
+
+	}
+
+	function _getCubemapShader() {
+
+		var shaderMaterial = new RawShaderMaterial( {
+
+			uniforms: {
+				'envMap': { value: null },
+				'inputEncoding': { value: ENCODINGS[ LinearEncoding ] },
+				'outputEncoding': { value: ENCODINGS[ LinearEncoding ] }
+			},
+
+			vertexShader: _getCommonVertexShader(),
+
+			fragmentShader: `
+precision mediump float;
+precision mediump int;
+varying vec3 vOutputDirection;
+uniform samplerCube envMap;
+
+${_getEncodings()}
+
+void main() {
+	gl_FragColor = vec4(0.0);
+	gl_FragColor.rgb = envMapTexelToLinear(textureCube(envMap, vec3( - vOutputDirection.x, vOutputDirection.yz ))).rgb;
+	gl_FragColor = linearToOutputTexel(gl_FragColor);
+}
+		`,
+
+			blending: NoBlending,
+			depthTest: false,
+			depthWrite: false
+
+		} );
+
+		shaderMaterial.type = 'CubemapToCubeUV';
+
+		return shaderMaterial;
+
+	}
+
+	function _getCommonVertexShader() {
+
+		return `
+precision mediump float;
+precision mediump int;
+attribute vec3 position;
+attribute vec2 uv;
+attribute float faceIndex;
+varying vec3 vOutputDirection;
+vec3 getDirection(vec2 uv, float face) {
+	uv = 2.0 * uv - 1.0;
+	vec3 direction = vec3(uv, 1.0);
+	if (face == 0.0) {
+		direction = direction.zyx;
+		direction.z *= -1.0;
+	} else if (face == 1.0) {
+		direction = direction.xzy;
+		direction.z *= -1.0;
+	} else if (face == 3.0) {
+		direction = direction.zyx;
+		direction.x *= -1.0;
+	} else if (face == 4.0) {
+		direction = direction.xzy;
+		direction.y *= -1.0;
+	} else if (face == 5.0) {
+		direction.xz *= -1.0;
+	}
+	return direction;
+}
+void main() {
+	vOutputDirection = getDirection(uv, faceIndex);
+	gl_Position = vec4( position, 1.0 );
+}
+	`;
+
+	}
+
+	function _getEncodings() {
+
+		return `
+uniform int inputEncoding;
+uniform int outputEncoding;
+
+#include <encodings_pars_fragment>
+
+vec4 inputTexelToLinear(vec4 value){
+	if(inputEncoding == 0){
+		return value;
+	}else if(inputEncoding == 1){
+		return sRGBToLinear(value);
+	}else if(inputEncoding == 2){
+		return RGBEToLinear(value);
+	}else if(inputEncoding == 3){
+		return RGBMToLinear(value, 7.0);
+	}else if(inputEncoding == 4){
+		return RGBMToLinear(value, 16.0);
+	}else if(inputEncoding == 5){
+		return RGBDToLinear(value, 256.0);
+	}else{
+		return GammaToLinear(value, 2.2);
+	}
+}
+
+vec4 linearToOutputTexel(vec4 value){
+	if(outputEncoding == 0){
+		return value;
+	}else if(outputEncoding == 1){
+		return LinearTosRGB(value);
+	}else if(outputEncoding == 2){
+		return LinearToRGBE(value);
+	}else if(outputEncoding == 3){
+		return LinearToRGBM(value, 7.0);
+	}else if(outputEncoding == 4){
+		return LinearToRGBM(value, 16.0);
+	}else if(outputEncoding == 5){
+		return LinearToRGBD(value, 256.0);
+	}else{
+		return LinearToGamma(value, 2.2);
+	}
+}
+
+vec4 envMapTexelToLinear(vec4 color) {
+	return inputTexelToLinear(color);
+}
+	`;
+
+	}
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -47099,8 +48635,10 @@ var Spacekit = (function (exports) {
 	}
 
 	var LineStrip = 0;
-
 	var LinePieces = 1;
+	var NoColors = 0;
+	var FaceColors = 1;
+	var VertexColors = 2;
 
 	function MeshFaceMaterial( materials ) {
 
@@ -47121,6 +48659,7 @@ var Spacekit = (function (exports) {
 			return materials.slice();
 
 		};
+
 		return materials;
 
 	}
@@ -47178,8 +48717,8 @@ var Spacekit = (function (exports) {
 
 	function DynamicBufferAttribute( array, itemSize ) {
 
-		console.warn( 'THREE.DynamicBufferAttribute has been removed. Use new THREE.BufferAttribute().setDynamic( true ) instead.' );
-		return new BufferAttribute( array, itemSize ).setDynamic( true );
+		console.warn( 'THREE.DynamicBufferAttribute has been removed. Use new THREE.BufferAttribute().setUsage( THREE.DynamicDrawUsage ) instead.' );
+		return new BufferAttribute( array, itemSize ).setUsage( DynamicDrawUsage );
 
 	}
 
@@ -47312,7 +48851,7 @@ var Spacekit = (function (exports) {
 		fromPoints: function ( points ) {
 
 			console.warn( 'THREE.Path: .fromPoints() has been renamed to .setFromPoints().' );
-			this.setFromPoints( points );
+			return this.setFromPoints( points );
 
 		}
 
@@ -47433,6 +48972,22 @@ var Spacekit = (function (exports) {
 
 	} );
 
+	Loader.Handlers = {
+
+		add: function ( /* regex, loader */ ) {
+
+			console.error( 'THREE.Loader: Handlers.add() has been removed. Use LoadingManager.addHandler() instead.' );
+
+		},
+
+		get: function ( /* file */ ) {
+
+			console.error( 'THREE.Loader: Handlers.get() has been removed. Use LoadingManager.getHandler() instead.' );
+
+		}
+
+	};
+
 	function XHRLoader( manager ) {
 
 		console.warn( 'THREE.XHRLoader has been renamed to THREE.FileLoader.' );
@@ -47522,6 +49077,24 @@ var Spacekit = (function (exports) {
 		}
 	} );
 
+	Object.assign( Sphere.prototype, {
+
+		empty: function () {
+
+			console.warn( 'THREE.Sphere: .empty() has been renamed to .isEmpty().' );
+			return this.isEmpty();
+
+		},
+
+	} );
+
+	Frustum.prototype.setFromMatrix = function ( m ) {
+
+		console.warn( 'THREE.Frustum: .setFromMatrix() has been renamed to .setFromProjectionMatrix().' );
+		return this.setFromProjectionMatrix( m );
+
+	};
+
 	Line3.prototype.center = function ( optionalTarget ) {
 
 		console.warn( 'THREE.Line3: .center() has been renamed to .getCenter().' );
@@ -47529,7 +49102,7 @@ var Spacekit = (function (exports) {
 
 	};
 
-	Object.assign( _Math, {
+	Object.assign( MathUtils, {
 
 		random16: function () {
 
@@ -47541,14 +49114,14 @@ var Spacekit = (function (exports) {
 		nearestPowerOfTwo: function ( value ) {
 
 			console.warn( 'THREE.Math: .nearestPowerOfTwo() has been renamed to .floorPowerOfTwo().' );
-			return _Math.floorPowerOfTwo( value );
+			return MathUtils.floorPowerOfTwo( value );
 
 		},
 
 		nextPowerOfTwo: function ( value ) {
 
 			console.warn( 'THREE.Math: .nextPowerOfTwo() has been renamed to .ceilPowerOfTwo().' );
-			return _Math.ceilPowerOfTwo( value );
+			return MathUtils.ceilPowerOfTwo( value );
 
 		}
 
@@ -47573,10 +49146,10 @@ var Spacekit = (function (exports) {
 			console.error( 'THREE.Matrix3: .multiplyVector3Array() has been removed.' );
 
 		},
-		applyToBuffer: function ( buffer /*, offset, length */ ) {
+		applyToBufferAttribute: function ( attribute ) {
 
-			console.warn( 'THREE.Matrix3: .applyToBuffer() has been removed. Use matrix.applyToBufferAttribute( attribute ) instead.' );
-			return this.applyToBufferAttribute( buffer );
+			console.warn( 'THREE.Matrix3: .applyToBufferAttribute() has been removed. Use attribute.applyMatrix3( matrix ) instead.' );
+			return attribute.applyMatrix3( this );
 
 		},
 		applyToVector3Array: function ( /* array, offset, length */ ) {
@@ -47603,17 +49176,10 @@ var Spacekit = (function (exports) {
 		},
 		getPosition: function () {
 
-			var v1;
+			console.warn( 'THREE.Matrix4: .getPosition() has been removed. Use Vector3.setFromMatrixPosition( matrix ) instead.' );
+			return new Vector3().setFromMatrixColumn( this, 3 );
 
-			return function getPosition() {
-
-				if ( v1 === undefined ) v1 = new Vector3();
-				console.warn( 'THREE.Matrix4: .getPosition() has been removed. Use Vector3.setFromMatrixPosition( matrix ) instead.' );
-				return v1.setFromMatrixColumn( this, 3 );
-
-			};
-
-		}(),
+		},
 		setRotationFromQuaternion: function ( q ) {
 
 			console.warn( 'THREE.Matrix4: .setRotationFromQuaternion() has been renamed to .makeRotationFromQuaternion().' );
@@ -47679,10 +49245,10 @@ var Spacekit = (function (exports) {
 			console.error( 'THREE.Matrix4: .rotateByAxis() has been removed.' );
 
 		},
-		applyToBuffer: function ( buffer /*, offset, length */ ) {
+		applyToBufferAttribute: function ( attribute ) {
 
-			console.warn( 'THREE.Matrix4: .applyToBuffer() has been removed. Use matrix.applyToBufferAttribute( attribute ) instead.' );
-			return this.applyToBufferAttribute( buffer );
+			console.warn( 'THREE.Matrix4: .applyToBufferAttribute() has been removed. Use attribute.applyMatrix4( matrix ) instead.' );
+			return attribute.applyMatrix4( this );
 
 		},
 		applyToVector3Array: function ( /* array, offset, length */ ) {
@@ -47921,6 +49487,12 @@ var Spacekit = (function (exports) {
 
 			console.error( 'THREE.Geometry: .computeLineDistances() has been removed. Use THREE.Line.computeLineDistances() instead.' );
 
+		},
+		applyMatrix: function ( matrix ) {
+
+			console.warn( 'THREE.Geometry: .applyMatrix() has been renamed to .applyMatrix4().' );
+			return this.applyMatrix4( matrix );
+
 		}
 
 	} );
@@ -47947,6 +49519,12 @@ var Spacekit = (function (exports) {
 		getWorldRotation: function () {
 
 			console.error( 'THREE.Object3D: .getWorldRotation() has been removed. Use THREE.Object3D.getWorldQuaternion( target ) instead.' );
+
+		},
+		applyMatrix: function ( matrix ) {
+
+			console.warn( 'THREE.Object3D: .applyMatrix() has been renamed to .applyMatrix4().' );
+			return this.applyMatrix4( matrix );
 
 		}
 
@@ -47977,6 +49555,34 @@ var Spacekit = (function (exports) {
 			set: function () {
 
 				console.warn( 'THREE.Object3D: .useQuaternion has been removed. The library now uses quaternions by default.' );
+
+			}
+		}
+
+	} );
+
+	Object.assign( Mesh.prototype, {
+
+		setDrawMode: function () {
+
+			console.error( 'THREE.Mesh: .setDrawMode() has been removed. The renderer now always assumes THREE.TrianglesDrawMode. Transform your geometry via BufferGeometryUtils.toTrianglesDrawMode() if necessary.' );
+
+		},
+
+	} );
+
+	Object.defineProperties( Mesh.prototype, {
+
+		drawMode: {
+			get: function () {
+
+				console.error( 'THREE.Mesh: .drawMode has been removed. The renderer now always assumes THREE.TrianglesDrawMode.' );
+				return TrianglesDrawMode;
+
+			},
+			set: function () {
+
+				console.error( 'THREE.Mesh: .drawMode has been removed. The renderer now always assumes THREE.TrianglesDrawMode. Transform your geometry via BufferGeometryUtils.toTrianglesDrawMode() if necessary.' );
 
 			}
 		}
@@ -48164,12 +49770,41 @@ var Spacekit = (function (exports) {
 
 			}
 		},
+		dynamic: {
+			get: function () {
+
+				console.warn( 'THREE.BufferAttribute: .dynamic has been deprecated. Use .usage instead.' );
+				return this.usage === DynamicDrawUsage;
+
+			},
+			set: function ( /* value */ ) {
+
+				console.warn( 'THREE.BufferAttribute: .dynamic has been deprecated. Use .usage instead.' );
+				this.setUsage( DynamicDrawUsage );
+
+			}
+		}
+
+	} );
+
+	Object.assign( BufferAttribute.prototype, {
+		setDynamic: function ( value ) {
+
+			console.warn( 'THREE.BufferAttribute: .setDynamic() has been deprecated. Use .setUsage() instead.' );
+			this.setUsage( value === true ? DynamicDrawUsage : StaticDrawUsage );
+			return this;
+
+		},
 		copyIndicesArray: function ( /* indices */ ) {
 
 			console.error( 'THREE.BufferAttribute: .copyIndicesArray() has been removed.' );
 
-		}
+		},
+		setArray: function ( /* array */ ) {
 
+			console.error( 'THREE.BufferAttribute: .setArray has been removed. Use BufferGeometry .setAttribute to replace/resize attribute buffers' );
+
+		}
 	} );
 
 	Object.assign( BufferGeometry.prototype, {
@@ -48180,6 +49815,30 @@ var Spacekit = (function (exports) {
 			this.setIndex( index );
 
 		},
+		addAttribute: function ( name, attribute ) {
+
+			console.warn( 'THREE.BufferGeometry: .addAttribute() has been renamed to .setAttribute().' );
+
+			if ( ! ( attribute && attribute.isBufferAttribute ) && ! ( attribute && attribute.isInterleavedBufferAttribute ) ) {
+
+				console.warn( 'THREE.BufferGeometry: .addAttribute() now expects ( name, attribute ).' );
+
+				return this.setAttribute( name, new BufferAttribute( arguments[ 1 ], arguments[ 2 ] ) );
+
+			}
+
+			if ( name === 'index' ) {
+
+				console.warn( 'THREE.BufferGeometry.addAttribute: Use .setIndex() for index attribute.' );
+				this.setIndex( attribute );
+
+				return this;
+
+			}
+
+			return this.setAttribute( name, attribute );
+
+		},
 		addDrawCall: function ( start, count, indexOffset ) {
 
 			if ( indexOffset !== undefined ) {
@@ -48187,6 +49846,7 @@ var Spacekit = (function (exports) {
 				console.warn( 'THREE.BufferGeometry: .addDrawCall() no longer supports indexOffset.' );
 
 			}
+
 			console.warn( 'THREE.BufferGeometry: .addDrawCall() is now .addGroup().' );
 			this.addGroup( start, count );
 
@@ -48205,6 +49865,19 @@ var Spacekit = (function (exports) {
 		computeOffsets: function () {
 
 			console.warn( 'THREE.BufferGeometry: .computeOffsets() has been removed.' );
+
+		},
+		removeAttribute: function ( name ) {
+
+			console.warn( 'THREE.BufferGeometry: .removeAttribute() has been renamed to .deleteAttribute().' );
+
+			return this.deleteAttribute( name );
+
+		},
+		applyMatrix: function ( matrix ) {
+
+			console.warn( 'THREE.BufferGeometry: .applyMatrix() has been renamed to .applyMatrix4().' );
+			return this.applyMatrix4( matrix );
 
 		}
 
@@ -48229,6 +49902,59 @@ var Spacekit = (function (exports) {
 			}
 		}
 
+	} );
+
+	Object.defineProperties( Raycaster.prototype, {
+
+		linePrecision: {
+			get: function () {
+
+				console.warn( 'THREE.Raycaster: .linePrecision has been deprecated. Use .params.Line.threshold instead.' );
+				return this.params.Line.threshold;
+
+			},
+			set: function ( value ) {
+
+				console.warn( 'THREE.Raycaster: .linePrecision has been deprecated. Use .params.Line.threshold instead.' );
+				this.params.Line.threshold = value;
+
+			}
+		}
+
+	} );
+
+	Object.defineProperties( InterleavedBuffer.prototype, {
+
+		dynamic: {
+			get: function () {
+
+				console.warn( 'THREE.InterleavedBuffer: .length has been deprecated. Use .usage instead.' );
+				return this.usage === DynamicDrawUsage;
+
+			},
+			set: function ( value ) {
+
+				console.warn( 'THREE.InterleavedBuffer: .length has been deprecated. Use .usage instead.' );
+				this.setUsage( value );
+
+			}
+		}
+
+	} );
+
+	Object.assign( InterleavedBuffer.prototype, {
+		setDynamic: function ( value ) {
+
+			console.warn( 'THREE.InterleavedBuffer: .setDynamic() has been deprecated. Use .setUsage() instead.' );
+			this.setUsage( value === true ? DynamicDrawUsage : StaticDrawUsage );
+			return this;
+
+		},
+		setArray: function ( /* array */ ) {
+
+			console.error( 'THREE.InterleavedBuffer: .setArray has been removed. Use BufferGeometry .setAttribute to replace/resize attribute buffers' );
+
+		}
 	} );
 
 	//
@@ -48326,6 +50052,21 @@ var Spacekit = (function (exports) {
 
 				console.warn( 'THREE.' + this.type + ': .shading has been removed. Use the boolean .flatShading instead.' );
 				this.flatShading = ( value === FlatShading );
+
+			}
+		},
+
+		stencilMask: {
+			get: function () {
+
+				console.warn( 'THREE.' + this.type + ': .stencilMask has been removed. Use .stencilFuncMask instead.' );
+				return this.stencilFuncMask;
+
+			},
+			set: function ( value ) {
+
+				console.warn( 'THREE.' + this.type + ': .stencilMask has been removed. Use .stencilFuncMask instead.' );
+				this.stencilFuncMask = value;
 
 			}
 		}
@@ -48566,6 +50307,41 @@ var Spacekit = (function (exports) {
 				return this.getContext();
 
 			}
+		},
+		vr: {
+			get: function () {
+
+				console.warn( 'THREE.WebGLRenderer: .vr has been renamed to .xr' );
+				return this.xr;
+
+			}
+		},
+		gammaInput: {
+			get: function () {
+
+				console.warn( 'THREE.WebGLRenderer: .gammaInput has been removed. Set the encoding for textures via Texture.encoding instead.' );
+				return false;
+
+			},
+			set: function () {
+
+				console.warn( 'THREE.WebGLRenderer: .gammaInput has been removed. Set the encoding for textures via Texture.encoding instead.' );
+
+			}
+		},
+		gammaOutput: {
+			get: function () {
+
+				console.warn( 'THREE.WebGLRenderer: .gammaOutput has been removed. Set WebGLRenderer.outputEncoding instead.' );
+				return false;
+
+			},
+			set: function ( value ) {
+
+				console.warn( 'THREE.WebGLRenderer: .gammaOutput has been removed. Set WebGLRenderer.outputEncoding instead.' );
+				this.outputEncoding = ( value === true ) ? sRGBEncoding : LinearEncoding;
+
+			}
 		}
 
 	} );
@@ -48614,26 +50390,12 @@ var Spacekit = (function (exports) {
 
 	} );
 
-	//
+	function WebGLRenderTargetCube( width, height, options ) {
 
-	Object.defineProperties( WebGLRenderTargetCube.prototype, {
+		console.warn( 'THREE.WebGLRenderTargetCube( width, height, options ) is now WebGLCubeRenderTarget( size, options ).' );
+		return new WebGLCubeRenderTarget( width, options );
 
-		activeCubeFace: {
-			set: function ( /* value */ ) {
-
-				console.warn( 'THREE.WebGLRenderTargetCube: .activeCubeFace has been removed. It is now the second parameter of WebGLRenderer.setRenderTarget().' );
-
-			}
-		},
-		activeMipMapLevel: {
-			set: function ( /* value */ ) {
-
-				console.warn( 'THREE.WebGLRenderTargetCube: .activeMipMapLevel has been removed. It is now the third parameter of WebGLRenderer.setRenderTarget().' );
-
-			}
-		}
-
-	} );
+	}
 
 	//
 
@@ -48784,40 +50546,32 @@ var Spacekit = (function (exports) {
 
 	//
 
-	Object.defineProperties( WebVRManager.prototype, {
+	Object.defineProperties( Audio.prototype, {
 
-		standing: {
-			set: function ( /* value */ ) {
+		load: {
+			value: function ( file ) {
 
-				console.warn( 'THREE.WebVRManager: .standing has been removed.' );
+				console.warn( 'THREE.Audio: .load has been deprecated. Use THREE.AudioLoader instead.' );
+				var scope = this;
+				var audioLoader = new AudioLoader();
+				audioLoader.load( file, function ( buffer ) {
+
+					scope.setBuffer( buffer );
+
+				} );
+				return this;
 
 			}
 		},
-		userHeight: {
-			set: function ( /* value */ ) {
+		startTime: {
+			set: function () {
 
-				console.warn( 'THREE.WebVRManager: .userHeight has been removed.' );
+				console.warn( 'THREE.Audio: .startTime is now .play( delay ).' );
 
 			}
 		}
 
 	} );
-
-	//
-
-	Audio.prototype.load = function ( file ) {
-
-		console.warn( 'THREE.Audio: .load has been deprecated. Use THREE.AudioLoader instead.' );
-		var scope = this;
-		var audioLoader = new AudioLoader();
-		audioLoader.load( file, function ( buffer ) {
-
-			scope.setBuffer( buffer );
-
-		} );
-		return this;
-
-	};
 
 	AudioAnalyser.prototype.getData = function () {
 
@@ -48932,19 +50686,19 @@ var Spacekit = (function (exports) {
 
 		createMultiMaterialObject: function ( /* geometry, materials */ ) {
 
-			console.error( 'THREE.SceneUtils has been moved to /examples/js/utils/SceneUtils.js' );
+			console.error( 'THREE.SceneUtils has been moved to /examples/jsm/utils/SceneUtils.js' );
 
 		},
 
 		detach: function ( /* child, parent, scene */ ) {
 
-			console.error( 'THREE.SceneUtils has been moved to /examples/js/utils/SceneUtils.js' );
+			console.error( 'THREE.SceneUtils has been moved to /examples/jsm/utils/SceneUtils.js' );
 
 		},
 
 		attach: function ( /* child, scene, parent */ ) {
 
-			console.error( 'THREE.SceneUtils has been moved to /examples/js/utils/SceneUtils.js' );
+			console.error( 'THREE.SceneUtils has been moved to /examples/jsm/utils/SceneUtils.js' );
 
 		}
 
@@ -48954,7 +50708,17 @@ var Spacekit = (function (exports) {
 
 	function LensFlare() {
 
-		console.error( 'THREE.LensFlare has been moved to /examples/js/objects/Lensflare.js' );
+		console.error( 'THREE.LensFlare has been moved to /examples/jsm/objects/Lensflare.js' );
+
+	}
+
+	if ( typeof __THREE_DEVTOOLS__ !== 'undefined' ) {
+
+		/* eslint-disable no-undef */
+		__THREE_DEVTOOLS__.dispatchEvent( new CustomEvent( 'register', { detail: {
+			revision: REVISION,
+		} } ) );
+		/* eslint-enable no-undef */
 
 	}
 
@@ -48962,6 +50726,7 @@ var Spacekit = (function (exports) {
 		ACESFilmicToneMapping: ACESFilmicToneMapping,
 		AddEquation: AddEquation,
 		AddOperation: AddOperation,
+		AdditiveAnimationBlendMode: AdditiveAnimationBlendMode,
 		AdditiveBlending: AdditiveBlending,
 		AlphaFormat: AlphaFormat,
 		AlwaysDepth: AlwaysDepth,
@@ -49059,6 +50824,9 @@ var Spacekit = (function (exports) {
 		DstAlphaFactor: DstAlphaFactor,
 		DstColorFactor: DstColorFactor,
 		DynamicBufferAttribute: DynamicBufferAttribute,
+		DynamicCopyUsage: DynamicCopyUsage,
+		DynamicDrawUsage: DynamicDrawUsage,
+		DynamicReadUsage: DynamicReadUsage,
 		EdgesGeometry: EdgesGeometry,
 		EdgesHelper: EdgesHelper,
 		EllipseCurve: EllipseCurve,
@@ -49073,7 +50841,6 @@ var Spacekit = (function (exports) {
 		Face3: Face3,
 		Face4: Face4,
 		FaceColors: FaceColors,
-		FaceNormalsHelper: FaceNormalsHelper,
 		FileLoader: FileLoader,
 		FlatShading: FlatShading,
 		Float32Attribute: Float32Attribute,
@@ -49113,6 +50880,7 @@ var Spacekit = (function (exports) {
 		InstancedBufferAttribute: InstancedBufferAttribute,
 		InstancedBufferGeometry: InstancedBufferGeometry,
 		InstancedInterleavedBuffer: InstancedInterleavedBuffer,
+		InstancedMesh: InstancedMesh,
 		Int16Attribute: Int16Attribute,
 		Int16BufferAttribute: Int16BufferAttribute,
 		Int32Attribute: Int32Attribute,
@@ -49141,7 +50909,6 @@ var Spacekit = (function (exports) {
 		LessStencilFunc: LessStencilFunc,
 		Light: Light,
 		LightProbe: LightProbe,
-		LightProbeHelper: LightProbeHelper,
 		LightShadow: LightShadow,
 		Line: Line,
 		Line3: Line3,
@@ -49173,7 +50940,8 @@ var Spacekit = (function (exports) {
 		MOUSE: MOUSE,
 		Material: Material,
 		MaterialLoader: MaterialLoader,
-		Math: _Math,
+		Math: MathUtils,
+		MathUtils: MathUtils,
 		Matrix3: Matrix3,
 		Matrix4: Matrix4,
 		MaxEquation: MaxEquation,
@@ -49205,6 +50973,7 @@ var Spacekit = (function (exports) {
 		NoBlending: NoBlending,
 		NoColors: NoColors,
 		NoToneMapping: NoToneMapping,
+		NormalAnimationBlendMode: NormalAnimationBlendMode,
 		NormalBlending: NormalBlending,
 		NotEqualDepth: NotEqualDepth,
 		NotEqualStencilFunc: NotEqualStencilFunc,
@@ -49222,6 +50991,7 @@ var Spacekit = (function (exports) {
 		OrthographicCamera: OrthographicCamera,
 		PCFShadowMap: PCFShadowMap,
 		PCFSoftShadowMap: PCFSoftShadowMap,
+		PMREMGenerator: PMREMGenerator,
 		ParametricBufferGeometry: ParametricBufferGeometry,
 		ParametricGeometry: ParametricGeometry,
 		Particle: Particle,
@@ -49244,7 +51014,6 @@ var Spacekit = (function (exports) {
 		PolyhedronBufferGeometry: PolyhedronBufferGeometry,
 		PolyhedronGeometry: PolyhedronGeometry,
 		PositionalAudio: PositionalAudio,
-		PositionalAudioHelper: PositionalAudioHelper,
 		PropertyBinding: PropertyBinding,
 		PropertyMixer: PropertyMixer,
 		QuadraticBezierCurve: QuadraticBezierCurve,
@@ -49255,6 +51024,7 @@ var Spacekit = (function (exports) {
 		REVISION: REVISION,
 		RGBADepthPacking: RGBADepthPacking,
 		RGBAFormat: RGBAFormat,
+		RGBAIntegerFormat: RGBAIntegerFormat,
 		RGBA_ASTC_10x10_Format: RGBA_ASTC_10x10_Format,
 		RGBA_ASTC_10x5_Format: RGBA_ASTC_10x5_Format,
 		RGBA_ASTC_10x6_Format: RGBA_ASTC_10x6_Format,
@@ -49269,6 +51039,8 @@ var Spacekit = (function (exports) {
 		RGBA_ASTC_8x5_Format: RGBA_ASTC_8x5_Format,
 		RGBA_ASTC_8x6_Format: RGBA_ASTC_8x6_Format,
 		RGBA_ASTC_8x8_Format: RGBA_ASTC_8x8_Format,
+		RGBA_BPTC_Format: RGBA_BPTC_Format,
+		RGBA_ETC2_EAC_Format: RGBA_ETC2_EAC_Format,
 		RGBA_PVRTC_2BPPV1_Format: RGBA_PVRTC_2BPPV1_Format,
 		RGBA_PVRTC_4BPPV1_Format: RGBA_PVRTC_4BPPV1_Format,
 		RGBA_S3TC_DXT1_Format: RGBA_S3TC_DXT1_Format,
@@ -49278,24 +51050,42 @@ var Spacekit = (function (exports) {
 		RGBEEncoding: RGBEEncoding,
 		RGBEFormat: RGBEFormat,
 		RGBFormat: RGBFormat,
+		RGBIntegerFormat: RGBIntegerFormat,
 		RGBM16Encoding: RGBM16Encoding,
 		RGBM7Encoding: RGBM7Encoding,
 		RGB_ETC1_Format: RGB_ETC1_Format,
+		RGB_ETC2_Format: RGB_ETC2_Format,
 		RGB_PVRTC_2BPPV1_Format: RGB_PVRTC_2BPPV1_Format,
 		RGB_PVRTC_4BPPV1_Format: RGB_PVRTC_4BPPV1_Format,
 		RGB_S3TC_DXT1_Format: RGB_S3TC_DXT1_Format,
+		RGFormat: RGFormat,
+		RGIntegerFormat: RGIntegerFormat,
 		RawShaderMaterial: RawShaderMaterial,
 		Ray: Ray,
 		Raycaster: Raycaster,
 		RectAreaLight: RectAreaLight,
-		RectAreaLightHelper: RectAreaLightHelper,
 		RedFormat: RedFormat,
+		RedIntegerFormat: RedIntegerFormat,
 		ReinhardToneMapping: ReinhardToneMapping,
 		RepeatWrapping: RepeatWrapping,
 		ReplaceStencilOp: ReplaceStencilOp,
 		ReverseSubtractEquation: ReverseSubtractEquation,
 		RingBufferGeometry: RingBufferGeometry,
 		RingGeometry: RingGeometry,
+		SRGB8_ALPHA8_ASTC_10x10_Format: SRGB8_ALPHA8_ASTC_10x10_Format,
+		SRGB8_ALPHA8_ASTC_10x5_Format: SRGB8_ALPHA8_ASTC_10x5_Format,
+		SRGB8_ALPHA8_ASTC_10x6_Format: SRGB8_ALPHA8_ASTC_10x6_Format,
+		SRGB8_ALPHA8_ASTC_10x8_Format: SRGB8_ALPHA8_ASTC_10x8_Format,
+		SRGB8_ALPHA8_ASTC_12x10_Format: SRGB8_ALPHA8_ASTC_12x10_Format,
+		SRGB8_ALPHA8_ASTC_12x12_Format: SRGB8_ALPHA8_ASTC_12x12_Format,
+		SRGB8_ALPHA8_ASTC_4x4_Format: SRGB8_ALPHA8_ASTC_4x4_Format,
+		SRGB8_ALPHA8_ASTC_5x4_Format: SRGB8_ALPHA8_ASTC_5x4_Format,
+		SRGB8_ALPHA8_ASTC_5x5_Format: SRGB8_ALPHA8_ASTC_5x5_Format,
+		SRGB8_ALPHA8_ASTC_6x5_Format: SRGB8_ALPHA8_ASTC_6x5_Format,
+		SRGB8_ALPHA8_ASTC_6x6_Format: SRGB8_ALPHA8_ASTC_6x6_Format,
+		SRGB8_ALPHA8_ASTC_8x5_Format: SRGB8_ALPHA8_ASTC_8x5_Format,
+		SRGB8_ALPHA8_ASTC_8x6_Format: SRGB8_ALPHA8_ASTC_8x6_Format,
+		SRGB8_ALPHA8_ASTC_8x8_Format: SRGB8_ALPHA8_ASTC_8x8_Format,
 		Scene: Scene,
 		SceneUtils: SceneUtils,
 		ShaderChunk: ShaderChunk,
@@ -49329,7 +51119,13 @@ var Spacekit = (function (exports) {
 		SrcAlphaFactor: SrcAlphaFactor,
 		SrcAlphaSaturateFactor: SrcAlphaSaturateFactor,
 		SrcColorFactor: SrcColorFactor,
+		StaticCopyUsage: StaticCopyUsage,
+		StaticDrawUsage: StaticDrawUsage,
+		StaticReadUsage: StaticReadUsage,
 		StereoCamera: StereoCamera,
+		StreamCopyUsage: StreamCopyUsage,
+		StreamDrawUsage: StreamDrawUsage,
+		StreamReadUsage: StreamReadUsage,
 		StringKeyframeTrack: StringKeyframeTrack,
 		SubtractEquation: SubtractEquation,
 		SubtractiveBlending: SubtractiveBlending,
@@ -49371,14 +51167,15 @@ var Spacekit = (function (exports) {
 		UnsignedShort5551Type: UnsignedShort5551Type,
 		UnsignedShort565Type: UnsignedShort565Type,
 		UnsignedShortType: UnsignedShortType,
+		VSMShadowMap: VSMShadowMap,
 		Vector2: Vector2,
 		Vector3: Vector3,
 		Vector4: Vector4,
 		VectorKeyframeTrack: VectorKeyframeTrack,
 		Vertex: Vertex,
 		VertexColors: VertexColors,
-		VertexNormalsHelper: VertexNormalsHelper,
 		VideoTexture: VideoTexture,
+		WebGLCubeRenderTarget: WebGLCubeRenderTarget,
 		WebGLMultisampleRenderTarget: WebGLMultisampleRenderTarget,
 		WebGLRenderTarget: WebGLRenderTarget,
 		WebGLRenderTargetCube: WebGLRenderTargetCube,
@@ -49413,9 +51210,11 @@ var Spacekit = (function (exports) {
 
 	var OrbitControls = function ( object, domElement ) {
 
-		this.object = object;
+		if ( domElement === undefined ) console.warn( 'THREE.OrbitControls: The second parameter "domElement" is now mandatory.' );
+		if ( domElement === document ) console.error( 'THREE.OrbitControls: "document" should not be used as the target "domElement". Please use "renderer.domElement" instead.' );
 
-		this.domElement = ( domElement !== undefined ) ? domElement : document;
+		this.object = object;
+		this.domElement = domElement;
 
 		// Set to false to disable this control
 		this.enabled = true;
@@ -49653,7 +51452,7 @@ var Spacekit = (function (exports) {
 			document.removeEventListener( 'mousemove', onMouseMove, false );
 			document.removeEventListener( 'mouseup', onMouseUp, false );
 
-			window.removeEventListener( 'keydown', onKeyDown, false );
+			scope.domElement.removeEventListener( 'keydown', onKeyDown, false );
 
 			//scope.dispatchEvent( { type: 'dispose' } ); // should this be added here?
 
@@ -49775,7 +51574,7 @@ var Spacekit = (function (exports) {
 
 			return function pan( deltaX, deltaY ) {
 
-				var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+				var element = scope.domElement;
 
 				if ( scope.object.isPerspectiveCamera ) {
 
@@ -49809,7 +51608,7 @@ var Spacekit = (function (exports) {
 
 		}();
 
-		function dollyIn( dollyScale ) {
+		function dollyOut( dollyScale ) {
 
 			if ( scope.object.isPerspectiveCamera ) {
 
@@ -49830,7 +51629,7 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function dollyOut( dollyScale ) {
+		function dollyIn( dollyScale ) {
 
 			if ( scope.object.isPerspectiveCamera ) {
 
@@ -49857,15 +51656,11 @@ var Spacekit = (function (exports) {
 
 		function handleMouseDownRotate( event ) {
 
-			//console.log( 'handleMouseDownRotate' );
-
 			rotateStart.set( event.clientX, event.clientY );
 
 		}
 
 		function handleMouseDownDolly( event ) {
-
-			//console.log( 'handleMouseDownDolly' );
 
 			dollyStart.set( event.clientX, event.clientY );
 
@@ -49873,21 +51668,17 @@ var Spacekit = (function (exports) {
 
 		function handleMouseDownPan( event ) {
 
-			//console.log( 'handleMouseDownPan' );
-
 			panStart.set( event.clientX, event.clientY );
 
 		}
 
 		function handleMouseMoveRotate( event ) {
 
-			//console.log( 'handleMouseMoveRotate' );
-
 			rotateEnd.set( event.clientX, event.clientY );
 
 			rotateDelta.subVectors( rotateEnd, rotateStart ).multiplyScalar( scope.rotateSpeed );
 
-			var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+			var element = scope.domElement;
 
 			rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientHeight ); // yes, height
 
@@ -49901,19 +51692,17 @@ var Spacekit = (function (exports) {
 
 		function handleMouseMoveDolly( event ) {
 
-			//console.log( 'handleMouseMoveDolly' );
-
 			dollyEnd.set( event.clientX, event.clientY );
 
 			dollyDelta.subVectors( dollyEnd, dollyStart );
 
 			if ( dollyDelta.y > 0 ) {
 
-				dollyIn( getZoomScale() );
+				dollyOut( getZoomScale() );
 
 			} else if ( dollyDelta.y < 0 ) {
 
-				dollyOut( getZoomScale() );
+				dollyIn( getZoomScale() );
 
 			}
 
@@ -49924,8 +51713,6 @@ var Spacekit = (function (exports) {
 		}
 
 		function handleMouseMovePan( event ) {
-
-			//console.log( 'handleMouseMovePan' );
 
 			panEnd.set( event.clientX, event.clientY );
 
@@ -49941,15 +51728,13 @@ var Spacekit = (function (exports) {
 
 		function handleMouseWheel( event ) {
 
-			// console.log( 'handleMouseWheel' );
-
 			if ( event.deltaY < 0 ) {
 
-				dollyOut( getZoomScale() );
+				dollyIn( getZoomScale() );
 
 			} else if ( event.deltaY > 0 ) {
 
-				dollyIn( getZoomScale() );
+				dollyOut( getZoomScale() );
 
 			}
 
@@ -49958,8 +51743,6 @@ var Spacekit = (function (exports) {
 		}
 
 		function handleKeyDown( event ) {
-
-			// console.log( 'handleKeyDown' );
 
 			var needsUpdate = false;
 
@@ -50001,8 +51784,6 @@ var Spacekit = (function (exports) {
 
 		function handleTouchStartRotate( event ) {
 
-			//console.log( 'handleTouchStartRotate' );
-
 			if ( event.touches.length == 1 ) {
 
 				rotateStart.set( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY );
@@ -50019,8 +51800,6 @@ var Spacekit = (function (exports) {
 		}
 
 		function handleTouchStartPan( event ) {
-
-			//console.log( 'handleTouchStartPan' );
 
 			if ( event.touches.length == 1 ) {
 
@@ -50039,8 +51818,6 @@ var Spacekit = (function (exports) {
 
 		function handleTouchStartDolly( event ) {
 
-			//console.log( 'handleTouchStartDolly' );
-
 			var dx = event.touches[ 0 ].pageX - event.touches[ 1 ].pageX;
 			var dy = event.touches[ 0 ].pageY - event.touches[ 1 ].pageY;
 
@@ -50052,8 +51829,6 @@ var Spacekit = (function (exports) {
 
 		function handleTouchStartDollyPan( event ) {
 
-			//console.log( 'handleTouchStartDollyPan' );
-
 			if ( scope.enableZoom ) handleTouchStartDolly( event );
 
 			if ( scope.enablePan ) handleTouchStartPan( event );
@@ -50062,8 +51837,6 @@ var Spacekit = (function (exports) {
 
 		function handleTouchStartDollyRotate( event ) {
 
-			//console.log( 'handleTouchStartDollyRotate' );
-
 			if ( scope.enableZoom ) handleTouchStartDolly( event );
 
 			if ( scope.enableRotate ) handleTouchStartRotate( event );
@@ -50071,8 +51844,6 @@ var Spacekit = (function (exports) {
 		}
 
 		function handleTouchMoveRotate( event ) {
-
-			//console.log( 'handleTouchMoveRotate' );
 
 			if ( event.touches.length == 1 ) {
 
@@ -50089,7 +51860,7 @@ var Spacekit = (function (exports) {
 
 			rotateDelta.subVectors( rotateEnd, rotateStart ).multiplyScalar( scope.rotateSpeed );
 
-			var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
+			var element = scope.domElement;
 
 			rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientHeight ); // yes, height
 
@@ -50100,8 +51871,6 @@ var Spacekit = (function (exports) {
 		}
 
 		function handleTouchMovePan( event ) {
-
-			//console.log( 'handleTouchMoveRotate' );
 
 			if ( event.touches.length == 1 ) {
 
@@ -50126,8 +51895,6 @@ var Spacekit = (function (exports) {
 
 		function handleTouchMoveDolly( event ) {
 
-			//console.log( 'handleTouchMoveRotate' );
-
 			var dx = event.touches[ 0 ].pageX - event.touches[ 1 ].pageX;
 			var dy = event.touches[ 0 ].pageY - event.touches[ 1 ].pageY;
 
@@ -50137,15 +51904,13 @@ var Spacekit = (function (exports) {
 
 			dollyDelta.set( 0, Math.pow( dollyEnd.y / dollyStart.y, scope.zoomSpeed ) );
 
-			dollyIn( dollyDelta.y );
+			dollyOut( dollyDelta.y );
 
 			dollyStart.copy( dollyEnd );
 
 		}
 
 		function handleTouchMoveDollyPan( event ) {
-
-			//console.log( 'handleTouchMoveDollyPan' );
 
 			if ( scope.enableZoom ) handleTouchMoveDolly( event );
 
@@ -50154,8 +51919,6 @@ var Spacekit = (function (exports) {
 		}
 
 		function handleTouchMoveDollyRotate( event ) {
-
-			//console.log( 'handleTouchMoveDollyPan' );
 
 			if ( scope.enableZoom ) handleTouchMoveDolly( event );
 
@@ -50172,7 +51935,6 @@ var Spacekit = (function (exports) {
 			if ( scope.enabled === false ) return;
 
 			// Prevent the browser from scrolling.
-
 			event.preventDefault();
 
 			// Manually set the focus since calling preventDefault above
@@ -50180,119 +51942,90 @@ var Spacekit = (function (exports) {
 
 			scope.domElement.focus ? scope.domElement.focus() : window.focus();
 
+			var mouseAction;
+
 			switch ( event.button ) {
 
 				case 0:
 
-					switch ( scope.mouseButtons.LEFT ) {
-
-						case MOUSE.ROTATE:
-
-							if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
-
-								if ( scope.enablePan === false ) return;
-
-								handleMouseDownPan( event );
-
-								state = STATE.PAN;
-
-							} else {
-
-								if ( scope.enableRotate === false ) return;
-
-								handleMouseDownRotate( event );
-
-								state = STATE.ROTATE;
-
-							}
-
-							break;
-
-						case MOUSE.PAN:
-
-							if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
-
-								if ( scope.enableRotate === false ) return;
-
-								handleMouseDownRotate( event );
-
-								state = STATE.ROTATE;
-
-							} else {
-
-								if ( scope.enablePan === false ) return;
-
-								handleMouseDownPan( event );
-
-								state = STATE.PAN;
-
-							}
-
-							break;
-
-						default:
-
-							state = STATE.NONE;
-
-					}
-
+					mouseAction = scope.mouseButtons.LEFT;
 					break;
-
 
 				case 1:
 
-					switch ( scope.mouseButtons.MIDDLE ) {
-
-						case MOUSE.DOLLY:
-
-							if ( scope.enableZoom === false ) return;
-
-							handleMouseDownDolly( event );
-
-							state = STATE.DOLLY;
-
-							break;
-
-
-						default:
-
-							state = STATE.NONE;
-
-					}
-
+					mouseAction = scope.mouseButtons.MIDDLE;
 					break;
 
 				case 2:
 
-					switch ( scope.mouseButtons.RIGHT ) {
+					mouseAction = scope.mouseButtons.RIGHT;
+					break;
 
-						case MOUSE.ROTATE:
+				default:
 
-							if ( scope.enableRotate === false ) return;
+					mouseAction = - 1;
 
-							handleMouseDownRotate( event );
+			}
 
-							state = STATE.ROTATE;
+			switch ( mouseAction ) {
 
-							break;
+				case MOUSE.DOLLY:
 
-						case MOUSE.PAN:
+					if ( scope.enableZoom === false ) return;
 
-							if ( scope.enablePan === false ) return;
+					handleMouseDownDolly( event );
 
-							handleMouseDownPan( event );
+					state = STATE.DOLLY;
 
-							state = STATE.PAN;
+					break;
 
-							break;
+				case MOUSE.ROTATE:
 
-						default:
+					if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
 
-							state = STATE.NONE;
+						if ( scope.enablePan === false ) return;
+
+						handleMouseDownPan( event );
+
+						state = STATE.PAN;
+
+					} else {
+
+						if ( scope.enableRotate === false ) return;
+
+						handleMouseDownRotate( event );
+
+						state = STATE.ROTATE;
 
 					}
 
 					break;
+
+				case MOUSE.PAN:
+
+					if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+
+						if ( scope.enableRotate === false ) return;
+
+						handleMouseDownRotate( event );
+
+						state = STATE.ROTATE;
+
+					} else {
+
+						if ( scope.enablePan === false ) return;
+
+						handleMouseDownPan( event );
+
+						state = STATE.PAN;
+
+					}
+
+					break;
+
+				default:
+
+					state = STATE.NONE;
 
 			}
 
@@ -50383,7 +52116,7 @@ var Spacekit = (function (exports) {
 
 			if ( scope.enabled === false ) return;
 
-			event.preventDefault();
+			event.preventDefault(); // prevent scrolling
 
 			switch ( event.touches.length ) {
 
@@ -50469,7 +52202,7 @@ var Spacekit = (function (exports) {
 
 			if ( scope.enabled === false ) return;
 
-			event.preventDefault();
+			event.preventDefault(); // prevent scrolling
 			event.stopPropagation();
 
 			switch ( state ) {
@@ -50551,7 +52284,15 @@ var Spacekit = (function (exports) {
 		scope.domElement.addEventListener( 'touchend', onTouchEnd, false );
 		scope.domElement.addEventListener( 'touchmove', onTouchMove, false );
 
-		window.addEventListener( 'keydown', onKeyDown, false );
+		scope.domElement.addEventListener( 'keydown', onKeyDown, false );
+
+		// make sure element can receive keys.
+
+		if ( scope.domElement.tabIndex === - 1 ) {
+
+			scope.domElement.tabIndex = 0;
+
+		}
 
 		// force an update at start
 
@@ -50562,130 +52303,6 @@ var Spacekit = (function (exports) {
 	OrbitControls.prototype = Object.create( EventDispatcher.prototype );
 	OrbitControls.prototype.constructor = OrbitControls;
 
-	Object.defineProperties( OrbitControls.prototype, {
-
-		center: {
-
-			get: function () {
-
-				console.warn( 'THREE.OrbitControls: .center has been renamed to .target' );
-				return this.target;
-
-			}
-
-		},
-
-		// backward compatibility
-
-		noZoom: {
-
-			get: function () {
-
-				console.warn( 'THREE.OrbitControls: .noZoom has been deprecated. Use .enableZoom instead.' );
-				return ! this.enableZoom;
-
-			},
-
-			set: function ( value ) {
-
-				console.warn( 'THREE.OrbitControls: .noZoom has been deprecated. Use .enableZoom instead.' );
-				this.enableZoom = ! value;
-
-			}
-
-		},
-
-		noRotate: {
-
-			get: function () {
-
-				console.warn( 'THREE.OrbitControls: .noRotate has been deprecated. Use .enableRotate instead.' );
-				return ! this.enableRotate;
-
-			},
-
-			set: function ( value ) {
-
-				console.warn( 'THREE.OrbitControls: .noRotate has been deprecated. Use .enableRotate instead.' );
-				this.enableRotate = ! value;
-
-			}
-
-		},
-
-		noPan: {
-
-			get: function () {
-
-				console.warn( 'THREE.OrbitControls: .noPan has been deprecated. Use .enablePan instead.' );
-				return ! this.enablePan;
-
-			},
-
-			set: function ( value ) {
-
-				console.warn( 'THREE.OrbitControls: .noPan has been deprecated. Use .enablePan instead.' );
-				this.enablePan = ! value;
-
-			}
-
-		},
-
-		noKeys: {
-
-			get: function () {
-
-				console.warn( 'THREE.OrbitControls: .noKeys has been deprecated. Use .enableKeys instead.' );
-				return ! this.enableKeys;
-
-			},
-
-			set: function ( value ) {
-
-				console.warn( 'THREE.OrbitControls: .noKeys has been deprecated. Use .enableKeys instead.' );
-				this.enableKeys = ! value;
-
-			}
-
-		},
-
-		staticMoving: {
-
-			get: function () {
-
-				console.warn( 'THREE.OrbitControls: .staticMoving has been deprecated. Use .enableDamping instead.' );
-				return ! this.enableDamping;
-
-			},
-
-			set: function ( value ) {
-
-				console.warn( 'THREE.OrbitControls: .staticMoving has been deprecated. Use .enableDamping instead.' );
-				this.enableDamping = ! value;
-
-			}
-
-		},
-
-		dynamicDampingFactor: {
-
-			get: function () {
-
-				console.warn( 'THREE.OrbitControls: .dynamicDampingFactor has been renamed. Use .dampingFactor instead.' );
-				return this.dampingFactor;
-
-			},
-
-			set: function ( value ) {
-
-				console.warn( 'THREE.OrbitControls: .dynamicDampingFactor has been renamed. Use .dampingFactor instead.' );
-				this.dampingFactor = value;
-
-			}
-
-		}
-
-	} );
 
 	// This set of controls performs orbiting, dollying (zooming), and panning.
 	// Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).
@@ -51701,6 +53318,13 @@ var Spacekit = (function (exports) {
 	    this._ellipsePoints = null;
 
 	    /**
+	     * Cached ecliptic drop lines.
+	     * @type {Array.<THREE.Vector3>}
+	     */
+	    this._eclipticDropLines = null;
+
+
+	    /**
 	     * Cached ellipse.
 	     * @type {THREE.Line}
 	     */
@@ -52050,6 +53674,10 @@ var Spacekit = (function (exports) {
 	   * @return {THREE.Geometry} A geometry with many line segments.
 	   */
 	  getLinesToEcliptic() {
+	    if (this._eclipticDropLines) {
+	      return this._eclipticDropLines;
+	    }
+
 	    const points = this.getEllipsePoints();
 	    const geometry = new Geometry();
 
@@ -52058,13 +53686,15 @@ var Spacekit = (function (exports) {
 	      geometry.vertices.push(new Vector3(vertex.x, vertex.y, 0));
 	    });
 
-	    return new LineSegments(
+	    this._eclipticDropLines = new LineSegments(
 	      geometry,
 	      new LineBasicMaterial({
 	        color: this._options.eclipticLineColor || 0x333333,
 	      }),
 	      LineStrip,
 	    );
+
+	    return this._eclipticDropLines;
 	  }
 
 	  /**
@@ -52272,14 +53902,15 @@ var Spacekit = (function (exports) {
 	};
 
 	/**
-	 * postprocessing v6.8.0 build Tue Oct 01 2019
+	 * postprocessing v6.13.5 build Wed May 06 2020
 	 * https://github.com/vanruesc/postprocessing
-	 * Copyright 2019 Raoul van Rüschen, Zlib
+	 * Copyright 2020 Raoul van Rüschen
+	 * @license Zlib
 	 */
 
 	var vertexShader = "varying vec2 vUv;void main(){vUv=position.xy*0.5+0.5;gl_Position=vec4(position.xy,1.0,1.0);}";
 
-	var fragmentShader$2 = "#include <common>\n#include <dithering_pars_fragment>\nuniform sampler2D inputBuffer;varying vec2 vUv0;varying vec2 vUv1;varying vec2 vUv2;varying vec2 vUv3;void main(){vec4 sum=texture2D(inputBuffer,vUv0);sum+=texture2D(inputBuffer,vUv1);sum+=texture2D(inputBuffer,vUv2);sum+=texture2D(inputBuffer,vUv3);gl_FragColor=sum*0.25;\n#include <dithering_fragment>\n}";
+	var fragmentShader$3 = "#include <common>\n#include <dithering_pars_fragment>\nuniform sampler2D inputBuffer;varying vec2 vUv0;varying vec2 vUv1;varying vec2 vUv2;varying vec2 vUv3;void main(){vec4 sum=texture2D(inputBuffer,vUv0);sum+=texture2D(inputBuffer,vUv1);sum+=texture2D(inputBuffer,vUv2);sum+=texture2D(inputBuffer,vUv3);gl_FragColor=sum*0.25;\n#include <dithering_fragment>\n}";
 
 	var vertexShader$2 = "uniform vec2 texelSize;uniform vec2 halfTexelSize;uniform float kernel;uniform float scale;/*Packing multiple texture coordinates into one varying and using a swizzle toextract them in the fragment shader still causes a dependent texture read.*/varying vec2 vUv0;varying vec2 vUv1;varying vec2 vUv2;varying vec2 vUv3;void main(){vec2 uv=position.xy*0.5+0.5;vec2 dUv=(texelSize*vec2(kernel)+halfTexelSize)*scale;vUv0=vec2(uv.x-dUv.x,uv.y+dUv.y);vUv1=vec2(uv.x+dUv.x,uv.y+dUv.y);vUv2=vec2(uv.x+dUv.x,uv.y-dUv.y);vUv3=vec2(uv.x-dUv.x,uv.y-dUv.y);gl_Position=vec4(position.xy,1.0,1.0);}";
 
@@ -52295,6 +53926,8 @@ var Spacekit = (function (exports) {
 	 *
 	 * Further modified according to Apple's
 	 * [Best Practices for Shaders](https://goo.gl/lmRoM5).
+	 *
+	 * @todo Remove dithering code from fragment shader.
 	 */
 
 	class ConvolutionMaterial extends ShaderMaterial {
@@ -52312,22 +53945,23 @@ var Spacekit = (function (exports) {
 				type: "ConvolutionMaterial",
 
 				uniforms: {
-
 					inputBuffer: new Uniform(null),
 					texelSize: new Uniform(new Vector2()),
 					halfTexelSize: new Uniform(new Vector2()),
 					kernel: new Uniform(0.0),
 					scale: new Uniform(1.0)
-
 				},
 
-				fragmentShader: fragmentShader$2,
+				fragmentShader: fragmentShader$3,
 				vertexShader: vertexShader$2,
 
 				depthWrite: false,
 				depthTest: false
 
 			});
+
+			/** @ignore */
+			this.toneMapped = false;
 
 			this.setTexelSize(texelSize.x, texelSize.y);
 
@@ -52408,7 +54042,7 @@ var Spacekit = (function (exports) {
 
 	};
 
-	var fragmentShader$3 = "uniform sampler2D inputBuffer;uniform float opacity;varying vec2 vUv;void main(){vec4 texel=texture2D(inputBuffer,vUv);gl_FragColor=opacity*texel;}";
+	var fragmentShader$4 = "uniform sampler2D inputBuffer;uniform float opacity;varying vec2 vUv;void main(){vec4 texel=texture2D(inputBuffer,vUv);gl_FragColor=opacity*texel;\n#include <encodings_fragment>\n}";
 
 	/**
 	 * A simple copy shader material.
@@ -52427,13 +54061,11 @@ var Spacekit = (function (exports) {
 				type: "CopyMaterial",
 
 				uniforms: {
-
 					inputBuffer: new Uniform(null),
 					opacity: new Uniform(1.0)
-
 				},
 
-				fragmentShader: fragmentShader$3,
+				fragmentShader: fragmentShader$4,
 				vertexShader,
 
 				depthWrite: false,
@@ -52441,11 +54073,14 @@ var Spacekit = (function (exports) {
 
 			});
 
+			/** @ignore */
+			this.toneMapped = false;
+
 		}
 
 	}
 
-	var fragmentTemplate = "#include <common>\n#include <packing>\n#include <dithering_pars_fragment>\nuniform sampler2D inputBuffer;uniform sampler2D depthBuffer;uniform vec2 resolution;uniform vec2 texelSize;uniform float cameraNear;uniform float cameraFar;uniform float aspect;uniform float time;varying vec2 vUv;float readDepth(const in vec2 uv){\n#if DEPTH_PACKING == 3201\nreturn unpackRGBAToDepth(texture2D(depthBuffer,uv));\n#else\nreturn texture2D(depthBuffer,uv).r;\n#endif\n}FRAGMENT_HEADvoid main(){FRAGMENT_MAIN_UVvec4 color0=texture2D(inputBuffer,UV);vec4 color1=vec4(0.0);FRAGMENT_MAIN_IMAGEgl_FragColor=color0;\n#include <dithering_fragment>\n}";
+	var fragmentTemplate = "#include <common>\n#include <packing>\n#include <dithering_pars_fragment>\nuniform sampler2D inputBuffer;\n#ifdef GL_FRAGMENT_PRECISION_HIGH\nuniform highp sampler2D depthBuffer;\n#else\nuniform mediump sampler2D depthBuffer;\n#endif\nuniform vec2 resolution;uniform vec2 texelSize;uniform float cameraNear;uniform float cameraFar;uniform float aspect;uniform float time;varying vec2 vUv;float readDepth(const in vec2 uv){\n#if DEPTH_PACKING == 3201\nreturn unpackRGBAToDepth(texture2D(depthBuffer,uv));\n#else\nreturn texture2D(depthBuffer,uv).r;\n#endif\n}float getViewZ(const in float depth){\n#ifdef PERSPECTIVE_CAMERA\nreturn perspectiveDepthToViewZ(depth,cameraNear,cameraFar);\n#else\nreturn orthographicDepthToViewZ(depth,cameraNear,cameraFar);\n#endif\n}FRAGMENT_HEADvoid main(){FRAGMENT_MAIN_UVvec4 color0=texture2D(inputBuffer,UV);vec4 color1=vec4(0.0);FRAGMENT_MAIN_IMAGEgl_FragColor=color0;\n#ifdef ENCODE_OUTPUT\n#include <encodings_fragment>\n#endif\n#include <dithering_fragment>\n}";
 
 	var vertexTemplate = "uniform vec2 resolution;uniform vec2 texelSize;uniform float cameraNear;uniform float cameraFar;uniform float aspect;uniform float time;varying vec2 vUv;VERTEX_HEADvoid main(){vUv=position.xy*0.5+0.5;VERTEX_MAIN_SUPPORTgl_Position=vec4(position.xy,1.0,1.0);}";
 
@@ -52462,70 +54097,59 @@ var Spacekit = (function (exports) {
 		/**
 		 * Constructs a new effect material.
 		 *
-		 * @param {Map<String, String>} shaderParts - A collection of shader snippets.
-		 * @param {Map<String, String>} defines - A collection of preprocessor macro definitions.
-		 * @param {Map<String, Uniform>} uniforms - A collection of uniforms.
+		 * @param {Map<String, String>} [shaderParts=null] - A collection of shader snippets. See {@link Section}.
+		 * @param {Map<String, String>} [defines=null] - A collection of preprocessor macro definitions.
+		 * @param {Map<String, Uniform>} [uniforms=null] - A collection of uniforms.
 		 * @param {Camera} [camera=null] - A camera.
 		 * @param {Boolean} [dithering=false] - Whether dithering should be enabled.
 		 */
 
-		constructor(shaderParts, defines, uniforms, camera = null, dithering = false) {
+		constructor(shaderParts = null, defines = null, uniforms = null, camera = null, dithering = false) {
 
 			super({
 
 				type: "EffectMaterial",
 
 				defines: {
-
-					DEPTH_PACKING: "0"
-
+					DEPTH_PACKING: "0",
+					ENCODE_OUTPUT: "1"
 				},
 
 				uniforms: {
-
 					inputBuffer: new Uniform(null),
 					depthBuffer: new Uniform(null),
-
 					resolution: new Uniform(new Vector2()),
 					texelSize: new Uniform(new Vector2()),
-
 					cameraNear: new Uniform(0.3),
 					cameraFar: new Uniform(1000.0),
 					aspect: new Uniform(1.0),
 					time: new Uniform(0.0)
-
 				},
 
-				fragmentShader: fragmentTemplate.replace(Section.FRAGMENT_HEAD, shaderParts.get(Section.FRAGMENT_HEAD))
-					.replace(Section.FRAGMENT_MAIN_UV, shaderParts.get(Section.FRAGMENT_MAIN_UV))
-					.replace(Section.FRAGMENT_MAIN_IMAGE, shaderParts.get(Section.FRAGMENT_MAIN_IMAGE)),
-
-				vertexShader: vertexTemplate.replace(Section.VERTEX_HEAD, shaderParts.get(Section.VERTEX_HEAD))
-					.replace(Section.VERTEX_MAIN_SUPPORT, shaderParts.get(Section.VERTEX_MAIN_SUPPORT)),
-
-				dithering: dithering,
 				depthWrite: false,
-				depthTest: false
+				depthTest: false,
+				dithering
 
 			});
 
+			/** @ignore */
+			this.toneMapped = false;
+
+			if(shaderParts !== null) {
+
+				this.setShaderParts(shaderParts);
+
+			}
+
 			if(defines !== null) {
 
-				for(const entry of defines.entries()) {
-
-					this.defines[entry[0]] = entry[1];
-
-				}
+				this.setDefines(defines);
 
 			}
 
 			if(uniforms !== null) {
 
-				for(const entry of uniforms.entries()) {
-
-					this.uniforms[entry[0]] = entry[1];
-
-				}
+				this.setUniforms(uniforms);
 
 			}
 
@@ -52541,7 +54165,7 @@ var Spacekit = (function (exports) {
 
 		get depthPacking() {
 
-			return Number.parseInt(this.defines.DEPTH_PACKING);
+			return Number(this.defines.DEPTH_PACKING);
 
 		}
 
@@ -52551,32 +54175,77 @@ var Spacekit = (function (exports) {
 		 * Use `BasicDepthPacking` or `RGBADepthPacking` if your depth texture
 		 * contains packed depth.
 		 *
-		 * You'll need to call {@link EffectPass#recompile} after changing this value.
-		 *
 		 * @type {Number}
 		 */
 
 		set depthPacking(value) {
 
 			this.defines.DEPTH_PACKING = value.toFixed(0);
+			this.needsUpdate = true;
 
 		}
 
 		/**
-		 * Sets the resolution.
+		 * Sets the shader parts.
 		 *
-		 * @param {Number} width - The width.
-		 * @param {Number} height - The height.
+		 * @param {Map<String, String>} shaderParts - A collection of shader snippets. See {@link Section}.
+		 * @return {EffectMaterial} This material.
 		 */
 
-		setSize(width, height) {
+		setShaderParts(shaderParts) {
 
-			width = Math.max(width, 1.0);
-			height = Math.max(height, 1.0);
+			this.fragmentShader = fragmentTemplate
+				.replace(Section.FRAGMENT_HEAD, shaderParts.get(Section.FRAGMENT_HEAD))
+				.replace(Section.FRAGMENT_MAIN_UV, shaderParts.get(Section.FRAGMENT_MAIN_UV))
+				.replace(Section.FRAGMENT_MAIN_IMAGE, shaderParts.get(Section.FRAGMENT_MAIN_IMAGE));
 
-			this.uniforms.resolution.value.set(width, height);
-			this.uniforms.texelSize.value.set(1.0 / width, 1.0 / height);
-			this.uniforms.aspect.value = width / height;
+			this.vertexShader = vertexTemplate
+				.replace(Section.VERTEX_HEAD, shaderParts.get(Section.VERTEX_HEAD))
+				.replace(Section.VERTEX_MAIN_SUPPORT, shaderParts.get(Section.VERTEX_MAIN_SUPPORT));
+
+			this.needsUpdate = true;
+
+			return this;
+
+		}
+
+		/**
+		 * Sets the shader macros.
+		 *
+		 * @param {Map<String, String>} defines - A collection of preprocessor macro definitions.
+		 * @return {EffectMaterial} This material.
+		 */
+
+		setDefines(defines) {
+
+			for(const entry of defines.entries()) {
+
+				this.defines[entry[0]] = entry[1];
+
+			}
+
+			this.needsUpdate = true;
+
+			return this;
+
+		}
+
+		/**
+		 * Sets the shader uniforms.
+		 *
+		 * @param {Map<String, Uniform>} uniforms - A collection of uniforms.
+		 * @return {EffectMaterial} This material.
+		 */
+
+		setUniforms(uniforms) {
+
+			for(const entry of uniforms.entries()) {
+
+				this.uniforms[entry[0]] = entry[1];
+
+			}
+
+			return this;
 
 		}
 
@@ -52603,7 +54272,27 @@ var Spacekit = (function (exports) {
 
 				}
 
+				this.needsUpdate = true;
+
 			}
+
+		}
+
+		/**
+		 * Sets the resolution.
+		 *
+		 * @param {Number} width - The width.
+		 * @param {Number} height - The height.
+		 */
+
+		setSize(width, height) {
+
+			width = Math.max(width, 1.0);
+			height = Math.max(height, 1.0);
+
+			this.uniforms.resolution.value.set(width, height);
+			this.uniforms.texelSize.value.set(1.0 / width, 1.0 / height);
+			this.uniforms.aspect.value = width / height;
 
 		}
 
@@ -52630,7 +54319,7 @@ var Spacekit = (function (exports) {
 
 	};
 
-	var fragmentShader$7 = "#include <common>\nuniform sampler2D inputBuffer;\n#ifdef RANGE\nuniform vec2 range;\n#elif defined(THRESHOLD)\nuniform float threshold;uniform float smoothing;\n#endif\nvarying vec2 vUv;void main(){vec4 texel=texture2D(inputBuffer,vUv);float l=linearToRelativeLuminance(texel.rgb);\n#ifdef RANGE\nfloat low=step(range.x,l);float high=step(l,range.y);l*=low*high;\n#elif defined(THRESHOLD)\nl=smoothstep(threshold,threshold+smoothing,l);\n#endif\n#ifdef COLOR\ngl_FragColor=vec4(texel.rgb*l,l);\n#else\ngl_FragColor=vec4(l);\n#endif\n}";
+	var fragmentShader$8 = "#include <common>\nuniform sampler2D inputBuffer;\n#ifdef RANGE\nuniform vec2 range;\n#elif defined(THRESHOLD)\nuniform float threshold;uniform float smoothing;\n#endif\nvarying vec2 vUv;void main(){vec4 texel=texture2D(inputBuffer,vUv);float l=linearToRelativeLuminance(texel.rgb);\n#ifdef RANGE\nfloat low=step(range.x,l);float high=step(l,range.y);l*=low*high;\n#elif defined(THRESHOLD)\nl=smoothstep(threshold,threshold+smoothing,l);\n#endif\n#ifdef COLOR\ngl_FragColor=vec4(texel.rgb*l,l);\n#else\ngl_FragColor=vec4(l);\n#endif\n}";
 
 	/**
 	 * A luminance shader material.
@@ -52670,21 +54359,22 @@ var Spacekit = (function (exports) {
 				type: "LuminanceMaterial",
 
 				uniforms: {
-
 					inputBuffer: new Uniform(null),
 					threshold: new Uniform(0.0),
 					smoothing: new Uniform(1.0),
 					range: new Uniform(useRange ? luminanceRange : new Vector2())
-
 				},
 
-				fragmentShader: fragmentShader$7,
+				fragmentShader: fragmentShader$8,
 				vertexShader,
 
 				depthWrite: false,
 				depthTest: false
 
 			});
+
+			/** @ignore */
+			this.toneMapped = false;
 
 			this.colorOutput = colorOutput;
 			this.useThreshold = true;
@@ -52881,13 +54571,206 @@ var Spacekit = (function (exports) {
 	}
 
 	/**
+	 * An auto sizing constant.
+	 *
+	 * @type {Number}
+	 * @private
+	 */
+
+	const AUTO_SIZE = -1;
+
+	/**
+	 * A resizer.
+	 */
+
+	class Resizer {
+
+		/**
+		 * Constructs a new resizer.
+		 *
+		 * @param {Resizable} resizeable - A resizable object.
+		 * @param {Number} [width=Resizer.AUTO_SIZE] - The width.
+		 * @param {Number} [height=Resizer.AUTO_SIZE] - The height.
+		 */
+
+		constructor(resizable, width = AUTO_SIZE, height = AUTO_SIZE) {
+
+			/**
+			 * A resizable object.
+			 *
+			 * @type {Resizable}
+			 */
+
+			this.resizable = resizable;
+
+			/**
+			 * The base size.
+			 *
+			 * This size will be passed to the resizable object every time the width or
+			 * height is changed.
+			 *
+			 * @type {Vector2}
+			 */
+
+			this.base = new Vector2(1, 1);
+
+			/**
+			 * The target size.
+			 *
+			 * @type {Vector2}
+			 * @private
+			 */
+
+			this.target = new Vector2(width, height);
+
+			/**
+			 * A scale.
+			 *
+			 * If both the width and the height are set to {@link Resizer.AUTO_SIZE},
+			 * they will be scaled uniformly using this scalar.
+			 *
+			 * @type {Number}
+			 * @deprecated Added for internal use only.
+			 */
+
+			this.scale = 1.0;
+
+		}
+
+		/**
+		 * The calculated width.
+		 *
+		 * If both the width and the height are set to {@link Resizer.AUTO_SIZE}, the
+		 * base width will be returned.
+		 *
+		 * @type {Number}
+		 */
+
+		get width() {
+
+			const base = this.base;
+			const target = this.target;
+
+			let result;
+
+			if(target.x !== AUTO_SIZE) {
+
+				result = target.x;
+
+			} else if(target.y !== AUTO_SIZE) {
+
+				result = Math.round(target.y * (base.x / base.y));
+
+			} else {
+
+				result = Math.round(base.x * this.scale);
+
+			}
+
+			return result;
+
+		}
+
+		/**
+		 * Sets the target width.
+		 *
+		 * Use {@link Resizer.AUTO_SIZE} to automatically calculate the width based
+		 * on the height and the original aspect ratio.
+		 *
+		 * @type {Number}
+		 */
+
+		set width(value) {
+
+			this.target.x = value;
+			this.resizable.setSize(this.base.x, this.base.y);
+
+		}
+
+		/**
+		 * The calculated height.
+		 *
+		 * If both the width and the height are set to {@link Resizer.AUTO_SIZE}, the
+		 * base height will be returned.
+		 *
+		 * @type {Number}
+		 */
+
+		get height() {
+
+			const base = this.base;
+			const target = this.target;
+
+			let result;
+
+			if(target.y !== AUTO_SIZE) {
+
+				result = target.y;
+
+			} else if(target.x !== AUTO_SIZE) {
+
+				result = Math.round(target.x / (base.x / base.y));
+
+			} else {
+
+				result = Math.round(base.y * this.scale);
+
+			}
+
+			return result;
+
+		}
+
+		/**
+		 * Sets the target height.
+		 *
+		 * Use {@link Resizer.AUTO_SIZE} to automatically calculate the height based
+		 * on the width and the original aspect ratio.
+		 *
+		 * @type {Number}
+		 */
+
+		set height(value) {
+
+			this.target.y = value;
+			this.resizable.setSize(this.base.x, this.base.y);
+
+		}
+
+		/**
+		 * An auto sizing constant.
+		 *
+		 * Can be used to automatically calculate the width or height based on the
+		 * original aspect ratio.
+		 *
+		 * @type {Number}
+		 */
+
+		static get AUTO_SIZE() {
+
+			return AUTO_SIZE;
+
+		}
+
+	}
+
+	/**
+	 * A dummy camera
+	 *
+	 * @type {Camera}
+	 * @private
+	 */
+
+	const dummyCamera = new Camera();
+
+	/**
 	 * Shared fullscreen geometry.
 	 *
 	 * @type {BufferGeometry}
 	 * @private
 	 */
 
-	let geometry$1 = null;
+	let geometry = null;
 
 	/**
 	 * Returns a shared fullscreen triangle.
@@ -52901,17 +54784,28 @@ var Spacekit = (function (exports) {
 
 	function getFullscreenTriangle() {
 
-		if(geometry$1 === null) {
+		if(geometry === null) {
 
 			const vertices = new Float32Array([-1, -1, 0, 3, -1, 0, -1, 3, 0]);
 			const uvs = new Float32Array([0, 0, 2, 0, 0, 2]);
-			geometry$1 = new BufferGeometry();
-			geometry$1.addAttribute("position", new BufferAttribute(vertices, 3));
-			geometry$1.addAttribute("uv", new BufferAttribute(uvs, 2));
+			geometry = new BufferGeometry();
+
+			// Added for backward compatibility (setAttribute was added in three r110).
+			if(geometry.setAttribute !== undefined) {
+
+				geometry.setAttribute("position", new BufferAttribute(vertices, 3));
+				geometry.setAttribute("uv", new BufferAttribute(uvs, 2));
+
+			} else {
+
+				geometry.addAttribute("position", new BufferAttribute(vertices, 3));
+				geometry.addAttribute("uv", new BufferAttribute(uvs, 2));
+
+			}
 
 		}
 
-		return geometry$1;
+		return geometry;
 
 	}
 
@@ -52936,10 +54830,10 @@ var Spacekit = (function (exports) {
 		 *
 		 * @param {String} [name] - The name of this pass. Does not have to be unique.
 		 * @param {Scene} [scene] - The scene to render. The default scene contains a single mesh that fills the screen.
-		 * @param {Camera} [camera] - The camera. The default camera perfectly captures the screen mesh.
+		 * @param {Camera} [camera] - A camera. Fullscreen effect passes don't require a camera.
 		 */
 
-		constructor(name = "Pass", scene = new Scene(), camera = new OrthographicCamera(-1, 1, 1, -1, 0, 1)) {
+		constructor(name = "Pass", scene = new Scene(), camera = dummyCamera) {
 
 			/**
 			 * The name of this pass.
@@ -52977,6 +54871,15 @@ var Spacekit = (function (exports) {
 			this.screen = null;
 
 			/**
+			 * Indicates whether this pass should render to texture.
+			 *
+			 * @type {Boolean}
+			 * @private
+			 */
+
+			this.rtt = true;
+
+			/**
 			 * Only relevant for subclassing.
 			 *
 			 * Indicates whether the {@link EffectComposer} should swap the frame
@@ -52991,8 +54894,6 @@ var Spacekit = (function (exports) {
 			this.needsSwap = true;
 
 			/**
-			 * Only relevant for subclassing.
-			 *
 			 * Indicates whether the {@link EffectComposer} should prepare a depth
 			 * texture for this pass.
 			 *
@@ -53005,20 +54906,51 @@ var Spacekit = (function (exports) {
 			this.needsDepthTexture = false;
 
 			/**
-			 * Indicates whether this pass should render to screen.
-			 *
-			 * @type {Boolean}
-			 */
-
-			this.renderToScreen = false;
-
-			/**
 			 * Indicates whether this pass should be executed.
 			 *
 			 * @type {Boolean}
 			 */
 
 			this.enabled = true;
+
+		}
+
+		/**
+		 * Indicates whether this pass should render to screen.
+		 *
+		 * @type {Boolean}
+		 */
+
+		get renderToScreen() {
+
+			return !this.rtt;
+
+		}
+
+		/**
+		 * Sets the render to screen flag.
+		 *
+		 * If the flag is changed to a different value, the fullscreen material will
+		 * be updated as well.
+		 *
+		 * @type {Boolean}
+		 */
+
+		set renderToScreen(value) {
+
+			if(this.rtt === value) {
+
+				const material = this.getFullscreenMaterial();
+
+				if(material !== null) {
+
+					material.needsUpdate = true;
+
+				}
+
+				this.rtt = !value;
+
+			}
 
 		}
 
@@ -53145,10 +55077,11 @@ var Spacekit = (function (exports) {
 		 *
 		 * @param {WebGLRenderer} renderer - The renderer.
 		 * @param {Boolean} alpha - Whether the renderer uses the alpha channel or not.
-		 * @example if(!alpha) { this.myRenderTarget.texture.format = RGBFormat; }
+		 * @param {Number} frameBufferType - The type of the main frame buffers.
+		 * @example if(!alpha && frameBufferType === UnsignedByteType) { this.myRenderTarget.texture.format = RGBFormat; }
 		 */
 
-		initialize(renderer, alpha) {}
+		initialize(renderer, alpha, frameBufferType) {}
 
 		/**
 		 * Performs a shallow search for disposable properties and deletes them. The
@@ -53190,15 +55123,6 @@ var Spacekit = (function (exports) {
 	}
 
 	/**
-	 * An auto sizing constant.
-	 *
-	 * @type {Number}
-	 * @private
-	 */
-
-	const AUTO_SIZE = -1;
-
-	/**
 	 * An efficient, incremental blur pass.
 	 */
 
@@ -53209,15 +55133,15 @@ var Spacekit = (function (exports) {
 		 *
 		 * @param {Object} [options] - The options.
 		 * @param {Number} [options.resolutionScale=0.5] - Deprecated. Adjust the height or width instead for consistent results.
-		 * @param {Number} [options.width=BlurPass.AUTO_SIZE] - The blur render width.
-		 * @param {Number} [options.height=BlurPass.AUTO_SIZE] - The blur render height.
+		 * @param {Number} [options.width=Resizer.AUTO_SIZE] - The blur render width.
+		 * @param {Number} [options.height=Resizer.AUTO_SIZE] - The blur render height.
 		 * @param {KernelSize} [options.kernelSize=KernelSize.LARGE] - The blur kernel size.
 		 */
 
 		constructor({
 			resolutionScale = 0.5,
-			width = AUTO_SIZE,
-			height = AUTO_SIZE,
+			width = Resizer.AUTO_SIZE,
+			height = Resizer.AUTO_SIZE,
 			kernelSize = KernelSize.LARGE
 		} = {}) {
 
@@ -53230,14 +55154,14 @@ var Spacekit = (function (exports) {
 			 * @private
 			 */
 
-			this.renderTargetX = new WebGLRenderTarget(1, 1, {
+			this.renderTargetA = new WebGLRenderTarget(1, 1, {
 				minFilter: LinearFilter,
 				magFilter: LinearFilter,
 				stencilBuffer: false,
 				depthBuffer: false
 			});
 
-			this.renderTargetX.texture.name = "Blur.TargetX";
+			this.renderTargetA.texture.name = "Blur.Target.A";
 
 			/**
 			 * A second render target.
@@ -53246,36 +55170,23 @@ var Spacekit = (function (exports) {
 			 * @private
 			 */
 
-			this.renderTargetY = this.renderTargetX.clone();
-			this.renderTargetY.texture.name = "Blur.TargetY";
+			this.renderTargetB = this.renderTargetA.clone();
+			this.renderTargetB.texture.name = "Blur.Target.B";
 
 			/**
-			 * The current main render size.
+			 * The desired render resolution.
 			 *
-			 * @type {Vector2}
-			 * @private
+			 * It's recommended to set the height or the width to an absolute value for
+			 * consistent results across different devices and resolutions.
+			 *
+			 * Use {@link Resizer.AUTO_SIZE} for the width or height to automatically
+			 * calculate it based on its counterpart and the original aspect ratio.
+			 *
+			 * @type {Resizer}
 			 */
 
-			this.originalSize = new Vector2();
-
-			/**
-			 * The absolute render resolution.
-			 *
-			 * @type {Vector2}
-			 * @private
-			 */
-
-			this.resolution = new Vector2(width, height);
-
-			/**
-			 * The current resolution scale.
-			 *
-			 * @type {Number}
-			 * @private
-			 * @deprecated
-			 */
-
-			this.resolutionScale = resolutionScale;
+			this.resolution = new Resizer(this, width, height);
+			this.resolution.scale = resolutionScale;
 
 			/**
 			 * A convolution shader material.
@@ -53300,6 +55211,7 @@ var Spacekit = (function (exports) {
 			 * Whether the blurred result should also be dithered using noise.
 			 *
 			 * @type {Boolean}
+			 * @deprecated Set the frameBufferType of the EffectComposer to HalfFloatType instead.
 			 */
 
 			this.dithering = false;
@@ -53312,27 +55224,25 @@ var Spacekit = (function (exports) {
 		 * The current width of the internal render targets.
 		 *
 		 * @type {Number}
+		 * @deprecated Use resolution.width instead.
 		 */
 
 		get width() {
 
-			return this.renderTargetX.width;
+			return this.resolution.width;
 
 		}
 
 		/**
 		 * Sets the render width.
 		 *
-		 * Use {@link BlurPass.AUTO_SIZE} to activate automatic sizing based on the
-		 * render height and aspect ratio.
-		 *
 		 * @type {Number}
+		 * @deprecated Use resolution.width instead.
 		 */
 
 		set width(value) {
 
-			this.resolution.x = value;
-			this.setSize(this.originalSize.x, this.originalSize.y);
+			this.resolution.width = value;
 
 		}
 
@@ -53340,27 +55250,25 @@ var Spacekit = (function (exports) {
 		 * The current height of the internal render targets.
 		 *
 		 * @type {Number}
+		 * @deprecated Use resolution.height instead.
 		 */
 
 		get height() {
 
-			return this.renderTargetX.height;
+			return this.resolution.height;
 
 		}
 
 		/**
 		 * Sets the render height.
 		 *
-		 * Use {@link BlurPass.AUTO_SIZE} to activate automatic sizing based on the
-		 * render width and aspect ratio.
-		 *
 		 * @type {Number}
+		 * @deprecated Use resolution.height instead.
 		 */
 
 		set height(value) {
 
-			this.resolution.y = value;
-			this.setSize(this.originalSize.x, this.originalSize.y);
+			this.resolution.height = value;
 
 		}
 
@@ -53425,28 +55333,15 @@ var Spacekit = (function (exports) {
 		}
 
 		/**
-		 * Returns the original resolution.
-		 *
-		 * @return {Vector2} The original resolution received via {@link setSize}.
-		 * @deprecated Added for internal use only.
-		 */
-
-		getOriginalSize() {
-
-			return this.originalSize;
-
-		}
-
-		/**
 		 * Returns the current resolution scale.
 		 *
 		 * @return {Number} The resolution scale.
-		 * @deprecated Adjust the width or height instead.
+		 * @deprecated Adjust the fixed resolution width or height instead.
 		 */
 
 		getResolutionScale() {
 
-			return this.resolutionScale;
+			return this.resolution.scale;
 
 		}
 
@@ -53454,13 +55349,13 @@ var Spacekit = (function (exports) {
 		 * Sets the resolution scale.
 		 *
 		 * @param {Number} scale - The new resolution scale.
-		 * @deprecated Adjust the width or height instead.
+		 * @deprecated Adjust the fixed resolution width or height instead.
 		 */
 
 		setResolutionScale(scale) {
 
-			this.resolutionScale = scale;
-			this.setSize(this.originalSize.x, this.originalSize.y);
+			this.resolution.scale = scale;
+			this.setSize(this.resolution.base.x, this.resolution.base.y);
 
 		}
 
@@ -53480,8 +55375,8 @@ var Spacekit = (function (exports) {
 			const scene = this.scene;
 			const camera = this.camera;
 
-			const renderTargetX = this.renderTargetX;
-			const renderTargetY = this.renderTargetY;
+			const renderTargetA = this.renderTargetA;
+			const renderTargetB = this.renderTargetB;
 
 			let material = this.convolutionMaterial;
 			let uniforms = material.uniforms;
@@ -53497,7 +55392,7 @@ var Spacekit = (function (exports) {
 			for(i = 0, l = kernel.length - 1; i < l; ++i) {
 
 				// Alternate between targets.
-				destRT = ((i % 2) === 0) ? renderTargetX : renderTargetY;
+				destRT = ((i & 1) === 0) ? renderTargetA : renderTargetB;
 
 				uniforms.kernel.value = kernel[i];
 				uniforms.inputBuffer.value = lastRT.texture;
@@ -53533,34 +55428,13 @@ var Spacekit = (function (exports) {
 		setSize(width, height) {
 
 			const resolution = this.resolution;
-			const aspect = width / height;
+			resolution.base.set(width, height);
 
-			this.originalSize.set(width, height);
+			width = resolution.width;
+			height = resolution.height;
 
-			if(resolution.x !== AUTO_SIZE && resolution.y !== AUTO_SIZE) {
-
-				width = Math.max(1, resolution.x);
-				height = Math.max(1, resolution.y);
-
-			} else if(resolution.x !== AUTO_SIZE) {
-
-				width = Math.max(1, resolution.x);
-				height = Math.round(Math.max(1, resolution.y) / aspect);
-
-			} else if(resolution.y !== AUTO_SIZE) {
-
-				width = Math.round(Math.max(1, resolution.y) * aspect);
-				height = Math.max(1, resolution.y);
-
-			} else {
-
-				width = Math.max(1, Math.round(width * this.resolutionScale));
-				height = Math.max(1, Math.round(height * this.resolutionScale));
-
-			}
-
-			this.renderTargetX.setSize(width, height);
-			this.renderTargetY.setSize(width, height);
+			this.renderTargetA.setSize(width, height);
+			this.renderTargetB.setSize(width, height);
 
 			this.convolutionMaterial.setTexelSize(1.0 / width, 1.0 / height);
 			this.ditheredConvolutionMaterial.setTexelSize(1.0 / width, 1.0 / height);
@@ -53572,32 +55446,37 @@ var Spacekit = (function (exports) {
 		 *
 		 * @param {WebGLRenderer} renderer - The renderer.
 		 * @param {Boolean} alpha - Whether the renderer uses the alpha channel or not.
+		 * @param {Number} frameBufferType - The type of the main frame buffers.
 		 */
 
-		initialize(renderer, alpha) {
+		initialize(renderer, alpha, frameBufferType) {
 
-			if(!alpha) {
+			if(!alpha && frameBufferType === UnsignedByteType) {
 
-				this.renderTargetX.texture.format = RGBFormat;
-				this.renderTargetY.texture.format = RGBFormat;
+				this.renderTargetA.texture.format = RGBFormat;
+				this.renderTargetB.texture.format = RGBFormat;
+
+			}
+
+			if(frameBufferType !== undefined) {
+
+				this.renderTargetA.texture.type = frameBufferType;
+				this.renderTargetB.texture.type = frameBufferType;
 
 			}
 
 		}
 
 		/**
-		 * An auto sizing flag that can be used for the render {@link BlurPass.width}
-		 * and {@link BlurPass.height}.
-		 *
-		 * It's recommended to set the height or the width to an absolute value for
-		 * consistent blur results across different devices and resolutions.
+		 * An auto sizing flag.
 		 *
 		 * @type {Number}
+		 * @deprecated Use {@link Resizer.AUTO_SIZE} instead.
 		 */
 
 		static get AUTO_SIZE() {
 
-			return AUTO_SIZE;
+			return Resizer.AUTO_SIZE;
 
 		}
 
@@ -53869,7 +55748,7 @@ var Spacekit = (function (exports) {
 		 * The provided texture will be attached to the input buffer unless this pass
 		 * renders to screen.
 		 *
-		 * @param {Texture} depthTexture - A depth texture.
+		 * @param {DepthTexture} depthTexture - A depth texture.
 		 * @param {Number} [depthPacking=0] - The depth packing.
 		 */
 
@@ -54257,10 +56136,11 @@ var Spacekit = (function (exports) {
 		 *
 		 * @param {WebGLRenderer} renderer - The renderer.
 		 * @param {Boolean} alpha - Whether the renderer uses the alpha channel or not.
-		 * @example if(!alpha) { this.myRenderTarget.texture.format = RGBFormat; }
+		 * @param {Number} frameBufferType - The type of the main frame buffers.
+		 * @example if(!alpha && frameBufferType === UnsignedByteType) { this.myRenderTarget.texture.format = RGBFormat; }
 		 */
 
-		initialize(renderer, alpha) {}
+		initialize(renderer, alpha, frameBufferType) {}
 
 		/**
 		 * Performs a shallow search for properties that define a dispose method and
@@ -54301,8 +56181,7 @@ var Spacekit = (function (exports) {
 	 * @property {Number} CONVOLUTION - Describes effects that fetch additional samples from the input buffer. There cannot be more than one effect with this attribute per {@link EffectPass}.
 	 * @property {Number} DEPTH - Describes effects that require a depth texture.
 	 * @property {Number} NONE - No attributes. Most effects don't need to specify any attributes.
-	 * @example
-	 * const attributes = EffectAttribute.CONVOLUTION | EffectAttribute.DEPTH;
+	 * @example const attributes = EffectAttribute.CONVOLUTION | EffectAttribute.DEPTH;
 	 */
 
 	const EffectAttribute = {
@@ -54448,9 +56327,10 @@ var Spacekit = (function (exports) {
 
 			}
 
+			// Assemble all names while ignoring parameters of function-like macros.
 			names = names.concat(findSubstrings(functionRegExp, shaders.get("fragment")))
-				.concat(Array.from(effect.uniforms.keys()))
-				.concat(Array.from(effect.defines.keys()));
+				.concat(Array.from(effect.defines.keys()).map((s) => s.replace(/\([\w\s,]*\)/g, "")))
+				.concat(Array.from(effect.uniforms.keys()));
 
 			// Store prefixed uniforms and macros.
 			effect.uniforms.forEach((value, key) => uniforms.set(prefix + key.charAt(0).toUpperCase() + key.slice(1), value));
@@ -54531,14 +56411,7 @@ var Spacekit = (function (exports) {
 
 			super("EffectPass");
 
-			/**
-			 * The main camera.
-			 *
-			 * @type {Camera}
-			 * @private
-			 */
-
-			this.mainCamera = camera;
+			this.setFullscreenMaterial(new EffectMaterial(null, null, null, camera));
 
 			/**
 			 * The effects, sorted by attribute priority, DESC.
@@ -54550,15 +56423,6 @@ var Spacekit = (function (exports) {
 			this.effects = effects.sort((a, b) => (b.attributes - a.attributes));
 
 			/**
-			 * The current render size.
-			 *
-			 * @type {Vector2}
-			 * @private
-			 */
-
-			this.size = new Vector2();
-
-			/**
 			 * Indicates whether this pass should skip rendering.
 			 *
 			 * Effects will still be updated, even if this flag is true.
@@ -54568,15 +56432,6 @@ var Spacekit = (function (exports) {
 			 */
 
 			this.skipRendering = false;
-
-			/**
-			 * Indicates whether dithering is enabled.
-			 *
-			 * @type {Boolean}
-			 * @private
-			 */
-
-			this.quantize = false;
 
 			/**
 			 * The amount of shader uniforms that this pass uses.
@@ -54619,6 +56474,45 @@ var Spacekit = (function (exports) {
 		}
 
 		/**
+		 * Indicates whether this pass encodes its output when rendering to screen.
+		 *
+		 * @type {Boolean}
+		 */
+
+		get encodeOutput() {
+
+			return (this.getFullscreenMaterial().defines.ENCODE_OUTPUT !== undefined);
+
+		}
+
+		/**
+		 * Enables or disables output encoding.
+		 *
+		 * @type {Boolean}
+		 */
+
+		set encodeOutput(value) {
+
+			if(this.encodeOutput !== value) {
+
+				const material = this.getFullscreenMaterial();
+				material.needsUpdate = true;
+
+				if(value) {
+
+					material.defines.ENCODE_OUTPUT = "1";
+
+				} else {
+
+					delete material.defines.ENCODE_OUTPUT;
+
+				}
+
+			}
+
+		}
+
+		/**
 		 * Indicates whether dithering is enabled.
 		 *
 		 * Color quantization reduces banding artifacts but degrades performance.
@@ -54628,45 +56522,36 @@ var Spacekit = (function (exports) {
 
 		get dithering() {
 
-			return this.quantize;
+			return this.getFullscreenMaterial().dithering;
 
 		}
 
 		/**
 		 * Enables or disables dithering.
 		 *
-		 * Note that some effects have their own dithering setting.
-		 *
 		 * @type {Boolean}
 		 */
 
 		set dithering(value) {
 
-			if(this.quantize !== value) {
+			const material = this.getFullscreenMaterial();
 
-				const material = this.getFullscreenMaterial();
+			if(material.dithering !== value) {
 
-				if(material !== null) {
-
-					material.dithering = value;
-					material.needsUpdate = true;
-
-				}
-
-				this.quantize = value;
+				material.dithering = value;
+				material.needsUpdate = true;
 
 			}
 
 		}
 
 		/**
-		 * Creates a compound shader material.
+		 * Updates the compound shader material.
 		 *
 		 * @private
-		 * @return {Material} The new material.
 		 */
 
-		createMaterial() {
+		updateMaterial() {
 
 			const blendRegExp = /\bblend\b/g;
 
@@ -54743,7 +56628,12 @@ var Spacekit = (function (exports) {
 
 				}
 
-				this.needsDepthTexture = true;
+				// Only request a depth texture if none has been provided yet.
+				this.needsDepthTexture = (this.getDepthTexture() === null);
+
+			} else {
+
+				this.needsDepthTexture = false;
 
 			}
 
@@ -54761,7 +56651,8 @@ var Spacekit = (function (exports) {
 
 			}
 
-			shaderParts.forEach((value, key, map) => map.set(key, value.trim()));
+			// Ensure that leading preprocessor directives start at a new line.
+			shaderParts.forEach((value, key, map) => map.set(key, value.trim().replace(/^#/, "\n#")));
 
 			this.uniforms = uniforms.size;
 			this.varyings = varyings;
@@ -54769,7 +56660,9 @@ var Spacekit = (function (exports) {
 			this.skipRendering = (id === 0);
 			this.needsSwap = !this.skipRendering;
 
-			const material = new EffectMaterial(shaderParts, defines, uniforms, this.mainCamera, this.dithering);
+			const material = this.getFullscreenMaterial();
+			material.setShaderParts(shaderParts).setDefines(defines).setUniforms(uniforms);
+			material.extensions = {};
 
 			if(extensions.size > 0) {
 
@@ -54782,37 +56675,17 @@ var Spacekit = (function (exports) {
 
 			}
 
-			return material;
-
 		}
 
 		/**
-		 * Destroys the current fullscreen shader material and builds a new one.
+		 * Updates the shader material.
 		 *
-		 * Warning: This method performs a relatively expensive shader recompilation.
+		 * Warning: This method triggers a relatively expensive shader recompilation.
 		 */
 
 		recompile() {
 
-			let material = this.getFullscreenMaterial();
-			let depthTexture = null;
-			let depthPacking = 0;
-
-			if(material !== null) {
-
-				depthTexture = material.uniforms.depthBuffer.value;
-				depthPacking = material.depthPacking;
-				material.dispose();
-
-				this.uniforms = 0;
-				this.varyings = 0;
-
-			}
-
-			material = this.createMaterial();
-			material.setSize(this.size.x, this.size.y);
-			this.setFullscreenMaterial(material);
-			this.setDepthTexture(depthTexture, depthPacking);
+			this.updateMaterial();
 
 		}
 
@@ -54824,9 +56697,7 @@ var Spacekit = (function (exports) {
 
 		getDepthTexture() {
 
-			const material = this.getFullscreenMaterial();
-
-			return (material !== null) ? material.uniforms.depthBuffer.value : null;
+			return this.getFullscreenMaterial().uniforms.depthBuffer.value;
 
 		}
 
@@ -54840,7 +56711,6 @@ var Spacekit = (function (exports) {
 		setDepthTexture(depthTexture, depthPacking = 0) {
 
 			const material = this.getFullscreenMaterial();
-
 			material.uniforms.depthBuffer.value = depthTexture;
 			material.depthPacking = depthPacking;
 			material.needsUpdate = true;
@@ -54894,15 +56764,7 @@ var Spacekit = (function (exports) {
 
 		setSize(width, height) {
 
-			const material = this.getFullscreenMaterial();
-
-			if(material !== null) {
-
-				material.setSize(width, height);
-
-			}
-
-			this.size.set(width, height);
+			this.getFullscreenMaterial().setSize(width, height);
 
 			for(const effect of this.effects) {
 
@@ -54917,20 +56779,20 @@ var Spacekit = (function (exports) {
 		 *
 		 * @param {WebGLRenderer} renderer - The renderer.
 		 * @param {Boolean} alpha - Whether the renderer uses the alpha channel or not.
+		 * @param {Number} frameBufferType - The type of the main frame buffers.
 		 */
 
-		initialize(renderer, alpha) {
+		initialize(renderer, alpha, frameBufferType) {
 
 			// Initialize effects before building the final shader.
 			for(const effect of this.effects) {
 
-				effect.initialize(renderer, alpha);
+				effect.initialize(renderer, alpha, frameBufferType);
 
 			}
 
-			// Generate the fullscreen material.
-			this.setFullscreenMaterial(this.createMaterial());
-			this.getFullscreenMaterial().setSize(this.size.x, this.size.y);
+			// Initialize the fullscreen material.
+			this.updateMaterial();
 
 			// Compare required resources with capabilities.
 			const capabilities = renderer.capabilities;
@@ -54973,7 +56835,7 @@ var Spacekit = (function (exports) {
 	}
 
 	/**
-	 * A mask pass.
+	 * A stencil mask pass.
 	 *
 	 * This pass requires that the input and output buffers have a stencil buffer.
 	 * You can enable the stencil buffer via the {@link EffectComposer} constructor.
@@ -55197,7 +57059,7 @@ var Spacekit = (function (exports) {
 
 		render(renderer, inputBuffer, outputBuffer, deltaTime, stencilTest) {
 
-			if(this.uniform !== null) {
+			if(this.uniform !== null && inputBuffer !== null) {
 
 				this.uniform.value = inputBuffer.texture;
 
@@ -55232,15 +57094,19 @@ var Spacekit = (function (exports) {
 		 * @param {Object} [options] - The options.
 		 * @param {Boolean} [options.depthBuffer=true] - Whether the main render targets should have a depth buffer.
 		 * @param {Boolean} [options.stencilBuffer=false] - Whether the main render targets should have a stencil buffer.
+		 * @param {Number} [options.multisampling=0] - The number of samples used for multisample antialiasing. Requires WebGL 2.
+		 * @param {Boolean} [options.frameBufferType] - The type of the internal frame buffers. It's recommended to use HalfFloatType if possible.
 		 */
 
-		constructor(renderer = null, { depthBuffer = true, stencilBuffer = false } = {}) {
+		constructor(renderer = null, {
+			depthBuffer = true,
+			stencilBuffer = false,
+			multisampling = 0,
+			frameBufferType
+		} = {}) {
 
 			/**
 			 * The renderer.
-			 *
-			 * You may replace the renderer at any time by using
-			 * {@link EffectComposer#replaceRenderer}.
 			 *
 			 * @type {WebGLRenderer}
 			 * @private
@@ -55272,8 +57138,9 @@ var Spacekit = (function (exports) {
 			if(this.renderer !== null) {
 
 				this.renderer.autoClear = false;
-				this.inputBuffer = this.createBuffer(depthBuffer, stencilBuffer);
+				this.inputBuffer = this.createBuffer(depthBuffer, stencilBuffer, frameBufferType, multisampling);
 				this.outputBuffer = this.inputBuffer.clone();
+				this.enableExtensions();
 
 			}
 
@@ -55304,10 +57171,72 @@ var Spacekit = (function (exports) {
 
 			this.passes = [];
 
+			/**
+			 * Determines whether the last pass automatically renders to screen.
+			 *
+			 * @type {Boolean}
+			 * @private
+			 */
+
+			this.autoRenderToScreen = true;
+
+		}
+
+		/**
+		 * The current amount of samples used for multisample antialiasing.
+		 *
+		 * @type {Number}
+		 */
+
+		get multisampling() {
+
+			return (this.inputBuffer instanceof WebGLMultisampleRenderTarget) ?
+				this.inputBuffer.samples : 0;
+
+		}
+
+		/**
+		 * Sets the amount of MSAA samples.
+		 *
+		 * Requires WebGL 2. Set to zero to disable multisampling.
+		 *
+		 * @type {Number}
+		 */
+
+		set multisampling(value) {
+
+			const buffer = this.inputBuffer;
+			const multisampling = this.multisampling;
+
+			if(multisampling > 0 && value > 0) {
+
+				this.inputBuffer.samples = value;
+				this.outputBuffer.samples = value;
+
+			} else if(multisampling !== value) {
+
+				this.inputBuffer.dispose();
+				this.outputBuffer.dispose();
+
+				// Enable or disable MSAA.
+				this.inputBuffer = this.createBuffer(
+					buffer.depthBuffer,
+					buffer.stencilBuffer,
+					buffer.texture.type,
+					value
+				);
+
+				this.outputBuffer = this.inputBuffer.clone();
+
+			}
+
 		}
 
 		/**
 		 * Returns the WebGL renderer.
+		 *
+		 * You may replace the renderer at any time by using
+		 * {@link EffectComposer#replaceRenderer}.
 		 *
 		 * @return {WebGLRenderer} The renderer.
 		 */
@@ -55315,6 +57244,34 @@ var Spacekit = (function (exports) {
 		getRenderer() {
 
 			return this.renderer;
+
+		}
+
+		/**
+		 * Explicitly enables required WebGL extensions.
+		 *
+		 * @private
+		 */
+
+		enableExtensions() {
+
+			const frameBufferType = this.inputBuffer.texture.type;
+			const capabilities = this.renderer.capabilities;
+			const context = this.renderer.getContext();
+
+			if(frameBufferType !== UnsignedByteType) {
+
+				if(capabilities.isWebGL2) {
+
+					context.getExtension("EXT_color_buffer_float");
+
+				} else {
+
+					context.getExtension("EXT_color_buffer_half_float");
+
+				}
+
+			}
 
 		}
 
@@ -55359,6 +57316,8 @@ var Spacekit = (function (exports) {
 
 				}
 
+				this.enableExtensions();
+
 			}
 
 			return oldRenderer;
@@ -55385,6 +57344,10 @@ var Spacekit = (function (exports) {
 				depthTexture.format = DepthStencilFormat;
 				depthTexture.type = UnsignedInt248Type;
 
+			} else {
+
+				depthTexture.type = UnsignedIntType;
+
 			}
 
 			return depthTexture;
@@ -55398,23 +57361,39 @@ var Spacekit = (function (exports) {
 		 * magnification. Its render texture format depends on whether the renderer
 		 * uses the alpha channel. Mipmaps are disabled.
 		 *
+		 * Note: The buffer format will also be set to RGBA if the frame buffer type
+		 * is HalfFloatType because RGB16F buffers are not renderable.
+		 *
 		 * @param {Boolean} depthBuffer - Whether the render target should have a depth buffer.
 		 * @param {Boolean} stencilBuffer - Whether the render target should have a stencil buffer.
+		 * @param {Number} type - The frame buffer type.
+		 * @param {Number} multisampling - The number of samples to use for antialiasing.
 		 * @return {WebGLRenderTarget} A new render target that equals the renderer's canvas.
 		 */
 
-		createBuffer(depthBuffer, stencilBuffer) {
+		createBuffer(depthBuffer, stencilBuffer, type, multisampling) {
 
-			const drawingBufferSize = this.renderer.getDrawingBufferSize(new Vector2());
+			const size = this.renderer.getDrawingBufferSize(new Vector2());
 			const alpha = this.renderer.getContext().getContextAttributes().alpha;
 
-			const renderTarget = new WebGLRenderTarget(drawingBufferSize.width, drawingBufferSize.height, {
+			const options = {
+				format: (!alpha && type === UnsignedByteType) ? RGBFormat : RGBAFormat,
 				minFilter: LinearFilter,
 				magFilter: LinearFilter,
-				format: alpha ? RGBAFormat : RGBFormat,
-				depthBuffer: depthBuffer,
-				stencilBuffer: stencilBuffer
-			});
+				stencilBuffer,
+				depthBuffer,
+				type
+			};
+
+			const renderTarget = (multisampling > 0) ?
+				new WebGLMultisampleRenderTarget(size.width, size.height, options) :
+				new WebGLRenderTarget(size.width, size.height, options);
+
+			if(multisampling > 0) {
+
+				renderTarget.samples = multisampling;
+
+			}
 
 			renderTarget.texture.name = "EffectComposer.Buffer";
 			renderTarget.texture.generateMipmaps = false;
@@ -55434,10 +57413,28 @@ var Spacekit = (function (exports) {
 
 			const passes = this.passes;
 			const renderer = this.renderer;
+			const alpha = renderer.getContext().getContextAttributes().alpha;
+			const frameBufferType = this.inputBuffer.texture.type;
 			const drawingBufferSize = renderer.getDrawingBufferSize(new Vector2());
 
 			pass.setSize(drawingBufferSize.width, drawingBufferSize.height);
-			pass.initialize(renderer, renderer.getContext().getContextAttributes().alpha);
+			pass.initialize(renderer, alpha, frameBufferType);
+
+			if(this.autoRenderToScreen) {
+
+				if(passes.length > 0) {
+
+					passes[passes.length - 1].renderToScreen = false;
+
+				}
+
+				if(pass.renderToScreen) {
+
+					this.autoRenderToScreen = false;
+
+				}
+
+			}
 
 			if(index !== undefined) {
 
@@ -55446,6 +57443,12 @@ var Spacekit = (function (exports) {
 			} else {
 
 				passes.push(pass);
+
+			}
+
+			if(this.autoRenderToScreen) {
+
+				passes[passes.length - 1].renderToScreen = true;
 
 			}
 
@@ -55480,24 +57483,43 @@ var Spacekit = (function (exports) {
 		removePass(pass) {
 
 			const passes = this.passes;
-			const removed = (passes.splice(passes.indexOf(pass), 1).length > 0);
+			const index = passes.indexOf(pass);
+			const removed = (passes.splice(index, 1).length > 0);
 
-			if(removed && this.depthTexture !== null) {
+			if(removed) {
 
-				const reducer = (a, b) => a || b.needsDepthTexture;
-				const depthTextureRequired = passes.reduce(reducer, false);
+				if(this.depthTexture !== null) {
 
-				if(!depthTextureRequired) {
+					// Check if the depth texture is still required.
+					const reducer = (a, b) => (a || b.needsDepthTexture);
+					const depthTextureRequired = passes.reduce(reducer, false);
 
-					this.depthTexture.dispose();
-					this.depthTexture = null;
+					if(!depthTextureRequired) {
 
-					this.inputBuffer.depthTexture = null;
-					this.outputBuffer.depthTexture = null;
+						this.depthTexture.dispose();
+						this.depthTexture = null;
 
-					for(pass of passes) {
+						this.inputBuffer.depthTexture = null;
+						this.outputBuffer.depthTexture = null;
 
 						pass.setDepthTexture(null);
+
+						for(pass of passes) {
+
+							pass.setDepthTexture(null);
+
+						}
+
+					}
+
+				}
+
+				if(this.autoRenderToScreen && passes.length > 0) {
+
+					// Check if the removed pass was the last one in the chain.
+					if(index === passes.length) {
+
+						passes[passes.length - 1].renderToScreen = true;
 
 					}
 
@@ -55578,9 +57600,10 @@ var Spacekit = (function (exports) {
 		 *
 		 * @param {Number} [width] - The width.
 		 * @param {Number} [height] - The height.
+		 * @param {Boolean} [updateStyle] - Determines whether the style of the canvas should be updated.
 		 */
 
-		setSize(width, height) {
+		setSize(width, height, updateStyle) {
 
 			const renderer = this.renderer;
 
@@ -55592,7 +57615,7 @@ var Spacekit = (function (exports) {
 			}
 
 			// Update the logical render size.
-			renderer.setSize(width, height);
+			renderer.setSize(width, height, updateStyle);
 
 			// The drawing buffer size takes the device pixel ratio into account.
 			const drawingBufferSize = renderer.getDrawingBufferSize(new Vector2());
@@ -55614,10 +57637,7 @@ var Spacekit = (function (exports) {
 
 		reset() {
 
-			const renderTarget = this.createBuffer(
-				this.inputBuffer.depthBuffer,
-				this.inputBuffer.stencilBuffer
-			);
+			const renderTarget = this.inputBuffer.clone();
 
 			this.dispose();
 
@@ -55626,6 +57646,7 @@ var Spacekit = (function (exports) {
 			this.outputBuffer = renderTarget.clone();
 			this.depthTexture = null;
 			this.copyPass = new ShaderPass(new CopyMaterial());
+			this.autoRenderToScreen = true;
 
 		}
 
@@ -55672,7 +57693,7 @@ var Spacekit = (function (exports) {
 
 	}
 
-	var fragmentShader$a = "uniform sampler2D texture;\n#ifdef ASPECT_CORRECTION\nvarying vec2 vUv2;\n#endif\nvoid mainImage(const in vec4 inputColor,const in vec2 uv,out vec4 outputColor){\n#ifdef ASPECT_CORRECTION\noutputColor=texture2D(texture,vUv2);\n#else\noutputColor=texture2D(texture,uv);\n#endif\n}";
+	var fragmentShader$c = "uniform sampler2D texture;uniform float intensity;void mainImage(const in vec4 inputColor,const in vec2 uv,out vec4 outputColor){outputColor=clamp(texture2D(texture,uv)*intensity,0.0,1.0);}";
 
 	/**
 	 * A bloom effect.
@@ -55691,8 +57712,9 @@ var Spacekit = (function (exports) {
 		 * @param {Number} [options.luminanceThreshold=0.9] - The luminance threshold. Raise this value to mask out darker elements in the scene. Range is [0, 1].
 		 * @param {Number} [options.luminanceSmoothing=0.025] - Controls the smoothness of the luminance threshold. Range is [0, 1].
 		 * @param {Number} [options.resolutionScale=0.5] - Deprecated. Use height or width instead.
-		 * @param {Number} [options.width=BlurPass.AUTO_SIZE] - The render width.
-		 * @param {Number} [options.height=BlurPass.AUTO_SIZE] - The render height.
+		 * @param {Number} [options.intensity=1.0] - The intensity.
+		 * @param {Number} [options.width=Resizer.AUTO_SIZE] - The render width.
+		 * @param {Number} [options.height=Resizer.AUTO_SIZE] - The render height.
 		 * @param {KernelSize} [options.kernelSize=KernelSize.LARGE] - The blur kernel size.
 		 */
 
@@ -55701,17 +57723,19 @@ var Spacekit = (function (exports) {
 			luminanceThreshold = 0.9,
 			luminanceSmoothing = 0.025,
 			resolutionScale = 0.5,
-			width = BlurPass.AUTO_SIZE,
-			height = BlurPass.AUTO_SIZE,
+			intensity = 1.0,
+			width = Resizer.AUTO_SIZE,
+			height = Resizer.AUTO_SIZE,
 			kernelSize = KernelSize.LARGE
 		} = {}) {
 
-			super("BloomEffect", fragmentShader$a, {
+			super("BloomEffect", fragmentShader$c, {
 
 				blendFunction,
 
 				uniforms: new Map([
-					["texture", new Uniform(null)]
+					["texture", new Uniform(null)],
+					["intensity", new Uniform(intensity)]
 				])
 
 			});
@@ -55738,13 +57762,11 @@ var Spacekit = (function (exports) {
 			/**
 			 * A blur pass.
 			 *
-			 * Do not adjust the width or height of this pass directly. Use
-			 * {@link width} or {@link height} instead.
-			 *
 			 * @type {BlurPass}
 			 */
 
 			this.blurPass = new BlurPass({ resolutionScale, width, height, kernelSize });
+			this.blurPass.resolution.resizable = this;
 
 			/**
 			 * A luminance shader pass.
@@ -55789,31 +57811,40 @@ var Spacekit = (function (exports) {
 		}
 
 		/**
+		 * The resolution of this effect.
+		 *
+		 * @type {Resizer}
+		 */
+
+		get resolution() {
+
+			return this.blurPass.resolution;
+
+		}
+
+		/**
 		 * The current width of the internal render targets.
 		 *
 		 * @type {Number}
+		 * @deprecated Use resolution.width instead.
 		 */
 
 		get width() {
 
-			return this.blurPass.width;
+			return this.resolution.width;
 
 		}
 
 		/**
 		 * Sets the render width.
 		 *
-		 * Use {@link BlurPass.AUTO_SIZE} to activate automatic sizing based on the
-		 * render height and aspect ratio.
-		 *
 		 * @type {Number}
+		 * @deprecated Use resolution.width instead.
 		 */
 
 		set width(value) {
 
-			const blurPass = this.blurPass;
-			blurPass.width = value;
-			this.renderTarget.setSize(blurPass.width, blurPass.height);
+			this.resolution.width = value;
 
 		}
 
@@ -55821,28 +57852,25 @@ var Spacekit = (function (exports) {
 		 * The current height of the internal render targets.
 		 *
 		 * @type {Number}
+		 * @deprecated Use resolution.height instead.
 		 */
 
 		get height() {
 
-			return this.blurPass.height;
+			return this.resolution.height;
 
 		}
 
 		/**
 		 * Sets the render height.
 		 *
-		 * Use {@link BlurPass.AUTO_SIZE} to activate automatic sizing based on the
-		 * render width and aspect ratio.
-		 *
 		 * @type {Number}
+		 * @deprecated Use resolution.height instead.
 		 */
 
 		set height(value) {
 
-			const blurPass = this.blurPass;
-			blurPass.height = value;
-			this.renderTarget.setSize(blurPass.width, blurPass.height);
+			this.resolution.height = value;
 
 		}
 
@@ -55850,7 +57878,7 @@ var Spacekit = (function (exports) {
 		 * Indicates whether dithering is enabled.
 		 *
 		 * @type {Boolean}
-		 * @deprecated Use blurPass.dithering instead.
+		 * @deprecated Set the frameBufferType of the EffectComposer to HalfFloatType instead.
 		 */
 
 		get dithering() {
@@ -55863,7 +57891,7 @@ var Spacekit = (function (exports) {
 		 * Enables or disables dithering.
 		 *
 		 * @type {Boolean}
-		 * @deprecated Use blurPass.dithering instead.
+		 * @deprecated Set the frameBufferType of the EffectComposer to HalfFloatType instead.
 		 */
 
 		set dithering(value) {
@@ -55921,15 +57949,39 @@ var Spacekit = (function (exports) {
 		}
 
 		/**
+		 * The bloom intensity.
+		 *
+		 * @type {Number}
+		 */
+
+		get intensity() {
+
+			return this.uniforms.get("intensity").value;
+
+		}
+
+		/**
+		 * Sets the bloom intensity.
+		 *
+		 * @type {Number}
+		 */
+
+		set intensity(value) {
+
+			this.uniforms.get("intensity").value = value;
+
+		}
+
+		/**
 		 * Returns the current resolution scale.
 		 *
 		 * @return {Number} The resolution scale.
-		 * @deprecated Adjust the width or height instead.
+		 * @deprecated Adjust the fixed resolution width or height instead.
 		 */
 
 		getResolutionScale() {
 
-			return this.blurPass.getResolutionScale();
+			return this.resolution.scale;
 
 		}
 
@@ -55937,14 +57989,13 @@ var Spacekit = (function (exports) {
 		 * Sets the resolution scale.
 		 *
 		 * @param {Number} scale - The new resolution scale.
-		 * @deprecated Adjust the width or height instead.
+		 * @deprecated Adjust the fixed resolution width or height instead.
 		 */
 
 		setResolutionScale(scale) {
 
-			const blurPass = this.blurPass;
-			blurPass.setResolutionScale(scale);
-			this.renderTarget.setSize(blurPass.width, blurPass.height);
+			this.resolution.scale = scale;
+			this.setSize(this.resolution.base.x, this.resolution.base.y);
 
 		}
 
@@ -55982,9 +58033,8 @@ var Spacekit = (function (exports) {
 
 		setSize(width, height) {
 
-			const blurPass = this.blurPass;
-			blurPass.setSize(width, height);
-			this.renderTarget.setSize(blurPass.width, blurPass.height);
+			this.blurPass.setSize(width, height);
+			this.renderTarget.setSize(this.resolution.width, this.resolution.height);
 
 		}
 
@@ -55993,15 +58043,22 @@ var Spacekit = (function (exports) {
 		 *
 		 * @param {WebGLRenderer} renderer - The renderer.
 		 * @param {Boolean} alpha - Whether the renderer uses the alpha channel or not.
+		 * @param {Number} frameBufferType - The type of the main frame buffers.
 		 */
 
-		initialize(renderer, alpha) {
+		initialize(renderer, alpha, frameBufferType) {
 
-			this.blurPass.initialize(renderer, alpha);
+			this.blurPass.initialize(renderer, alpha, frameBufferType);
 
-			if(!alpha) {
+			if(!alpha && frameBufferType === UnsignedByteType) {
 
 				this.renderTarget.texture.format = RGBFormat;
+
+			}
+
+			if(frameBufferType !== undefined) {
+
+				this.renderTarget.texture.type = frameBufferType;
 
 			}
 
@@ -56639,6 +58696,21 @@ var Spacekit = (function (exports) {
 	    return offset;
 	  }
 
+	  hideParticle(offset) {
+	    const attributes = this._attributes;
+	    attributes.size.set(
+	      [0],
+	      offset,
+	    );
+
+	    for (const attributeKey in attributes) {
+	      if (attributes.hasOwnProperty(attributeKey)) {
+	        attributes[attributeKey].needsUpdate = true;
+	      }
+	    }
+
+	  }
+
 	  /**
 	   * Change the `origin` attribute of a particle.
 	   * @param {Number} offset The location of this particle in the attributes * array.
@@ -56710,6 +58782,8 @@ var Spacekit = (function (exports) {
 		var material_library_pattern = /^mtllib /;
 		// usemtl material_name
 		var material_use_pattern = /^usemtl /;
+		// usemap map_name
+		var map_use_pattern = /^usemap /;
 
 		function ParserState() {
 
@@ -56722,6 +58796,7 @@ var Spacekit = (function (exports) {
 				colors: [],
 				uvs: [],
 
+				materials: {},
 				materialLibraries: [],
 
 				startObject: function ( name, fromDeclaration ) {
@@ -56950,9 +59025,9 @@ var Spacekit = (function (exports) {
 					var src = this.colors;
 					var dst = this.object.geometry.colors;
 
-					dst.push( src[ a + 0 ], src[ a + 1 ], src[ a + 2 ] );
-					dst.push( src[ b + 0 ], src[ b + 1 ], src[ b + 2 ] );
-					dst.push( src[ c + 0 ], src[ c + 1 ], src[ c + 2 ] );
+					if ( src[ a ] !== undefined ) dst.push( src[ a + 0 ], src[ a + 1 ], src[ a + 2 ] );
+					if ( src[ b ] !== undefined ) dst.push( src[ b + 0 ], src[ b + 1 ], src[ b + 2 ] );
+					if ( src[ c ] !== undefined ) dst.push( src[ c + 0 ], src[ c + 1 ], src[ c + 2 ] );
 
 				},
 
@@ -56985,6 +59060,7 @@ var Spacekit = (function (exports) {
 					var ic = this.parseVertexIndex( c, vLen );
 
 					this.addVertex( ia, ib, ic );
+					this.addColor( ia, ib, ic );
 
 					if ( ua !== undefined && ua !== '' ) {
 
@@ -57006,12 +59082,6 @@ var Spacekit = (function (exports) {
 						ic = na === nc ? ia : this.parseNormalIndex( nc, nLen );
 
 						this.addNormal( ia, ib, ic );
-
-					}
-
-					if ( this.colors.length > 0 ) {
-
-						this.addColor( ia, ib, ic );
 
 					}
 
@@ -57064,13 +59134,13 @@ var Spacekit = (function (exports) {
 
 		function OBJLoader( manager ) {
 
-			this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
+			Loader.call( this, manager );
 
 			this.materials = null;
 
 		}
 
-		OBJLoader.prototype = {
+		OBJLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
 
 			constructor: OBJLoader,
 
@@ -57088,14 +59158,6 @@ var Spacekit = (function (exports) {
 
 			},
 
-			setPath: function ( value ) {
-
-				this.path = value;
-
-				return this;
-
-			},
-
 			setMaterials: function ( materials ) {
 
 				this.materials = materials;
@@ -57105,8 +59167,6 @@ var Spacekit = (function (exports) {
 			},
 
 			parse: function ( text ) {
-
-				console.time( 'OBJLoader' );
 
 				var state = new ParserState();
 
@@ -57168,7 +59228,14 @@ var Spacekit = (function (exports) {
 
 									);
 
+								} else {
+
+									// if no colors are defined, add placeholders so color and vertex indices match
+
+									state.colors.push( undefined, undefined, undefined );
+
 								}
+
 								break;
 							case 'vn':
 								state.normals.push(
@@ -57245,6 +59312,7 @@ var Spacekit = (function (exports) {
 							}
 
 						}
+
 						state.addLineGeometry( lineVertices, lineUVs );
 
 					} else if ( lineFirstChar === 'p' ) {
@@ -57277,6 +59345,13 @@ var Spacekit = (function (exports) {
 						// mtl file
 
 						state.materialLibraries.push( line.substring( 7 ).trim() );
+
+					} else if ( map_use_pattern.test( line ) ) {
+
+						// the line is parsed but ignored since the loader assumes textures are defined MTL files
+						// (according to https://www.okino.com/conv/imp_wave.htm, 'usemap' is the old-style Wavefront texture reference method)
+
+						console.warn( 'THREE.OBJLoader: Rendering identifier "usemap" not supported. Textures must be defined in MTL files.' );
 
 					} else if ( lineFirstChar === 's' ) {
 
@@ -57313,6 +59388,7 @@ var Spacekit = (function (exports) {
 							state.object.smooth = true;
 
 						}
+
 						var material = state.object.currentMaterial();
 						if ( material ) material.smooth = state.object.smooth;
 
@@ -57321,7 +59397,7 @@ var Spacekit = (function (exports) {
 						// Handle null terminated files without exception
 						if ( line === '\0' ) continue;
 
-						throw new Error( 'THREE.OBJLoader: Unexpected line: "' + line + '"' );
+						console.warn( 'THREE.OBJLoader: Unexpected line: "' + line + '"' );
 
 					}
 
@@ -57346,11 +59422,11 @@ var Spacekit = (function (exports) {
 
 					var buffergeometry = new BufferGeometry();
 
-					buffergeometry.addAttribute( 'position', new Float32BufferAttribute( geometry.vertices, 3 ) );
+					buffergeometry.setAttribute( 'position', new Float32BufferAttribute( geometry.vertices, 3 ) );
 
 					if ( geometry.normals.length > 0 ) {
 
-						buffergeometry.addAttribute( 'normal', new Float32BufferAttribute( geometry.normals, 3 ) );
+						buffergeometry.setAttribute( 'normal', new Float32BufferAttribute( geometry.normals, 3 ) );
 
 					} else {
 
@@ -57361,13 +59437,13 @@ var Spacekit = (function (exports) {
 					if ( geometry.colors.length > 0 ) {
 
 						hasVertexColors = true;
-						buffergeometry.addAttribute( 'color', new Float32BufferAttribute( geometry.colors, 3 ) );
+						buffergeometry.setAttribute( 'color', new Float32BufferAttribute( geometry.colors, 3 ) );
 
 					}
 
 					if ( geometry.uvs.length > 0 ) {
 
-						buffergeometry.addAttribute( 'uv', new Float32BufferAttribute( geometry.uvs, 2 ) );
+						buffergeometry.setAttribute( 'uv', new Float32BufferAttribute( geometry.uvs, 2 ) );
 
 					}
 
@@ -57378,7 +59454,8 @@ var Spacekit = (function (exports) {
 					for ( var mi = 0, miLen = materials.length; mi < miLen; mi ++ ) {
 
 						var sourceMaterial = materials[ mi ];
-						var material = undefined;
+						var materialHash = sourceMaterial.name + '_' + sourceMaterial.smooth + '_' + hasVertexColors;
+						var material = state.materials[ materialHash ];
 
 						if ( this.materials !== null ) {
 
@@ -57390,7 +59467,6 @@ var Spacekit = (function (exports) {
 								var materialLine = new LineBasicMaterial();
 								Material.prototype.copy.call( materialLine, material );
 								materialLine.color.copy( material.color );
-								materialLine.lights = false;
 								material = materialLine;
 
 							} else if ( isPoints && material && ! ( material instanceof PointsMaterial ) ) {
@@ -57399,14 +59475,13 @@ var Spacekit = (function (exports) {
 								Material.prototype.copy.call( materialPoints, material );
 								materialPoints.color.copy( material.color );
 								materialPoints.map = material.map;
-								materialPoints.lights = false;
 								material = materialPoints;
 
 							}
 
 						}
 
-						if ( ! material ) {
+						if ( material === undefined ) {
 
 							if ( isLine ) {
 
@@ -57423,11 +59498,12 @@ var Spacekit = (function (exports) {
 							}
 
 							material.name = sourceMaterial.name;
+							material.flatShading = sourceMaterial.smooth ? false : true;
+							material.vertexColors = hasVertexColors;
+
+							state.materials[ materialHash ] = material;
 
 						}
-
-						material.flatShading = sourceMaterial.smooth ? false : true;
-						material.vertexColors = hasVertexColors ? VertexColors : NoColors;
 
 						createdMaterials.push( material );
 
@@ -57484,13 +59560,11 @@ var Spacekit = (function (exports) {
 
 				}
 
-				console.timeEnd( 'OBJLoader' );
-
 				return container;
 
 			}
 
-		};
+		} );
 
 		return OBJLoader;
 
@@ -58019,6 +60093,17 @@ var Spacekit = (function (exports) {
 	   */
 	  isReady() {
 	    return this._initialized;
+	  }
+
+	  removalCleanup() {
+	    if (this._label) {
+	      this._simulation.getSimulationElement().removeChild(this._label);
+	      this._label = null;
+	    }
+
+	    if (this._particleIndex !== undefined) {
+	      this._context.objects.particles.hideParticle(this._particleIndex);
+	    }
 	  }
 	}
 
@@ -59328,6 +61413,9 @@ var Spacekit = (function (exports) {
 	      this._scene.remove(x);
 	    });
 
+	    if (typeof obj.removalCleanup == 'function') {
+	      obj.removalCleanup();
+	    }
 	    delete this._subscribedObjects[obj.getId()];
 	  }
 
@@ -59705,9 +61793,9 @@ var Spacekit = (function (exports) {
 	  }
 	}
 
-	const THREE$1 = _THREE;
+	const THREE = _THREE;
 
-	exports.THREE = THREE$1;
+	exports.THREE = THREE;
 	exports.Camera = Camera$1;
 	exports.sphericalToCartesian = sphericalToCartesian;
 	exports.equatorialToEcliptic_Cartesian = equatorialToEcliptic_Cartesian;

--- a/build/spacekit.js
+++ b/build/spacekit.js
@@ -57080,17 +57080,13 @@ var Spacekit = (function (exports) {
 	   */
 	  hideParticle(offset) {
 	    const attributes = this._attributes;
-	    attributes.size.set(
-	      [0],
-	      offset,
-	    );
+	    attributes.size.set([0], offset);
 
 	    for (const attributeKey in attributes) {
 	      if (attributes.hasOwnProperty(attributeKey)) {
 	        attributes[attributeKey].needsUpdate = true;
 	      }
 	    }
-
 	  }
 
 	  /**
@@ -59549,6 +59545,7 @@ var Spacekit = (function (exports) {
 
 	    // Scene
 	    this._scene = new Scene();
+
 	    // Camera
 	    const camera = new Camera$1(this.getContext());
 	    camera

--- a/build/spacekit.js
+++ b/build/spacekit.js
@@ -58,27 +58,31 @@ var Spacekit = (function (exports) {
 		// Missing in IE
 		// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
 
-		Object.assign = function ( target ) {
+		( function () {
 
-			if ( target === undefined || target === null ) {
+			Object.assign = function ( target ) {
 
-				throw new TypeError( 'Cannot convert undefined or null to object' );
+				if ( target === undefined || target === null ) {
 
-			}
+					throw new TypeError( 'Cannot convert undefined or null to object' );
 
-			var output = Object( target );
+				}
 
-			for ( var index = 1; index < arguments.length; index ++ ) {
+				var output = Object( target );
 
-				var source = arguments[ index ];
+				for ( var index = 1; index < arguments.length; index ++ ) {
 
-				if ( source !== undefined && source !== null ) {
+					var source = arguments[ index ];
 
-					for ( var nextKey in source ) {
+					if ( source !== undefined && source !== null ) {
 
-						if ( Object.prototype.hasOwnProperty.call( source, nextKey ) ) {
+						for ( var nextKey in source ) {
 
-							output[ nextKey ] = source[ nextKey ];
+							if ( Object.prototype.hasOwnProperty.call( source, nextKey ) ) {
+
+								output[ nextKey ] = source[ nextKey ];
+
+							}
 
 						}
 
@@ -86,15 +90,99 @@ var Spacekit = (function (exports) {
 
 				}
 
-			}
+				return output;
 
-			return output;
+			};
 
-		};
+		} )();
 
 	}
 
-	var REVISION = '116';
+	/**
+	 * https://github.com/mrdoob/eventdispatcher.js/
+	 */
+
+	function EventDispatcher() {}
+
+	Object.assign( EventDispatcher.prototype, {
+
+		addEventListener: function ( type, listener ) {
+
+			if ( this._listeners === undefined ) this._listeners = {};
+
+			var listeners = this._listeners;
+
+			if ( listeners[ type ] === undefined ) {
+
+				listeners[ type ] = [];
+
+			}
+
+			if ( listeners[ type ].indexOf( listener ) === - 1 ) {
+
+				listeners[ type ].push( listener );
+
+			}
+
+		},
+
+		hasEventListener: function ( type, listener ) {
+
+			if ( this._listeners === undefined ) return false;
+
+			var listeners = this._listeners;
+
+			return listeners[ type ] !== undefined && listeners[ type ].indexOf( listener ) !== - 1;
+
+		},
+
+		removeEventListener: function ( type, listener ) {
+
+			if ( this._listeners === undefined ) return;
+
+			var listeners = this._listeners;
+			var listenerArray = listeners[ type ];
+
+			if ( listenerArray !== undefined ) {
+
+				var index = listenerArray.indexOf( listener );
+
+				if ( index !== - 1 ) {
+
+					listenerArray.splice( index, 1 );
+
+				}
+
+			}
+
+		},
+
+		dispatchEvent: function ( event ) {
+
+			if ( this._listeners === undefined ) return;
+
+			var listeners = this._listeners;
+			var listenerArray = listeners[ event.type ];
+
+			if ( listenerArray !== undefined ) {
+
+				event.target = this;
+
+				var array = listenerArray.slice( 0 );
+
+				for ( var i = 0, l = array.length; i < l; i ++ ) {
+
+					array[ i ].call( this, event );
+
+				}
+
+			}
+
+		}
+
+	} );
+
+	var REVISION = '107';
 	var MOUSE = { LEFT: 0, MIDDLE: 1, RIGHT: 2, ROTATE: 0, DOLLY: 1, PAN: 2 };
 	var TOUCH = { ROTATE: 0, PAN: 1, DOLLY_PAN: 2, DOLLY_ROTATE: 3 };
 	var CullFaceNone = 0;
@@ -106,12 +194,14 @@ var Spacekit = (function (exports) {
 	var BasicShadowMap = 0;
 	var PCFShadowMap = 1;
 	var PCFSoftShadowMap = 2;
-	var VSMShadowMap = 3;
 	var FrontSide = 0;
 	var BackSide = 1;
 	var DoubleSide = 2;
 	var FlatShading = 1;
 	var SmoothShading = 2;
+	var NoColors = 0;
+	var FaceColors = 1;
+	var VertexColors = 2;
 	var NoBlending = 0;
 	var NormalBlending = 1;
 	var AdditiveBlending = 2;
@@ -194,12 +284,6 @@ var Spacekit = (function (exports) {
 	var DepthFormat = 1026;
 	var DepthStencilFormat = 1027;
 	var RedFormat = 1028;
-	var RedIntegerFormat = 1029;
-	var RGFormat = 1030;
-	var RGIntegerFormat = 1031;
-	var RGBIntegerFormat = 1032;
-	var RGBAIntegerFormat = 1033;
-
 	var RGB_S3TC_DXT1_Format = 33776;
 	var RGBA_S3TC_DXT1_Format = 33777;
 	var RGBA_S3TC_DXT3_Format = 33778;
@@ -209,8 +293,6 @@ var Spacekit = (function (exports) {
 	var RGBA_PVRTC_4BPPV1_Format = 35842;
 	var RGBA_PVRTC_2BPPV1_Format = 35843;
 	var RGB_ETC1_Format = 36196;
-	var RGB_ETC2_Format = 37492;
-	var RGBA_ETC2_EAC_Format = 37496;
 	var RGBA_ASTC_4x4_Format = 37808;
 	var RGBA_ASTC_5x4_Format = 37809;
 	var RGBA_ASTC_5x5_Format = 37810;
@@ -225,21 +307,6 @@ var Spacekit = (function (exports) {
 	var RGBA_ASTC_10x10_Format = 37819;
 	var RGBA_ASTC_12x10_Format = 37820;
 	var RGBA_ASTC_12x12_Format = 37821;
-	var RGBA_BPTC_Format = 36492;
-	var SRGB8_ALPHA8_ASTC_4x4_Format = 37840;
-	var SRGB8_ALPHA8_ASTC_5x4_Format = 37841;
-	var SRGB8_ALPHA8_ASTC_5x5_Format = 37842;
-	var SRGB8_ALPHA8_ASTC_6x5_Format = 37843;
-	var SRGB8_ALPHA8_ASTC_6x6_Format = 37844;
-	var SRGB8_ALPHA8_ASTC_8x5_Format = 37845;
-	var SRGB8_ALPHA8_ASTC_8x6_Format = 37846;
-	var SRGB8_ALPHA8_ASTC_8x8_Format = 37847;
-	var SRGB8_ALPHA8_ASTC_10x5_Format = 37848;
-	var SRGB8_ALPHA8_ASTC_10x6_Format = 37849;
-	var SRGB8_ALPHA8_ASTC_10x8_Format = 37850;
-	var SRGB8_ALPHA8_ASTC_10x10_Format = 37851;
-	var SRGB8_ALPHA8_ASTC_12x10_Format = 37852;
-	var SRGB8_ALPHA8_ASTC_12x12_Format = 37853;
 	var LoopOnce = 2200;
 	var LoopRepeat = 2201;
 	var LoopPingPong = 2202;
@@ -249,8 +316,6 @@ var Spacekit = (function (exports) {
 	var ZeroCurvatureEnding = 2400;
 	var ZeroSlopeEnding = 2401;
 	var WrapAroundEnding = 2402;
-	var NormalAnimationBlendMode = 2500;
-	var AdditiveAnimationBlendMode = 2501;
 	var TrianglesDrawMode = 0;
 	var TriangleStripDrawMode = 1;
 	var TriangleFanDrawMode = 2;
@@ -285,138 +350,45 @@ var Spacekit = (function (exports) {
 	var GreaterEqualStencilFunc = 518;
 	var AlwaysStencilFunc = 519;
 
-	var StaticDrawUsage = 35044;
-	var DynamicDrawUsage = 35048;
-	var StreamDrawUsage = 35040;
-	var StaticReadUsage = 35045;
-	var DynamicReadUsage = 35049;
-	var StreamReadUsage = 35041;
-	var StaticCopyUsage = 35046;
-	var DynamicCopyUsage = 35050;
-	var StreamCopyUsage = 35042;
-
-	/**
-	 * https://github.com/mrdoob/eventdispatcher.js/
-	 */
-
-	function EventDispatcher() {}
-
-	Object.assign( EventDispatcher.prototype, {
-
-		addEventListener: function ( type, listener ) {
-
-			if ( this._listeners === undefined ) this._listeners = {};
-
-			var listeners = this._listeners;
-
-			if ( listeners[ type ] === undefined ) {
-
-				listeners[ type ] = [];
-
-			}
-
-			if ( listeners[ type ].indexOf( listener ) === - 1 ) {
-
-				listeners[ type ].push( listener );
-
-			}
-
-		},
-
-		hasEventListener: function ( type, listener ) {
-
-			if ( this._listeners === undefined ) return false;
-
-			var listeners = this._listeners;
-
-			return listeners[ type ] !== undefined && listeners[ type ].indexOf( listener ) !== - 1;
-
-		},
-
-		removeEventListener: function ( type, listener ) {
-
-			if ( this._listeners === undefined ) return;
-
-			var listeners = this._listeners;
-			var listenerArray = listeners[ type ];
-
-			if ( listenerArray !== undefined ) {
-
-				var index = listenerArray.indexOf( listener );
-
-				if ( index !== - 1 ) {
-
-					listenerArray.splice( index, 1 );
-
-				}
-
-			}
-
-		},
-
-		dispatchEvent: function ( event ) {
-
-			if ( this._listeners === undefined ) return;
-
-			var listeners = this._listeners;
-			var listenerArray = listeners[ event.type ];
-
-			if ( listenerArray !== undefined ) {
-
-				event.target = this;
-
-				// Make a copy, in case listeners are removed while iterating.
-				var array = listenerArray.slice( 0 );
-
-				for ( var i = 0, l = array.length; i < l; i ++ ) {
-
-					array[ i ].call( this, event );
-
-				}
-
-			}
-
-		}
-
-	} );
-
 	/**
 	 * @author alteredq / http://alteredqualia.com/
 	 * @author mrdoob / http://mrdoob.com/
-	 * @author WestLangley / http://github.com/WestLangley
-	 * @author thezwap
 	 */
 
-	var _lut = [];
-
-	for ( var i = 0; i < 256; i ++ ) {
-
-		_lut[ i ] = ( i < 16 ? '0' : '' ) + ( i ).toString( 16 );
-
-	}
-
-	var MathUtils = {
+	var _Math = {
 
 		DEG2RAD: Math.PI / 180,
 		RAD2DEG: 180 / Math.PI,
 
-		generateUUID: function () {
+		generateUUID: ( function () {
 
 			// http://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid-in-javascript/21963136#21963136
 
-			var d0 = Math.random() * 0xffffffff | 0;
-			var d1 = Math.random() * 0xffffffff | 0;
-			var d2 = Math.random() * 0xffffffff | 0;
-			var d3 = Math.random() * 0xffffffff | 0;
-			var uuid = _lut[ d0 & 0xff ] + _lut[ d0 >> 8 & 0xff ] + _lut[ d0 >> 16 & 0xff ] + _lut[ d0 >> 24 & 0xff ] + '-' +
-				_lut[ d1 & 0xff ] + _lut[ d1 >> 8 & 0xff ] + '-' + _lut[ d1 >> 16 & 0x0f | 0x40 ] + _lut[ d1 >> 24 & 0xff ] + '-' +
-				_lut[ d2 & 0x3f | 0x80 ] + _lut[ d2 >> 8 & 0xff ] + '-' + _lut[ d2 >> 16 & 0xff ] + _lut[ d2 >> 24 & 0xff ] +
-				_lut[ d3 & 0xff ] + _lut[ d3 >> 8 & 0xff ] + _lut[ d3 >> 16 & 0xff ] + _lut[ d3 >> 24 & 0xff ];
+			var lut = [];
 
-			// .toUpperCase() here flattens concatenated strings to save heap memory space.
-			return uuid.toUpperCase();
+			for ( var i = 0; i < 256; i ++ ) {
 
-		},
+				lut[ i ] = ( i < 16 ? '0' : '' ) + ( i ).toString( 16 );
+
+			}
+
+			return function generateUUID() {
+
+				var d0 = Math.random() * 0xffffffff | 0;
+				var d1 = Math.random() * 0xffffffff | 0;
+				var d2 = Math.random() * 0xffffffff | 0;
+				var d3 = Math.random() * 0xffffffff | 0;
+				var uuid = lut[ d0 & 0xff ] + lut[ d0 >> 8 & 0xff ] + lut[ d0 >> 16 & 0xff ] + lut[ d0 >> 24 & 0xff ] + '-' +
+					lut[ d1 & 0xff ] + lut[ d1 >> 8 & 0xff ] + '-' + lut[ d1 >> 16 & 0x0f | 0x40 ] + lut[ d1 >> 24 & 0xff ] + '-' +
+					lut[ d2 & 0x3f | 0x80 ] + lut[ d2 >> 8 & 0xff ] + '-' + lut[ d2 >> 16 & 0xff ] + lut[ d2 >> 24 & 0xff ] +
+					lut[ d3 & 0xff ] + lut[ d3 >> 8 & 0xff ] + lut[ d3 >> 16 & 0xff ] + lut[ d3 >> 24 & 0xff ];
+
+				// .toUpperCase() here flattens concatenated strings to save heap memory space.
+				return uuid.toUpperCase();
+
+			};
+
+		} )(),
 
 		clamp: function ( value, min, max ) {
 
@@ -499,13 +471,13 @@ var Spacekit = (function (exports) {
 
 		degToRad: function ( degrees ) {
 
-			return degrees * MathUtils.DEG2RAD;
+			return degrees * _Math.DEG2RAD;
 
 		},
 
 		radToDeg: function ( radians ) {
 
-			return radians * MathUtils.RAD2DEG;
+			return radians * _Math.RAD2DEG;
 
 		},
 
@@ -524,62 +496,6 @@ var Spacekit = (function (exports) {
 		floorPowerOfTwo: function ( value ) {
 
 			return Math.pow( 2, Math.floor( Math.log( value ) / Math.LN2 ) );
-
-		},
-
-		setQuaternionFromProperEuler: function ( q, a, b, c, order ) {
-
-			// Intrinsic Proper Euler Angles - see https://en.wikipedia.org/wiki/Euler_angles
-
-			// rotations are applied to the axes in the order specified by 'order'
-			// rotation by angle 'a' is applied first, then by angle 'b', then by angle 'c'
-			// angles are in radians
-
-			var cos = Math.cos;
-			var sin = Math.sin;
-
-			var c2 = cos( b / 2 );
-			var s2 = sin( b / 2 );
-
-			var c13 = cos( ( a + c ) / 2 );
-			var s13 = sin( ( a + c ) / 2 );
-
-			var c1_3 = cos( ( a - c ) / 2 );
-			var s1_3 = sin( ( a - c ) / 2 );
-
-			var c3_1 = cos( ( c - a ) / 2 );
-			var s3_1 = sin( ( c - a ) / 2 );
-
-			switch ( order ) {
-
-				case 'XYX':
-					q.set( c2 * s13, s2 * c1_3, s2 * s1_3, c2 * c13 );
-					break;
-
-				case 'YZY':
-					q.set( s2 * s1_3, c2 * s13, s2 * c1_3, c2 * c13 );
-					break;
-
-				case 'ZXZ':
-					q.set( s2 * c1_3, s2 * s1_3, c2 * s13, c2 * c13 );
-					break;
-
-				case 'XZX':
-					q.set( c2 * s13, s2 * s3_1, s2 * c3_1, c2 * c13 );
-					break;
-
-				case 'YXY':
-					q.set( s2 * c3_1, c2 * s13, s2 * s3_1, c2 * c13 );
-					break;
-
-				case 'ZYZ':
-					q.set( s2 * s3_1, s2 * c3_1, c2 * s13, c2 * c13 );
-					break;
-
-				default:
-					console.warn( 'THREE.MathUtils: .setQuaternionFromProperEuler() encountered an unknown order: ' + order );
-
-			}
 
 		}
 
@@ -967,7 +883,9 @@ var Spacekit = (function (exports) {
 
 			// computes the angle in radians with respect to the positive x-axis
 
-			var angle = Math.atan2( - this.y, - this.x ) + Math.PI;
+			var angle = Math.atan2( this.y, this.x );
+
+			if ( angle < 0 ) angle += 2 * Math.PI;
 
 			return angle;
 
@@ -1069,12 +987,1351 @@ var Spacekit = (function (exports) {
 
 			return this;
 
+		}
+
+	} );
+
+	/**
+	 * @author mikael emtinger / http://gomo.se/
+	 * @author alteredq / http://alteredqualia.com/
+	 * @author WestLangley / http://github.com/WestLangley
+	 * @author bhouston / http://clara.io
+	 */
+
+	function Quaternion( x, y, z, w ) {
+
+		this._x = x || 0;
+		this._y = y || 0;
+		this._z = z || 0;
+		this._w = ( w !== undefined ) ? w : 1;
+
+	}
+
+	Object.assign( Quaternion, {
+
+		slerp: function ( qa, qb, qm, t ) {
+
+			return qm.copy( qa ).slerp( qb, t );
+
 		},
 
-		random: function () {
+		slerpFlat: function ( dst, dstOffset, src0, srcOffset0, src1, srcOffset1, t ) {
 
-			this.x = Math.random();
-			this.y = Math.random();
+			// fuzz-free, array-based Quaternion SLERP operation
+
+			var x0 = src0[ srcOffset0 + 0 ],
+				y0 = src0[ srcOffset0 + 1 ],
+				z0 = src0[ srcOffset0 + 2 ],
+				w0 = src0[ srcOffset0 + 3 ],
+
+				x1 = src1[ srcOffset1 + 0 ],
+				y1 = src1[ srcOffset1 + 1 ],
+				z1 = src1[ srcOffset1 + 2 ],
+				w1 = src1[ srcOffset1 + 3 ];
+
+			if ( w0 !== w1 || x0 !== x1 || y0 !== y1 || z0 !== z1 ) {
+
+				var s = 1 - t,
+
+					cos = x0 * x1 + y0 * y1 + z0 * z1 + w0 * w1,
+
+					dir = ( cos >= 0 ? 1 : - 1 ),
+					sqrSin = 1 - cos * cos;
+
+				// Skip the Slerp for tiny steps to avoid numeric problems:
+				if ( sqrSin > Number.EPSILON ) {
+
+					var sin = Math.sqrt( sqrSin ),
+						len = Math.atan2( sin, cos * dir );
+
+					s = Math.sin( s * len ) / sin;
+					t = Math.sin( t * len ) / sin;
+
+				}
+
+				var tDir = t * dir;
+
+				x0 = x0 * s + x1 * tDir;
+				y0 = y0 * s + y1 * tDir;
+				z0 = z0 * s + z1 * tDir;
+				w0 = w0 * s + w1 * tDir;
+
+				// Normalize in case we just did a lerp:
+				if ( s === 1 - t ) {
+
+					var f = 1 / Math.sqrt( x0 * x0 + y0 * y0 + z0 * z0 + w0 * w0 );
+
+					x0 *= f;
+					y0 *= f;
+					z0 *= f;
+					w0 *= f;
+
+				}
+
+			}
+
+			dst[ dstOffset ] = x0;
+			dst[ dstOffset + 1 ] = y0;
+			dst[ dstOffset + 2 ] = z0;
+			dst[ dstOffset + 3 ] = w0;
+
+		}
+
+	} );
+
+	Object.defineProperties( Quaternion.prototype, {
+
+		x: {
+
+			get: function () {
+
+				return this._x;
+
+			},
+
+			set: function ( value ) {
+
+				this._x = value;
+				this._onChangeCallback();
+
+			}
+
+		},
+
+		y: {
+
+			get: function () {
+
+				return this._y;
+
+			},
+
+			set: function ( value ) {
+
+				this._y = value;
+				this._onChangeCallback();
+
+			}
+
+		},
+
+		z: {
+
+			get: function () {
+
+				return this._z;
+
+			},
+
+			set: function ( value ) {
+
+				this._z = value;
+				this._onChangeCallback();
+
+			}
+
+		},
+
+		w: {
+
+			get: function () {
+
+				return this._w;
+
+			},
+
+			set: function ( value ) {
+
+				this._w = value;
+				this._onChangeCallback();
+
+			}
+
+		}
+
+	} );
+
+	Object.assign( Quaternion.prototype, {
+
+		isQuaternion: true,
+
+		set: function ( x, y, z, w ) {
+
+			this._x = x;
+			this._y = y;
+			this._z = z;
+			this._w = w;
+
+			this._onChangeCallback();
+
+			return this;
+
+		},
+
+		clone: function () {
+
+			return new this.constructor( this._x, this._y, this._z, this._w );
+
+		},
+
+		copy: function ( quaternion ) {
+
+			this._x = quaternion.x;
+			this._y = quaternion.y;
+			this._z = quaternion.z;
+			this._w = quaternion.w;
+
+			this._onChangeCallback();
+
+			return this;
+
+		},
+
+		setFromEuler: function ( euler, update ) {
+
+			if ( ! ( euler && euler.isEuler ) ) {
+
+				throw new Error( 'THREE.Quaternion: .setFromEuler() now expects an Euler rotation rather than a Vector3 and order.' );
+
+			}
+
+			var x = euler._x, y = euler._y, z = euler._z, order = euler.order;
+
+			// http://www.mathworks.com/matlabcentral/fileexchange/
+			// 	20696-function-to-convert-between-dcm-euler-angles-quaternions-and-euler-vectors/
+			//	content/SpinCalc.m
+
+			var cos = Math.cos;
+			var sin = Math.sin;
+
+			var c1 = cos( x / 2 );
+			var c2 = cos( y / 2 );
+			var c3 = cos( z / 2 );
+
+			var s1 = sin( x / 2 );
+			var s2 = sin( y / 2 );
+			var s3 = sin( z / 2 );
+
+			if ( order === 'XYZ' ) {
+
+				this._x = s1 * c2 * c3 + c1 * s2 * s3;
+				this._y = c1 * s2 * c3 - s1 * c2 * s3;
+				this._z = c1 * c2 * s3 + s1 * s2 * c3;
+				this._w = c1 * c2 * c3 - s1 * s2 * s3;
+
+			} else if ( order === 'YXZ' ) {
+
+				this._x = s1 * c2 * c3 + c1 * s2 * s3;
+				this._y = c1 * s2 * c3 - s1 * c2 * s3;
+				this._z = c1 * c2 * s3 - s1 * s2 * c3;
+				this._w = c1 * c2 * c3 + s1 * s2 * s3;
+
+			} else if ( order === 'ZXY' ) {
+
+				this._x = s1 * c2 * c3 - c1 * s2 * s3;
+				this._y = c1 * s2 * c3 + s1 * c2 * s3;
+				this._z = c1 * c2 * s3 + s1 * s2 * c3;
+				this._w = c1 * c2 * c3 - s1 * s2 * s3;
+
+			} else if ( order === 'ZYX' ) {
+
+				this._x = s1 * c2 * c3 - c1 * s2 * s3;
+				this._y = c1 * s2 * c3 + s1 * c2 * s3;
+				this._z = c1 * c2 * s3 - s1 * s2 * c3;
+				this._w = c1 * c2 * c3 + s1 * s2 * s3;
+
+			} else if ( order === 'YZX' ) {
+
+				this._x = s1 * c2 * c3 + c1 * s2 * s3;
+				this._y = c1 * s2 * c3 + s1 * c2 * s3;
+				this._z = c1 * c2 * s3 - s1 * s2 * c3;
+				this._w = c1 * c2 * c3 - s1 * s2 * s3;
+
+			} else if ( order === 'XZY' ) {
+
+				this._x = s1 * c2 * c3 - c1 * s2 * s3;
+				this._y = c1 * s2 * c3 - s1 * c2 * s3;
+				this._z = c1 * c2 * s3 + s1 * s2 * c3;
+				this._w = c1 * c2 * c3 + s1 * s2 * s3;
+
+			}
+
+			if ( update !== false ) this._onChangeCallback();
+
+			return this;
+
+		},
+
+		setFromAxisAngle: function ( axis, angle ) {
+
+			// http://www.euclideanspace.com/maths/geometry/rotations/conversions/angleToQuaternion/index.htm
+
+			// assumes axis is normalized
+
+			var halfAngle = angle / 2, s = Math.sin( halfAngle );
+
+			this._x = axis.x * s;
+			this._y = axis.y * s;
+			this._z = axis.z * s;
+			this._w = Math.cos( halfAngle );
+
+			this._onChangeCallback();
+
+			return this;
+
+		},
+
+		setFromRotationMatrix: function ( m ) {
+
+			// http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/index.htm
+
+			// assumes the upper 3x3 of m is a pure rotation matrix (i.e, unscaled)
+
+			var te = m.elements,
+
+				m11 = te[ 0 ], m12 = te[ 4 ], m13 = te[ 8 ],
+				m21 = te[ 1 ], m22 = te[ 5 ], m23 = te[ 9 ],
+				m31 = te[ 2 ], m32 = te[ 6 ], m33 = te[ 10 ],
+
+				trace = m11 + m22 + m33,
+				s;
+
+			if ( trace > 0 ) {
+
+				s = 0.5 / Math.sqrt( trace + 1.0 );
+
+				this._w = 0.25 / s;
+				this._x = ( m32 - m23 ) * s;
+				this._y = ( m13 - m31 ) * s;
+				this._z = ( m21 - m12 ) * s;
+
+			} else if ( m11 > m22 && m11 > m33 ) {
+
+				s = 2.0 * Math.sqrt( 1.0 + m11 - m22 - m33 );
+
+				this._w = ( m32 - m23 ) / s;
+				this._x = 0.25 * s;
+				this._y = ( m12 + m21 ) / s;
+				this._z = ( m13 + m31 ) / s;
+
+			} else if ( m22 > m33 ) {
+
+				s = 2.0 * Math.sqrt( 1.0 + m22 - m11 - m33 );
+
+				this._w = ( m13 - m31 ) / s;
+				this._x = ( m12 + m21 ) / s;
+				this._y = 0.25 * s;
+				this._z = ( m23 + m32 ) / s;
+
+			} else {
+
+				s = 2.0 * Math.sqrt( 1.0 + m33 - m11 - m22 );
+
+				this._w = ( m21 - m12 ) / s;
+				this._x = ( m13 + m31 ) / s;
+				this._y = ( m23 + m32 ) / s;
+				this._z = 0.25 * s;
+
+			}
+
+			this._onChangeCallback();
+
+			return this;
+
+		},
+
+		setFromUnitVectors: function ( vFrom, vTo ) {
+
+			// assumes direction vectors vFrom and vTo are normalized
+
+			var EPS = 0.000001;
+
+			var r = vFrom.dot( vTo ) + 1;
+
+			if ( r < EPS ) {
+
+				r = 0;
+
+				if ( Math.abs( vFrom.x ) > Math.abs( vFrom.z ) ) {
+
+					this._x = - vFrom.y;
+					this._y = vFrom.x;
+					this._z = 0;
+					this._w = r;
+
+				} else {
+
+					this._x = 0;
+					this._y = - vFrom.z;
+					this._z = vFrom.y;
+					this._w = r;
+
+				}
+
+			} else {
+
+				// crossVectors( vFrom, vTo ); // inlined to avoid cyclic dependency on Vector3
+
+				this._x = vFrom.y * vTo.z - vFrom.z * vTo.y;
+				this._y = vFrom.z * vTo.x - vFrom.x * vTo.z;
+				this._z = vFrom.x * vTo.y - vFrom.y * vTo.x;
+				this._w = r;
+
+			}
+
+			return this.normalize();
+
+		},
+
+		angleTo: function ( q ) {
+
+			return 2 * Math.acos( Math.abs( _Math.clamp( this.dot( q ), - 1, 1 ) ) );
+
+		},
+
+		rotateTowards: function ( q, step ) {
+
+			var angle = this.angleTo( q );
+
+			if ( angle === 0 ) return this;
+
+			var t = Math.min( 1, step / angle );
+
+			this.slerp( q, t );
+
+			return this;
+
+		},
+
+		inverse: function () {
+
+			// quaternion is assumed to have unit length
+
+			return this.conjugate();
+
+		},
+
+		conjugate: function () {
+
+			this._x *= - 1;
+			this._y *= - 1;
+			this._z *= - 1;
+
+			this._onChangeCallback();
+
+			return this;
+
+		},
+
+		dot: function ( v ) {
+
+			return this._x * v._x + this._y * v._y + this._z * v._z + this._w * v._w;
+
+		},
+
+		lengthSq: function () {
+
+			return this._x * this._x + this._y * this._y + this._z * this._z + this._w * this._w;
+
+		},
+
+		length: function () {
+
+			return Math.sqrt( this._x * this._x + this._y * this._y + this._z * this._z + this._w * this._w );
+
+		},
+
+		normalize: function () {
+
+			var l = this.length();
+
+			if ( l === 0 ) {
+
+				this._x = 0;
+				this._y = 0;
+				this._z = 0;
+				this._w = 1;
+
+			} else {
+
+				l = 1 / l;
+
+				this._x = this._x * l;
+				this._y = this._y * l;
+				this._z = this._z * l;
+				this._w = this._w * l;
+
+			}
+
+			this._onChangeCallback();
+
+			return this;
+
+		},
+
+		multiply: function ( q, p ) {
+
+			if ( p !== undefined ) {
+
+				console.warn( 'THREE.Quaternion: .multiply() now only accepts one argument. Use .multiplyQuaternions( a, b ) instead.' );
+				return this.multiplyQuaternions( q, p );
+
+			}
+
+			return this.multiplyQuaternions( this, q );
+
+		},
+
+		premultiply: function ( q ) {
+
+			return this.multiplyQuaternions( q, this );
+
+		},
+
+		multiplyQuaternions: function ( a, b ) {
+
+			// from http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/code/index.htm
+
+			var qax = a._x, qay = a._y, qaz = a._z, qaw = a._w;
+			var qbx = b._x, qby = b._y, qbz = b._z, qbw = b._w;
+
+			this._x = qax * qbw + qaw * qbx + qay * qbz - qaz * qby;
+			this._y = qay * qbw + qaw * qby + qaz * qbx - qax * qbz;
+			this._z = qaz * qbw + qaw * qbz + qax * qby - qay * qbx;
+			this._w = qaw * qbw - qax * qbx - qay * qby - qaz * qbz;
+
+			this._onChangeCallback();
+
+			return this;
+
+		},
+
+		slerp: function ( qb, t ) {
+
+			if ( t === 0 ) return this;
+			if ( t === 1 ) return this.copy( qb );
+
+			var x = this._x, y = this._y, z = this._z, w = this._w;
+
+			// http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/slerp/
+
+			var cosHalfTheta = w * qb._w + x * qb._x + y * qb._y + z * qb._z;
+
+			if ( cosHalfTheta < 0 ) {
+
+				this._w = - qb._w;
+				this._x = - qb._x;
+				this._y = - qb._y;
+				this._z = - qb._z;
+
+				cosHalfTheta = - cosHalfTheta;
+
+			} else {
+
+				this.copy( qb );
+
+			}
+
+			if ( cosHalfTheta >= 1.0 ) {
+
+				this._w = w;
+				this._x = x;
+				this._y = y;
+				this._z = z;
+
+				return this;
+
+			}
+
+			var sqrSinHalfTheta = 1.0 - cosHalfTheta * cosHalfTheta;
+
+			if ( sqrSinHalfTheta <= Number.EPSILON ) {
+
+				var s = 1 - t;
+				this._w = s * w + t * this._w;
+				this._x = s * x + t * this._x;
+				this._y = s * y + t * this._y;
+				this._z = s * z + t * this._z;
+
+				this.normalize();
+				this._onChangeCallback();
+
+				return this;
+
+			}
+
+			var sinHalfTheta = Math.sqrt( sqrSinHalfTheta );
+			var halfTheta = Math.atan2( sinHalfTheta, cosHalfTheta );
+			var ratioA = Math.sin( ( 1 - t ) * halfTheta ) / sinHalfTheta,
+				ratioB = Math.sin( t * halfTheta ) / sinHalfTheta;
+
+			this._w = ( w * ratioA + this._w * ratioB );
+			this._x = ( x * ratioA + this._x * ratioB );
+			this._y = ( y * ratioA + this._y * ratioB );
+			this._z = ( z * ratioA + this._z * ratioB );
+
+			this._onChangeCallback();
+
+			return this;
+
+		},
+
+		equals: function ( quaternion ) {
+
+			return ( quaternion._x === this._x ) && ( quaternion._y === this._y ) && ( quaternion._z === this._z ) && ( quaternion._w === this._w );
+
+		},
+
+		fromArray: function ( array, offset ) {
+
+			if ( offset === undefined ) offset = 0;
+
+			this._x = array[ offset ];
+			this._y = array[ offset + 1 ];
+			this._z = array[ offset + 2 ];
+			this._w = array[ offset + 3 ];
+
+			this._onChangeCallback();
+
+			return this;
+
+		},
+
+		toArray: function ( array, offset ) {
+
+			if ( array === undefined ) array = [];
+			if ( offset === undefined ) offset = 0;
+
+			array[ offset ] = this._x;
+			array[ offset + 1 ] = this._y;
+			array[ offset + 2 ] = this._z;
+			array[ offset + 3 ] = this._w;
+
+			return array;
+
+		},
+
+		_onChange: function ( callback ) {
+
+			this._onChangeCallback = callback;
+
+			return this;
+
+		},
+
+		_onChangeCallback: function () {}
+
+	} );
+
+	/**
+	 * @author mrdoob / http://mrdoob.com/
+	 * @author kile / http://kile.stravaganza.org/
+	 * @author philogb / http://blog.thejit.org/
+	 * @author mikael emtinger / http://gomo.se/
+	 * @author egraether / http://egraether.com/
+	 * @author WestLangley / http://github.com/WestLangley
+	 */
+
+	function Vector3( x, y, z ) {
+
+		this.x = x || 0;
+		this.y = y || 0;
+		this.z = z || 0;
+
+	}
+
+	Object.assign( Vector3.prototype, {
+
+		isVector3: true,
+
+		set: function ( x, y, z ) {
+
+			this.x = x;
+			this.y = y;
+			this.z = z;
+
+			return this;
+
+		},
+
+		setScalar: function ( scalar ) {
+
+			this.x = scalar;
+			this.y = scalar;
+			this.z = scalar;
+
+			return this;
+
+		},
+
+		setX: function ( x ) {
+
+			this.x = x;
+
+			return this;
+
+		},
+
+		setY: function ( y ) {
+
+			this.y = y;
+
+			return this;
+
+		},
+
+		setZ: function ( z ) {
+
+			this.z = z;
+
+			return this;
+
+		},
+
+		setComponent: function ( index, value ) {
+
+			switch ( index ) {
+
+				case 0: this.x = value; break;
+				case 1: this.y = value; break;
+				case 2: this.z = value; break;
+				default: throw new Error( 'index is out of range: ' + index );
+
+			}
+
+			return this;
+
+		},
+
+		getComponent: function ( index ) {
+
+			switch ( index ) {
+
+				case 0: return this.x;
+				case 1: return this.y;
+				case 2: return this.z;
+				default: throw new Error( 'index is out of range: ' + index );
+
+			}
+
+		},
+
+		clone: function () {
+
+			return new this.constructor( this.x, this.y, this.z );
+
+		},
+
+		copy: function ( v ) {
+
+			this.x = v.x;
+			this.y = v.y;
+			this.z = v.z;
+
+			return this;
+
+		},
+
+		add: function ( v, w ) {
+
+			if ( w !== undefined ) {
+
+				console.warn( 'THREE.Vector3: .add() now only accepts one argument. Use .addVectors( a, b ) instead.' );
+				return this.addVectors( v, w );
+
+			}
+
+			this.x += v.x;
+			this.y += v.y;
+			this.z += v.z;
+
+			return this;
+
+		},
+
+		addScalar: function ( s ) {
+
+			this.x += s;
+			this.y += s;
+			this.z += s;
+
+			return this;
+
+		},
+
+		addVectors: function ( a, b ) {
+
+			this.x = a.x + b.x;
+			this.y = a.y + b.y;
+			this.z = a.z + b.z;
+
+			return this;
+
+		},
+
+		addScaledVector: function ( v, s ) {
+
+			this.x += v.x * s;
+			this.y += v.y * s;
+			this.z += v.z * s;
+
+			return this;
+
+		},
+
+		sub: function ( v, w ) {
+
+			if ( w !== undefined ) {
+
+				console.warn( 'THREE.Vector3: .sub() now only accepts one argument. Use .subVectors( a, b ) instead.' );
+				return this.subVectors( v, w );
+
+			}
+
+			this.x -= v.x;
+			this.y -= v.y;
+			this.z -= v.z;
+
+			return this;
+
+		},
+
+		subScalar: function ( s ) {
+
+			this.x -= s;
+			this.y -= s;
+			this.z -= s;
+
+			return this;
+
+		},
+
+		subVectors: function ( a, b ) {
+
+			this.x = a.x - b.x;
+			this.y = a.y - b.y;
+			this.z = a.z - b.z;
+
+			return this;
+
+		},
+
+		multiply: function ( v, w ) {
+
+			if ( w !== undefined ) {
+
+				console.warn( 'THREE.Vector3: .multiply() now only accepts one argument. Use .multiplyVectors( a, b ) instead.' );
+				return this.multiplyVectors( v, w );
+
+			}
+
+			this.x *= v.x;
+			this.y *= v.y;
+			this.z *= v.z;
+
+			return this;
+
+		},
+
+		multiplyScalar: function ( scalar ) {
+
+			this.x *= scalar;
+			this.y *= scalar;
+			this.z *= scalar;
+
+			return this;
+
+		},
+
+		multiplyVectors: function ( a, b ) {
+
+			this.x = a.x * b.x;
+			this.y = a.y * b.y;
+			this.z = a.z * b.z;
+
+			return this;
+
+		},
+
+		applyEuler: function () {
+
+			var quaternion = new Quaternion();
+
+			return function applyEuler( euler ) {
+
+				if ( ! ( euler && euler.isEuler ) ) {
+
+					console.error( 'THREE.Vector3: .applyEuler() now expects an Euler rotation rather than a Vector3 and order.' );
+
+				}
+
+				return this.applyQuaternion( quaternion.setFromEuler( euler ) );
+
+			};
+
+		}(),
+
+		applyAxisAngle: function () {
+
+			var quaternion = new Quaternion();
+
+			return function applyAxisAngle( axis, angle ) {
+
+				return this.applyQuaternion( quaternion.setFromAxisAngle( axis, angle ) );
+
+			};
+
+		}(),
+
+		applyMatrix3: function ( m ) {
+
+			var x = this.x, y = this.y, z = this.z;
+			var e = m.elements;
+
+			this.x = e[ 0 ] * x + e[ 3 ] * y + e[ 6 ] * z;
+			this.y = e[ 1 ] * x + e[ 4 ] * y + e[ 7 ] * z;
+			this.z = e[ 2 ] * x + e[ 5 ] * y + e[ 8 ] * z;
+
+			return this;
+
+		},
+
+		applyMatrix4: function ( m ) {
+
+			var x = this.x, y = this.y, z = this.z;
+			var e = m.elements;
+
+			var w = 1 / ( e[ 3 ] * x + e[ 7 ] * y + e[ 11 ] * z + e[ 15 ] );
+
+			this.x = ( e[ 0 ] * x + e[ 4 ] * y + e[ 8 ] * z + e[ 12 ] ) * w;
+			this.y = ( e[ 1 ] * x + e[ 5 ] * y + e[ 9 ] * z + e[ 13 ] ) * w;
+			this.z = ( e[ 2 ] * x + e[ 6 ] * y + e[ 10 ] * z + e[ 14 ] ) * w;
+
+			return this;
+
+		},
+
+		applyQuaternion: function ( q ) {
+
+			var x = this.x, y = this.y, z = this.z;
+			var qx = q.x, qy = q.y, qz = q.z, qw = q.w;
+
+			// calculate quat * vector
+
+			var ix = qw * x + qy * z - qz * y;
+			var iy = qw * y + qz * x - qx * z;
+			var iz = qw * z + qx * y - qy * x;
+			var iw = - qx * x - qy * y - qz * z;
+
+			// calculate result * inverse quat
+
+			this.x = ix * qw + iw * - qx + iy * - qz - iz * - qy;
+			this.y = iy * qw + iw * - qy + iz * - qx - ix * - qz;
+			this.z = iz * qw + iw * - qz + ix * - qy - iy * - qx;
+
+			return this;
+
+		},
+
+		project: function ( camera ) {
+
+			return this.applyMatrix4( camera.matrixWorldInverse ).applyMatrix4( camera.projectionMatrix );
+
+		},
+
+		unproject: function ( camera ) {
+
+			return this.applyMatrix4( camera.projectionMatrixInverse ).applyMatrix4( camera.matrixWorld );
+
+		},
+
+		transformDirection: function ( m ) {
+
+			// input: THREE.Matrix4 affine matrix
+			// vector interpreted as a direction
+
+			var x = this.x, y = this.y, z = this.z;
+			var e = m.elements;
+
+			this.x = e[ 0 ] * x + e[ 4 ] * y + e[ 8 ] * z;
+			this.y = e[ 1 ] * x + e[ 5 ] * y + e[ 9 ] * z;
+			this.z = e[ 2 ] * x + e[ 6 ] * y + e[ 10 ] * z;
+
+			return this.normalize();
+
+		},
+
+		divide: function ( v ) {
+
+			this.x /= v.x;
+			this.y /= v.y;
+			this.z /= v.z;
+
+			return this;
+
+		},
+
+		divideScalar: function ( scalar ) {
+
+			return this.multiplyScalar( 1 / scalar );
+
+		},
+
+		min: function ( v ) {
+
+			this.x = Math.min( this.x, v.x );
+			this.y = Math.min( this.y, v.y );
+			this.z = Math.min( this.z, v.z );
+
+			return this;
+
+		},
+
+		max: function ( v ) {
+
+			this.x = Math.max( this.x, v.x );
+			this.y = Math.max( this.y, v.y );
+			this.z = Math.max( this.z, v.z );
+
+			return this;
+
+		},
+
+		clamp: function ( min, max ) {
+
+			// assumes min < max, componentwise
+
+			this.x = Math.max( min.x, Math.min( max.x, this.x ) );
+			this.y = Math.max( min.y, Math.min( max.y, this.y ) );
+			this.z = Math.max( min.z, Math.min( max.z, this.z ) );
+
+			return this;
+
+		},
+
+		clampScalar: function ( minVal, maxVal ) {
+
+			this.x = Math.max( minVal, Math.min( maxVal, this.x ) );
+			this.y = Math.max( minVal, Math.min( maxVal, this.y ) );
+			this.z = Math.max( minVal, Math.min( maxVal, this.z ) );
+
+			return this;
+
+		},
+
+		clampLength: function ( min, max ) {
+
+			var length = this.length();
+
+			return this.divideScalar( length || 1 ).multiplyScalar( Math.max( min, Math.min( max, length ) ) );
+
+		},
+
+		floor: function () {
+
+			this.x = Math.floor( this.x );
+			this.y = Math.floor( this.y );
+			this.z = Math.floor( this.z );
+
+			return this;
+
+		},
+
+		ceil: function () {
+
+			this.x = Math.ceil( this.x );
+			this.y = Math.ceil( this.y );
+			this.z = Math.ceil( this.z );
+
+			return this;
+
+		},
+
+		round: function () {
+
+			this.x = Math.round( this.x );
+			this.y = Math.round( this.y );
+			this.z = Math.round( this.z );
+
+			return this;
+
+		},
+
+		roundToZero: function () {
+
+			this.x = ( this.x < 0 ) ? Math.ceil( this.x ) : Math.floor( this.x );
+			this.y = ( this.y < 0 ) ? Math.ceil( this.y ) : Math.floor( this.y );
+			this.z = ( this.z < 0 ) ? Math.ceil( this.z ) : Math.floor( this.z );
+
+			return this;
+
+		},
+
+		negate: function () {
+
+			this.x = - this.x;
+			this.y = - this.y;
+			this.z = - this.z;
+
+			return this;
+
+		},
+
+		dot: function ( v ) {
+
+			return this.x * v.x + this.y * v.y + this.z * v.z;
+
+		},
+
+		// TODO lengthSquared?
+
+		lengthSq: function () {
+
+			return this.x * this.x + this.y * this.y + this.z * this.z;
+
+		},
+
+		length: function () {
+
+			return Math.sqrt( this.x * this.x + this.y * this.y + this.z * this.z );
+
+		},
+
+		manhattanLength: function () {
+
+			return Math.abs( this.x ) + Math.abs( this.y ) + Math.abs( this.z );
+
+		},
+
+		normalize: function () {
+
+			return this.divideScalar( this.length() || 1 );
+
+		},
+
+		setLength: function ( length ) {
+
+			return this.normalize().multiplyScalar( length );
+
+		},
+
+		lerp: function ( v, alpha ) {
+
+			this.x += ( v.x - this.x ) * alpha;
+			this.y += ( v.y - this.y ) * alpha;
+			this.z += ( v.z - this.z ) * alpha;
+
+			return this;
+
+		},
+
+		lerpVectors: function ( v1, v2, alpha ) {
+
+			return this.subVectors( v2, v1 ).multiplyScalar( alpha ).add( v1 );
+
+		},
+
+		cross: function ( v, w ) {
+
+			if ( w !== undefined ) {
+
+				console.warn( 'THREE.Vector3: .cross() now only accepts one argument. Use .crossVectors( a, b ) instead.' );
+				return this.crossVectors( v, w );
+
+			}
+
+			return this.crossVectors( this, v );
+
+		},
+
+		crossVectors: function ( a, b ) {
+
+			var ax = a.x, ay = a.y, az = a.z;
+			var bx = b.x, by = b.y, bz = b.z;
+
+			this.x = ay * bz - az * by;
+			this.y = az * bx - ax * bz;
+			this.z = ax * by - ay * bx;
+
+			return this;
+
+		},
+
+		projectOnVector: function ( vector ) {
+
+			var scalar = vector.dot( this ) / vector.lengthSq();
+
+			return this.copy( vector ).multiplyScalar( scalar );
+
+		},
+
+		projectOnPlane: function () {
+
+			var v1 = new Vector3();
+
+			return function projectOnPlane( planeNormal ) {
+
+				v1.copy( this ).projectOnVector( planeNormal );
+
+				return this.sub( v1 );
+
+			};
+
+		}(),
+
+		reflect: function () {
+
+			// reflect incident vector off plane orthogonal to normal
+			// normal is assumed to have unit length
+
+			var v1 = new Vector3();
+
+			return function reflect( normal ) {
+
+				return this.sub( v1.copy( normal ).multiplyScalar( 2 * this.dot( normal ) ) );
+
+			};
+
+		}(),
+
+		angleTo: function ( v ) {
+
+			var theta = this.dot( v ) / ( Math.sqrt( this.lengthSq() * v.lengthSq() ) );
+
+			// clamp, to handle numerical problems
+
+			return Math.acos( _Math.clamp( theta, - 1, 1 ) );
+
+		},
+
+		distanceTo: function ( v ) {
+
+			return Math.sqrt( this.distanceToSquared( v ) );
+
+		},
+
+		distanceToSquared: function ( v ) {
+
+			var dx = this.x - v.x, dy = this.y - v.y, dz = this.z - v.z;
+
+			return dx * dx + dy * dy + dz * dz;
+
+		},
+
+		manhattanDistanceTo: function ( v ) {
+
+			return Math.abs( this.x - v.x ) + Math.abs( this.y - v.y ) + Math.abs( this.z - v.z );
+
+		},
+
+		setFromSpherical: function ( s ) {
+
+			return this.setFromSphericalCoords( s.radius, s.phi, s.theta );
+
+		},
+
+		setFromSphericalCoords: function ( radius, phi, theta ) {
+
+			var sinPhiRadius = Math.sin( phi ) * radius;
+
+			this.x = sinPhiRadius * Math.sin( theta );
+			this.y = Math.cos( phi ) * radius;
+			this.z = sinPhiRadius * Math.cos( theta );
+
+			return this;
+
+		},
+
+		setFromCylindrical: function ( c ) {
+
+			return this.setFromCylindricalCoords( c.radius, c.theta, c.y );
+
+		},
+
+		setFromCylindricalCoords: function ( radius, theta, y ) {
+
+			this.x = radius * Math.sin( theta );
+			this.y = y;
+			this.z = radius * Math.cos( theta );
+
+			return this;
+
+		},
+
+		setFromMatrixPosition: function ( m ) {
+
+			var e = m.elements;
+
+			this.x = e[ 12 ];
+			this.y = e[ 13 ];
+			this.z = e[ 14 ];
+
+			return this;
+
+		},
+
+		setFromMatrixScale: function ( m ) {
+
+			var sx = this.setFromMatrixColumn( m, 0 ).length();
+			var sy = this.setFromMatrixColumn( m, 1 ).length();
+			var sz = this.setFromMatrixColumn( m, 2 ).length();
+
+			this.x = sx;
+			this.y = sy;
+			this.z = sz;
+
+			return this;
+
+		},
+
+		setFromMatrixColumn: function ( m, index ) {
+
+			return this.fromArray( m.elements, index * 4 );
+
+		},
+
+		equals: function ( v ) {
+
+			return ( ( v.x === this.x ) && ( v.y === this.y ) && ( v.z === this.z ) );
+
+		},
+
+		fromArray: function ( array, offset ) {
+
+			if ( offset === undefined ) offset = 0;
+
+			this.x = array[ offset ];
+			this.y = array[ offset + 1 ];
+			this.z = array[ offset + 2 ];
+
+			return this;
+
+		},
+
+		toArray: function ( array, offset ) {
+
+			if ( array === undefined ) array = [];
+			if ( offset === undefined ) offset = 0;
+
+			array[ offset ] = this.x;
+			array[ offset + 1 ] = this.y;
+			array[ offset + 2 ] = this.z;
+
+			return array;
+
+		},
+
+		fromBufferAttribute: function ( attribute, index, offset ) {
+
+			if ( offset !== undefined ) {
+
+				console.warn( 'THREE.Vector3: offset has been removed from .fromBufferAttribute().' );
+
+			}
+
+			this.x = attribute.getX( index );
+			this.y = attribute.getY( index );
+			this.z = attribute.getZ( index );
 
 			return this;
 
@@ -1088,6 +2345,8 @@ var Spacekit = (function (exports) {
 	 * @author bhouston / http://clara.io
 	 * @author tschw
 	 */
+
+	var _vector;
 
 	function Matrix3() {
 
@@ -1156,16 +2415,6 @@ var Spacekit = (function (exports) {
 
 		},
 
-		extractBasis: function ( xAxis, yAxis, zAxis ) {
-
-			xAxis.setFromMatrix3Column( this, 0 );
-			yAxis.setFromMatrix3Column( this, 1 );
-			zAxis.setFromMatrix3Column( this, 2 );
-
-			return this;
-
-		},
-
 		setFromMatrix4: function ( m ) {
 
 			var me = m.elements;
@@ -1179,6 +2428,26 @@ var Spacekit = (function (exports) {
 			);
 
 			return this;
+
+		},
+
+		applyToBufferAttribute: function ( attribute ) {
+
+			if ( _vector === undefined ) _vector = new Vector3();
+
+			for ( var i = 0, l = attribute.count; i < l; i ++ ) {
+
+				_vector.x = attribute.getX( i );
+				_vector.y = attribute.getY( i );
+				_vector.z = attribute.getZ( i );
+
+				_vector.applyMatrix3( this );
+
+				attribute.setXYZ( i, _vector.x, _vector.y, _vector.z );
+
+			}
+
+			return attribute;
 
 		},
 
@@ -1250,9 +2519,9 @@ var Spacekit = (function (exports) {
 
 		getInverse: function ( matrix, throwOnDegenerate ) {
 
-			if ( throwOnDegenerate !== undefined ) {
+			if ( matrix && matrix.isMatrix4 ) {
 
-				console.warn( "THREE.Matrix3: .getInverse() can no longer be configured to throw on degenerate." );
+				console.error( "THREE.Matrix3: .getInverse() no longer takes a Matrix4 argument." );
 
 			}
 
@@ -1269,7 +2538,23 @@ var Spacekit = (function (exports) {
 
 				det = n11 * t11 + n21 * t12 + n31 * t13;
 
-			if ( det === 0 ) return this.set( 0, 0, 0, 0, 0, 0, 0, 0, 0 );
+			if ( det === 0 ) {
+
+				var msg = "THREE.Matrix3: .getInverse() can't invert matrix, determinant is 0";
+
+				if ( throwOnDegenerate === true ) {
+
+					throw new Error( msg );
+
+				} else {
+
+					console.warn( msg );
+
+				}
+
+				return this.identity();
+
+			}
 
 			var detInv = 1 / det;
 
@@ -1507,7 +2792,7 @@ var Spacekit = (function (exports) {
 
 		Object.defineProperty( this, 'id', { value: textureId ++ } );
 
-		this.uuid = MathUtils.generateUUID();
+		this.uuid = _Math.generateUUID();
 
 		this.name = '';
 
@@ -1525,7 +2810,6 @@ var Spacekit = (function (exports) {
 		this.anisotropy = anisotropy !== undefined ? anisotropy : 1;
 
 		this.format = format !== undefined ? format : RGBAFormat;
-		this.internalFormat = null;
 		this.type = type !== undefined ? type : UnsignedByteType;
 
 		this.offset = new Vector2( 0, 0 );
@@ -1591,7 +2875,6 @@ var Spacekit = (function (exports) {
 			this.anisotropy = source.anisotropy;
 
 			this.format = source.format;
-			this.internalFormat = source.internalFormat;
 			this.type = source.type;
 
 			this.offset.copy( source.offset );
@@ -1665,7 +2948,7 @@ var Spacekit = (function (exports) {
 
 				if ( image.uuid === undefined ) {
 
-					image.uuid = MathUtils.generateUUID(); // UGH
+					image.uuid = _Math.generateUUID(); // UGH
 
 				}
 
@@ -1751,7 +3034,6 @@ var Spacekit = (function (exports) {
 							uv.x = uv.x - Math.floor( uv.x );
 
 						}
-
 						break;
 
 				}
@@ -1783,7 +3065,6 @@ var Spacekit = (function (exports) {
 							uv.y = uv.y - Math.floor( uv.y );
 
 						}
-
 						break;
 
 				}
@@ -2460,17 +3741,6 @@ var Spacekit = (function (exports) {
 
 			return this;
 
-		},
-
-		random: function () {
-
-			this.x = Math.random();
-			this.y = Math.random();
-			this.z = Math.random();
-			this.w = Math.random();
-
-			return this;
-
 		}
 
 	} );
@@ -2498,7 +3768,7 @@ var Spacekit = (function (exports) {
 
 		options = options || {};
 
-		this.texture = new Texture( undefined, options.mapping, options.wrapS, options.wrapT, options.magFilter, options.minFilter, options.format, options.type, options.anisotropy, options.encoding );
+		this.texture = new Texture( undefined, undefined, options.wrapS, options.wrapT, options.magFilter, options.minFilter, options.format, options.type, options.anisotropy, options.encoding );
 
 		this.texture.image = {};
 		this.texture.image.width = width;
@@ -2599,1408 +3869,6 @@ var Spacekit = (function (exports) {
 		}
 
 	} );
-
-	/**
-	 * @author mikael emtinger / http://gomo.se/
-	 * @author alteredq / http://alteredqualia.com/
-	 * @author WestLangley / http://github.com/WestLangley
-	 * @author bhouston / http://clara.io
-	 */
-
-	function Quaternion( x, y, z, w ) {
-
-		this._x = x || 0;
-		this._y = y || 0;
-		this._z = z || 0;
-		this._w = ( w !== undefined ) ? w : 1;
-
-	}
-
-	Object.assign( Quaternion, {
-
-		slerp: function ( qa, qb, qm, t ) {
-
-			return qm.copy( qa ).slerp( qb, t );
-
-		},
-
-		slerpFlat: function ( dst, dstOffset, src0, srcOffset0, src1, srcOffset1, t ) {
-
-			// fuzz-free, array-based Quaternion SLERP operation
-
-			var x0 = src0[ srcOffset0 + 0 ],
-				y0 = src0[ srcOffset0 + 1 ],
-				z0 = src0[ srcOffset0 + 2 ],
-				w0 = src0[ srcOffset0 + 3 ],
-
-				x1 = src1[ srcOffset1 + 0 ],
-				y1 = src1[ srcOffset1 + 1 ],
-				z1 = src1[ srcOffset1 + 2 ],
-				w1 = src1[ srcOffset1 + 3 ];
-
-			if ( w0 !== w1 || x0 !== x1 || y0 !== y1 || z0 !== z1 ) {
-
-				var s = 1 - t,
-
-					cos = x0 * x1 + y0 * y1 + z0 * z1 + w0 * w1,
-
-					dir = ( cos >= 0 ? 1 : - 1 ),
-					sqrSin = 1 - cos * cos;
-
-				// Skip the Slerp for tiny steps to avoid numeric problems:
-				if ( sqrSin > Number.EPSILON ) {
-
-					var sin = Math.sqrt( sqrSin ),
-						len = Math.atan2( sin, cos * dir );
-
-					s = Math.sin( s * len ) / sin;
-					t = Math.sin( t * len ) / sin;
-
-				}
-
-				var tDir = t * dir;
-
-				x0 = x0 * s + x1 * tDir;
-				y0 = y0 * s + y1 * tDir;
-				z0 = z0 * s + z1 * tDir;
-				w0 = w0 * s + w1 * tDir;
-
-				// Normalize in case we just did a lerp:
-				if ( s === 1 - t ) {
-
-					var f = 1 / Math.sqrt( x0 * x0 + y0 * y0 + z0 * z0 + w0 * w0 );
-
-					x0 *= f;
-					y0 *= f;
-					z0 *= f;
-					w0 *= f;
-
-				}
-
-			}
-
-			dst[ dstOffset ] = x0;
-			dst[ dstOffset + 1 ] = y0;
-			dst[ dstOffset + 2 ] = z0;
-			dst[ dstOffset + 3 ] = w0;
-
-		},
-
-		multiplyQuaternionsFlat: function ( dst, dstOffset, src0, srcOffset0, src1, srcOffset1 ) {
-
-			var x0 = src0[ srcOffset0 ];
-			var y0 = src0[ srcOffset0 + 1 ];
-			var z0 = src0[ srcOffset0 + 2 ];
-			var w0 = src0[ srcOffset0 + 3 ];
-
-			var x1 = src1[ srcOffset1 ];
-			var y1 = src1[ srcOffset1 + 1 ];
-			var z1 = src1[ srcOffset1 + 2 ];
-			var w1 = src1[ srcOffset1 + 3 ];
-
-			dst[ dstOffset ] = x0 * w1 + w0 * x1 + y0 * z1 - z0 * y1;
-			dst[ dstOffset + 1 ] = y0 * w1 + w0 * y1 + z0 * x1 - x0 * z1;
-			dst[ dstOffset + 2 ] = z0 * w1 + w0 * z1 + x0 * y1 - y0 * x1;
-			dst[ dstOffset + 3 ] = w0 * w1 - x0 * x1 - y0 * y1 - z0 * z1;
-
-			return dst;
-
-		}
-
-	} );
-
-	Object.defineProperties( Quaternion.prototype, {
-
-		x: {
-
-			get: function () {
-
-				return this._x;
-
-			},
-
-			set: function ( value ) {
-
-				this._x = value;
-				this._onChangeCallback();
-
-			}
-
-		},
-
-		y: {
-
-			get: function () {
-
-				return this._y;
-
-			},
-
-			set: function ( value ) {
-
-				this._y = value;
-				this._onChangeCallback();
-
-			}
-
-		},
-
-		z: {
-
-			get: function () {
-
-				return this._z;
-
-			},
-
-			set: function ( value ) {
-
-				this._z = value;
-				this._onChangeCallback();
-
-			}
-
-		},
-
-		w: {
-
-			get: function () {
-
-				return this._w;
-
-			},
-
-			set: function ( value ) {
-
-				this._w = value;
-				this._onChangeCallback();
-
-			}
-
-		}
-
-	} );
-
-	Object.assign( Quaternion.prototype, {
-
-		isQuaternion: true,
-
-		set: function ( x, y, z, w ) {
-
-			this._x = x;
-			this._y = y;
-			this._z = z;
-			this._w = w;
-
-			this._onChangeCallback();
-
-			return this;
-
-		},
-
-		clone: function () {
-
-			return new this.constructor( this._x, this._y, this._z, this._w );
-
-		},
-
-		copy: function ( quaternion ) {
-
-			this._x = quaternion.x;
-			this._y = quaternion.y;
-			this._z = quaternion.z;
-			this._w = quaternion.w;
-
-			this._onChangeCallback();
-
-			return this;
-
-		},
-
-		setFromEuler: function ( euler, update ) {
-
-			if ( ! ( euler && euler.isEuler ) ) {
-
-				throw new Error( 'THREE.Quaternion: .setFromEuler() now expects an Euler rotation rather than a Vector3 and order.' );
-
-			}
-
-			var x = euler._x, y = euler._y, z = euler._z, order = euler.order;
-
-			// http://www.mathworks.com/matlabcentral/fileexchange/
-			// 	20696-function-to-convert-between-dcm-euler-angles-quaternions-and-euler-vectors/
-			//	content/SpinCalc.m
-
-			var cos = Math.cos;
-			var sin = Math.sin;
-
-			var c1 = cos( x / 2 );
-			var c2 = cos( y / 2 );
-			var c3 = cos( z / 2 );
-
-			var s1 = sin( x / 2 );
-			var s2 = sin( y / 2 );
-			var s3 = sin( z / 2 );
-
-			switch ( order ) {
-
-				case 'XYZ':
-					this._x = s1 * c2 * c3 + c1 * s2 * s3;
-					this._y = c1 * s2 * c3 - s1 * c2 * s3;
-					this._z = c1 * c2 * s3 + s1 * s2 * c3;
-					this._w = c1 * c2 * c3 - s1 * s2 * s3;
-					break;
-
-				case 'YXZ':
-					this._x = s1 * c2 * c3 + c1 * s2 * s3;
-					this._y = c1 * s2 * c3 - s1 * c2 * s3;
-					this._z = c1 * c2 * s3 - s1 * s2 * c3;
-					this._w = c1 * c2 * c3 + s1 * s2 * s3;
-					break;
-
-				case 'ZXY':
-					this._x = s1 * c2 * c3 - c1 * s2 * s3;
-					this._y = c1 * s2 * c3 + s1 * c2 * s3;
-					this._z = c1 * c2 * s3 + s1 * s2 * c3;
-					this._w = c1 * c2 * c3 - s1 * s2 * s3;
-					break;
-
-				case 'ZYX':
-					this._x = s1 * c2 * c3 - c1 * s2 * s3;
-					this._y = c1 * s2 * c3 + s1 * c2 * s3;
-					this._z = c1 * c2 * s3 - s1 * s2 * c3;
-					this._w = c1 * c2 * c3 + s1 * s2 * s3;
-					break;
-
-				case 'YZX':
-					this._x = s1 * c2 * c3 + c1 * s2 * s3;
-					this._y = c1 * s2 * c3 + s1 * c2 * s3;
-					this._z = c1 * c2 * s3 - s1 * s2 * c3;
-					this._w = c1 * c2 * c3 - s1 * s2 * s3;
-					break;
-
-				case 'XZY':
-					this._x = s1 * c2 * c3 - c1 * s2 * s3;
-					this._y = c1 * s2 * c3 - s1 * c2 * s3;
-					this._z = c1 * c2 * s3 + s1 * s2 * c3;
-					this._w = c1 * c2 * c3 + s1 * s2 * s3;
-					break;
-
-				default:
-					console.warn( 'THREE.Quaternion: .setFromEuler() encountered an unknown order: ' + order );
-
-			}
-
-			if ( update !== false ) this._onChangeCallback();
-
-			return this;
-
-		},
-
-		setFromAxisAngle: function ( axis, angle ) {
-
-			// http://www.euclideanspace.com/maths/geometry/rotations/conversions/angleToQuaternion/index.htm
-
-			// assumes axis is normalized
-
-			var halfAngle = angle / 2, s = Math.sin( halfAngle );
-
-			this._x = axis.x * s;
-			this._y = axis.y * s;
-			this._z = axis.z * s;
-			this._w = Math.cos( halfAngle );
-
-			this._onChangeCallback();
-
-			return this;
-
-		},
-
-		setFromRotationMatrix: function ( m ) {
-
-			// http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/index.htm
-
-			// assumes the upper 3x3 of m is a pure rotation matrix (i.e, unscaled)
-
-			var te = m.elements,
-
-				m11 = te[ 0 ], m12 = te[ 4 ], m13 = te[ 8 ],
-				m21 = te[ 1 ], m22 = te[ 5 ], m23 = te[ 9 ],
-				m31 = te[ 2 ], m32 = te[ 6 ], m33 = te[ 10 ],
-
-				trace = m11 + m22 + m33,
-				s;
-
-			if ( trace > 0 ) {
-
-				s = 0.5 / Math.sqrt( trace + 1.0 );
-
-				this._w = 0.25 / s;
-				this._x = ( m32 - m23 ) * s;
-				this._y = ( m13 - m31 ) * s;
-				this._z = ( m21 - m12 ) * s;
-
-			} else if ( m11 > m22 && m11 > m33 ) {
-
-				s = 2.0 * Math.sqrt( 1.0 + m11 - m22 - m33 );
-
-				this._w = ( m32 - m23 ) / s;
-				this._x = 0.25 * s;
-				this._y = ( m12 + m21 ) / s;
-				this._z = ( m13 + m31 ) / s;
-
-			} else if ( m22 > m33 ) {
-
-				s = 2.0 * Math.sqrt( 1.0 + m22 - m11 - m33 );
-
-				this._w = ( m13 - m31 ) / s;
-				this._x = ( m12 + m21 ) / s;
-				this._y = 0.25 * s;
-				this._z = ( m23 + m32 ) / s;
-
-			} else {
-
-				s = 2.0 * Math.sqrt( 1.0 + m33 - m11 - m22 );
-
-				this._w = ( m21 - m12 ) / s;
-				this._x = ( m13 + m31 ) / s;
-				this._y = ( m23 + m32 ) / s;
-				this._z = 0.25 * s;
-
-			}
-
-			this._onChangeCallback();
-
-			return this;
-
-		},
-
-		setFromUnitVectors: function ( vFrom, vTo ) {
-
-			// assumes direction vectors vFrom and vTo are normalized
-
-			var EPS = 0.000001;
-
-			var r = vFrom.dot( vTo ) + 1;
-
-			if ( r < EPS ) {
-
-				r = 0;
-
-				if ( Math.abs( vFrom.x ) > Math.abs( vFrom.z ) ) {
-
-					this._x = - vFrom.y;
-					this._y = vFrom.x;
-					this._z = 0;
-					this._w = r;
-
-				} else {
-
-					this._x = 0;
-					this._y = - vFrom.z;
-					this._z = vFrom.y;
-					this._w = r;
-
-				}
-
-			} else {
-
-				// crossVectors( vFrom, vTo ); // inlined to avoid cyclic dependency on Vector3
-
-				this._x = vFrom.y * vTo.z - vFrom.z * vTo.y;
-				this._y = vFrom.z * vTo.x - vFrom.x * vTo.z;
-				this._z = vFrom.x * vTo.y - vFrom.y * vTo.x;
-				this._w = r;
-
-			}
-
-			return this.normalize();
-
-		},
-
-		angleTo: function ( q ) {
-
-			return 2 * Math.acos( Math.abs( MathUtils.clamp( this.dot( q ), - 1, 1 ) ) );
-
-		},
-
-		rotateTowards: function ( q, step ) {
-
-			var angle = this.angleTo( q );
-
-			if ( angle === 0 ) return this;
-
-			var t = Math.min( 1, step / angle );
-
-			this.slerp( q, t );
-
-			return this;
-
-		},
-
-		inverse: function () {
-
-			// quaternion is assumed to have unit length
-
-			return this.conjugate();
-
-		},
-
-		conjugate: function () {
-
-			this._x *= - 1;
-			this._y *= - 1;
-			this._z *= - 1;
-
-			this._onChangeCallback();
-
-			return this;
-
-		},
-
-		dot: function ( v ) {
-
-			return this._x * v._x + this._y * v._y + this._z * v._z + this._w * v._w;
-
-		},
-
-		lengthSq: function () {
-
-			return this._x * this._x + this._y * this._y + this._z * this._z + this._w * this._w;
-
-		},
-
-		length: function () {
-
-			return Math.sqrt( this._x * this._x + this._y * this._y + this._z * this._z + this._w * this._w );
-
-		},
-
-		normalize: function () {
-
-			var l = this.length();
-
-			if ( l === 0 ) {
-
-				this._x = 0;
-				this._y = 0;
-				this._z = 0;
-				this._w = 1;
-
-			} else {
-
-				l = 1 / l;
-
-				this._x = this._x * l;
-				this._y = this._y * l;
-				this._z = this._z * l;
-				this._w = this._w * l;
-
-			}
-
-			this._onChangeCallback();
-
-			return this;
-
-		},
-
-		multiply: function ( q, p ) {
-
-			if ( p !== undefined ) {
-
-				console.warn( 'THREE.Quaternion: .multiply() now only accepts one argument. Use .multiplyQuaternions( a, b ) instead.' );
-				return this.multiplyQuaternions( q, p );
-
-			}
-
-			return this.multiplyQuaternions( this, q );
-
-		},
-
-		premultiply: function ( q ) {
-
-			return this.multiplyQuaternions( q, this );
-
-		},
-
-		multiplyQuaternions: function ( a, b ) {
-
-			// from http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/code/index.htm
-
-			var qax = a._x, qay = a._y, qaz = a._z, qaw = a._w;
-			var qbx = b._x, qby = b._y, qbz = b._z, qbw = b._w;
-
-			this._x = qax * qbw + qaw * qbx + qay * qbz - qaz * qby;
-			this._y = qay * qbw + qaw * qby + qaz * qbx - qax * qbz;
-			this._z = qaz * qbw + qaw * qbz + qax * qby - qay * qbx;
-			this._w = qaw * qbw - qax * qbx - qay * qby - qaz * qbz;
-
-			this._onChangeCallback();
-
-			return this;
-
-		},
-
-		slerp: function ( qb, t ) {
-
-			if ( t === 0 ) return this;
-			if ( t === 1 ) return this.copy( qb );
-
-			var x = this._x, y = this._y, z = this._z, w = this._w;
-
-			// http://www.euclideanspace.com/maths/algebra/realNormedAlgebra/quaternions/slerp/
-
-			var cosHalfTheta = w * qb._w + x * qb._x + y * qb._y + z * qb._z;
-
-			if ( cosHalfTheta < 0 ) {
-
-				this._w = - qb._w;
-				this._x = - qb._x;
-				this._y = - qb._y;
-				this._z = - qb._z;
-
-				cosHalfTheta = - cosHalfTheta;
-
-			} else {
-
-				this.copy( qb );
-
-			}
-
-			if ( cosHalfTheta >= 1.0 ) {
-
-				this._w = w;
-				this._x = x;
-				this._y = y;
-				this._z = z;
-
-				return this;
-
-			}
-
-			var sqrSinHalfTheta = 1.0 - cosHalfTheta * cosHalfTheta;
-
-			if ( sqrSinHalfTheta <= Number.EPSILON ) {
-
-				var s = 1 - t;
-				this._w = s * w + t * this._w;
-				this._x = s * x + t * this._x;
-				this._y = s * y + t * this._y;
-				this._z = s * z + t * this._z;
-
-				this.normalize();
-				this._onChangeCallback();
-
-				return this;
-
-			}
-
-			var sinHalfTheta = Math.sqrt( sqrSinHalfTheta );
-			var halfTheta = Math.atan2( sinHalfTheta, cosHalfTheta );
-			var ratioA = Math.sin( ( 1 - t ) * halfTheta ) / sinHalfTheta,
-				ratioB = Math.sin( t * halfTheta ) / sinHalfTheta;
-
-			this._w = ( w * ratioA + this._w * ratioB );
-			this._x = ( x * ratioA + this._x * ratioB );
-			this._y = ( y * ratioA + this._y * ratioB );
-			this._z = ( z * ratioA + this._z * ratioB );
-
-			this._onChangeCallback();
-
-			return this;
-
-		},
-
-		equals: function ( quaternion ) {
-
-			return ( quaternion._x === this._x ) && ( quaternion._y === this._y ) && ( quaternion._z === this._z ) && ( quaternion._w === this._w );
-
-		},
-
-		fromArray: function ( array, offset ) {
-
-			if ( offset === undefined ) offset = 0;
-
-			this._x = array[ offset ];
-			this._y = array[ offset + 1 ];
-			this._z = array[ offset + 2 ];
-			this._w = array[ offset + 3 ];
-
-			this._onChangeCallback();
-
-			return this;
-
-		},
-
-		toArray: function ( array, offset ) {
-
-			if ( array === undefined ) array = [];
-			if ( offset === undefined ) offset = 0;
-
-			array[ offset ] = this._x;
-			array[ offset + 1 ] = this._y;
-			array[ offset + 2 ] = this._z;
-			array[ offset + 3 ] = this._w;
-
-			return array;
-
-		},
-
-		fromBufferAttribute: function ( attribute, index ) {
-
-			this._x = attribute.getX( index );
-			this._y = attribute.getY( index );
-			this._z = attribute.getZ( index );
-			this._w = attribute.getW( index );
-
-			return this;
-
-		},
-
-		_onChange: function ( callback ) {
-
-			this._onChangeCallback = callback;
-
-			return this;
-
-		},
-
-		_onChangeCallback: function () {}
-
-	} );
-
-	/**
-	 * @author mrdoob / http://mrdoob.com/
-	 * @author kile / http://kile.stravaganza.org/
-	 * @author philogb / http://blog.thejit.org/
-	 * @author mikael emtinger / http://gomo.se/
-	 * @author egraether / http://egraether.com/
-	 * @author WestLangley / http://github.com/WestLangley
-	 */
-
-	var _vector = new Vector3();
-	var _quaternion = new Quaternion();
-
-	function Vector3( x, y, z ) {
-
-		this.x = x || 0;
-		this.y = y || 0;
-		this.z = z || 0;
-
-	}
-
-	Object.assign( Vector3.prototype, {
-
-		isVector3: true,
-
-		set: function ( x, y, z ) {
-
-			this.x = x;
-			this.y = y;
-			this.z = z;
-
-			return this;
-
-		},
-
-		setScalar: function ( scalar ) {
-
-			this.x = scalar;
-			this.y = scalar;
-			this.z = scalar;
-
-			return this;
-
-		},
-
-		setX: function ( x ) {
-
-			this.x = x;
-
-			return this;
-
-		},
-
-		setY: function ( y ) {
-
-			this.y = y;
-
-			return this;
-
-		},
-
-		setZ: function ( z ) {
-
-			this.z = z;
-
-			return this;
-
-		},
-
-		setComponent: function ( index, value ) {
-
-			switch ( index ) {
-
-				case 0: this.x = value; break;
-				case 1: this.y = value; break;
-				case 2: this.z = value; break;
-				default: throw new Error( 'index is out of range: ' + index );
-
-			}
-
-			return this;
-
-		},
-
-		getComponent: function ( index ) {
-
-			switch ( index ) {
-
-				case 0: return this.x;
-				case 1: return this.y;
-				case 2: return this.z;
-				default: throw new Error( 'index is out of range: ' + index );
-
-			}
-
-		},
-
-		clone: function () {
-
-			return new this.constructor( this.x, this.y, this.z );
-
-		},
-
-		copy: function ( v ) {
-
-			this.x = v.x;
-			this.y = v.y;
-			this.z = v.z;
-
-			return this;
-
-		},
-
-		add: function ( v, w ) {
-
-			if ( w !== undefined ) {
-
-				console.warn( 'THREE.Vector3: .add() now only accepts one argument. Use .addVectors( a, b ) instead.' );
-				return this.addVectors( v, w );
-
-			}
-
-			this.x += v.x;
-			this.y += v.y;
-			this.z += v.z;
-
-			return this;
-
-		},
-
-		addScalar: function ( s ) {
-
-			this.x += s;
-			this.y += s;
-			this.z += s;
-
-			return this;
-
-		},
-
-		addVectors: function ( a, b ) {
-
-			this.x = a.x + b.x;
-			this.y = a.y + b.y;
-			this.z = a.z + b.z;
-
-			return this;
-
-		},
-
-		addScaledVector: function ( v, s ) {
-
-			this.x += v.x * s;
-			this.y += v.y * s;
-			this.z += v.z * s;
-
-			return this;
-
-		},
-
-		sub: function ( v, w ) {
-
-			if ( w !== undefined ) {
-
-				console.warn( 'THREE.Vector3: .sub() now only accepts one argument. Use .subVectors( a, b ) instead.' );
-				return this.subVectors( v, w );
-
-			}
-
-			this.x -= v.x;
-			this.y -= v.y;
-			this.z -= v.z;
-
-			return this;
-
-		},
-
-		subScalar: function ( s ) {
-
-			this.x -= s;
-			this.y -= s;
-			this.z -= s;
-
-			return this;
-
-		},
-
-		subVectors: function ( a, b ) {
-
-			this.x = a.x - b.x;
-			this.y = a.y - b.y;
-			this.z = a.z - b.z;
-
-			return this;
-
-		},
-
-		multiply: function ( v, w ) {
-
-			if ( w !== undefined ) {
-
-				console.warn( 'THREE.Vector3: .multiply() now only accepts one argument. Use .multiplyVectors( a, b ) instead.' );
-				return this.multiplyVectors( v, w );
-
-			}
-
-			this.x *= v.x;
-			this.y *= v.y;
-			this.z *= v.z;
-
-			return this;
-
-		},
-
-		multiplyScalar: function ( scalar ) {
-
-			this.x *= scalar;
-			this.y *= scalar;
-			this.z *= scalar;
-
-			return this;
-
-		},
-
-		multiplyVectors: function ( a, b ) {
-
-			this.x = a.x * b.x;
-			this.y = a.y * b.y;
-			this.z = a.z * b.z;
-
-			return this;
-
-		},
-
-		applyEuler: function ( euler ) {
-
-			if ( ! ( euler && euler.isEuler ) ) {
-
-				console.error( 'THREE.Vector3: .applyEuler() now expects an Euler rotation rather than a Vector3 and order.' );
-
-			}
-
-			return this.applyQuaternion( _quaternion.setFromEuler( euler ) );
-
-		},
-
-		applyAxisAngle: function ( axis, angle ) {
-
-			return this.applyQuaternion( _quaternion.setFromAxisAngle( axis, angle ) );
-
-		},
-
-		applyMatrix3: function ( m ) {
-
-			var x = this.x, y = this.y, z = this.z;
-			var e = m.elements;
-
-			this.x = e[ 0 ] * x + e[ 3 ] * y + e[ 6 ] * z;
-			this.y = e[ 1 ] * x + e[ 4 ] * y + e[ 7 ] * z;
-			this.z = e[ 2 ] * x + e[ 5 ] * y + e[ 8 ] * z;
-
-			return this;
-
-		},
-
-		applyNormalMatrix: function ( m ) {
-
-			return this.applyMatrix3( m ).normalize();
-
-		},
-
-		applyMatrix4: function ( m ) {
-
-			var x = this.x, y = this.y, z = this.z;
-			var e = m.elements;
-
-			var w = 1 / ( e[ 3 ] * x + e[ 7 ] * y + e[ 11 ] * z + e[ 15 ] );
-
-			this.x = ( e[ 0 ] * x + e[ 4 ] * y + e[ 8 ] * z + e[ 12 ] ) * w;
-			this.y = ( e[ 1 ] * x + e[ 5 ] * y + e[ 9 ] * z + e[ 13 ] ) * w;
-			this.z = ( e[ 2 ] * x + e[ 6 ] * y + e[ 10 ] * z + e[ 14 ] ) * w;
-
-			return this;
-
-		},
-
-		applyQuaternion: function ( q ) {
-
-			var x = this.x, y = this.y, z = this.z;
-			var qx = q.x, qy = q.y, qz = q.z, qw = q.w;
-
-			// calculate quat * vector
-
-			var ix = qw * x + qy * z - qz * y;
-			var iy = qw * y + qz * x - qx * z;
-			var iz = qw * z + qx * y - qy * x;
-			var iw = - qx * x - qy * y - qz * z;
-
-			// calculate result * inverse quat
-
-			this.x = ix * qw + iw * - qx + iy * - qz - iz * - qy;
-			this.y = iy * qw + iw * - qy + iz * - qx - ix * - qz;
-			this.z = iz * qw + iw * - qz + ix * - qy - iy * - qx;
-
-			return this;
-
-		},
-
-		project: function ( camera ) {
-
-			return this.applyMatrix4( camera.matrixWorldInverse ).applyMatrix4( camera.projectionMatrix );
-
-		},
-
-		unproject: function ( camera ) {
-
-			return this.applyMatrix4( camera.projectionMatrixInverse ).applyMatrix4( camera.matrixWorld );
-
-		},
-
-		transformDirection: function ( m ) {
-
-			// input: THREE.Matrix4 affine matrix
-			// vector interpreted as a direction
-
-			var x = this.x, y = this.y, z = this.z;
-			var e = m.elements;
-
-			this.x = e[ 0 ] * x + e[ 4 ] * y + e[ 8 ] * z;
-			this.y = e[ 1 ] * x + e[ 5 ] * y + e[ 9 ] * z;
-			this.z = e[ 2 ] * x + e[ 6 ] * y + e[ 10 ] * z;
-
-			return this.normalize();
-
-		},
-
-		divide: function ( v ) {
-
-			this.x /= v.x;
-			this.y /= v.y;
-			this.z /= v.z;
-
-			return this;
-
-		},
-
-		divideScalar: function ( scalar ) {
-
-			return this.multiplyScalar( 1 / scalar );
-
-		},
-
-		min: function ( v ) {
-
-			this.x = Math.min( this.x, v.x );
-			this.y = Math.min( this.y, v.y );
-			this.z = Math.min( this.z, v.z );
-
-			return this;
-
-		},
-
-		max: function ( v ) {
-
-			this.x = Math.max( this.x, v.x );
-			this.y = Math.max( this.y, v.y );
-			this.z = Math.max( this.z, v.z );
-
-			return this;
-
-		},
-
-		clamp: function ( min, max ) {
-
-			// assumes min < max, componentwise
-
-			this.x = Math.max( min.x, Math.min( max.x, this.x ) );
-			this.y = Math.max( min.y, Math.min( max.y, this.y ) );
-			this.z = Math.max( min.z, Math.min( max.z, this.z ) );
-
-			return this;
-
-		},
-
-		clampScalar: function ( minVal, maxVal ) {
-
-			this.x = Math.max( minVal, Math.min( maxVal, this.x ) );
-			this.y = Math.max( minVal, Math.min( maxVal, this.y ) );
-			this.z = Math.max( minVal, Math.min( maxVal, this.z ) );
-
-			return this;
-
-		},
-
-		clampLength: function ( min, max ) {
-
-			var length = this.length();
-
-			return this.divideScalar( length || 1 ).multiplyScalar( Math.max( min, Math.min( max, length ) ) );
-
-		},
-
-		floor: function () {
-
-			this.x = Math.floor( this.x );
-			this.y = Math.floor( this.y );
-			this.z = Math.floor( this.z );
-
-			return this;
-
-		},
-
-		ceil: function () {
-
-			this.x = Math.ceil( this.x );
-			this.y = Math.ceil( this.y );
-			this.z = Math.ceil( this.z );
-
-			return this;
-
-		},
-
-		round: function () {
-
-			this.x = Math.round( this.x );
-			this.y = Math.round( this.y );
-			this.z = Math.round( this.z );
-
-			return this;
-
-		},
-
-		roundToZero: function () {
-
-			this.x = ( this.x < 0 ) ? Math.ceil( this.x ) : Math.floor( this.x );
-			this.y = ( this.y < 0 ) ? Math.ceil( this.y ) : Math.floor( this.y );
-			this.z = ( this.z < 0 ) ? Math.ceil( this.z ) : Math.floor( this.z );
-
-			return this;
-
-		},
-
-		negate: function () {
-
-			this.x = - this.x;
-			this.y = - this.y;
-			this.z = - this.z;
-
-			return this;
-
-		},
-
-		dot: function ( v ) {
-
-			return this.x * v.x + this.y * v.y + this.z * v.z;
-
-		},
-
-		// TODO lengthSquared?
-
-		lengthSq: function () {
-
-			return this.x * this.x + this.y * this.y + this.z * this.z;
-
-		},
-
-		length: function () {
-
-			return Math.sqrt( this.x * this.x + this.y * this.y + this.z * this.z );
-
-		},
-
-		manhattanLength: function () {
-
-			return Math.abs( this.x ) + Math.abs( this.y ) + Math.abs( this.z );
-
-		},
-
-		normalize: function () {
-
-			return this.divideScalar( this.length() || 1 );
-
-		},
-
-		setLength: function ( length ) {
-
-			return this.normalize().multiplyScalar( length );
-
-		},
-
-		lerp: function ( v, alpha ) {
-
-			this.x += ( v.x - this.x ) * alpha;
-			this.y += ( v.y - this.y ) * alpha;
-			this.z += ( v.z - this.z ) * alpha;
-
-			return this;
-
-		},
-
-		lerpVectors: function ( v1, v2, alpha ) {
-
-			return this.subVectors( v2, v1 ).multiplyScalar( alpha ).add( v1 );
-
-		},
-
-		cross: function ( v, w ) {
-
-			if ( w !== undefined ) {
-
-				console.warn( 'THREE.Vector3: .cross() now only accepts one argument. Use .crossVectors( a, b ) instead.' );
-				return this.crossVectors( v, w );
-
-			}
-
-			return this.crossVectors( this, v );
-
-		},
-
-		crossVectors: function ( a, b ) {
-
-			var ax = a.x, ay = a.y, az = a.z;
-			var bx = b.x, by = b.y, bz = b.z;
-
-			this.x = ay * bz - az * by;
-			this.y = az * bx - ax * bz;
-			this.z = ax * by - ay * bx;
-
-			return this;
-
-		},
-
-		projectOnVector: function ( v ) {
-
-			var denominator = v.lengthSq();
-
-			if ( denominator === 0 ) return this.set( 0, 0, 0 );
-
-			var scalar = v.dot( this ) / denominator;
-
-			return this.copy( v ).multiplyScalar( scalar );
-
-		},
-
-		projectOnPlane: function ( planeNormal ) {
-
-			_vector.copy( this ).projectOnVector( planeNormal );
-
-			return this.sub( _vector );
-
-		},
-
-		reflect: function ( normal ) {
-
-			// reflect incident vector off plane orthogonal to normal
-			// normal is assumed to have unit length
-
-			return this.sub( _vector.copy( normal ).multiplyScalar( 2 * this.dot( normal ) ) );
-
-		},
-
-		angleTo: function ( v ) {
-
-			var denominator = Math.sqrt( this.lengthSq() * v.lengthSq() );
-
-			if ( denominator === 0 ) return Math.PI / 2;
-
-			var theta = this.dot( v ) / denominator;
-
-			// clamp, to handle numerical problems
-
-			return Math.acos( MathUtils.clamp( theta, - 1, 1 ) );
-
-		},
-
-		distanceTo: function ( v ) {
-
-			return Math.sqrt( this.distanceToSquared( v ) );
-
-		},
-
-		distanceToSquared: function ( v ) {
-
-			var dx = this.x - v.x, dy = this.y - v.y, dz = this.z - v.z;
-
-			return dx * dx + dy * dy + dz * dz;
-
-		},
-
-		manhattanDistanceTo: function ( v ) {
-
-			return Math.abs( this.x - v.x ) + Math.abs( this.y - v.y ) + Math.abs( this.z - v.z );
-
-		},
-
-		setFromSpherical: function ( s ) {
-
-			return this.setFromSphericalCoords( s.radius, s.phi, s.theta );
-
-		},
-
-		setFromSphericalCoords: function ( radius, phi, theta ) {
-
-			var sinPhiRadius = Math.sin( phi ) * radius;
-
-			this.x = sinPhiRadius * Math.sin( theta );
-			this.y = Math.cos( phi ) * radius;
-			this.z = sinPhiRadius * Math.cos( theta );
-
-			return this;
-
-		},
-
-		setFromCylindrical: function ( c ) {
-
-			return this.setFromCylindricalCoords( c.radius, c.theta, c.y );
-
-		},
-
-		setFromCylindricalCoords: function ( radius, theta, y ) {
-
-			this.x = radius * Math.sin( theta );
-			this.y = y;
-			this.z = radius * Math.cos( theta );
-
-			return this;
-
-		},
-
-		setFromMatrixPosition: function ( m ) {
-
-			var e = m.elements;
-
-			this.x = e[ 12 ];
-			this.y = e[ 13 ];
-			this.z = e[ 14 ];
-
-			return this;
-
-		},
-
-		setFromMatrixScale: function ( m ) {
-
-			var sx = this.setFromMatrixColumn( m, 0 ).length();
-			var sy = this.setFromMatrixColumn( m, 1 ).length();
-			var sz = this.setFromMatrixColumn( m, 2 ).length();
-
-			this.x = sx;
-			this.y = sy;
-			this.z = sz;
-
-			return this;
-
-		},
-
-		setFromMatrixColumn: function ( m, index ) {
-
-			return this.fromArray( m.elements, index * 4 );
-
-		},
-
-		setFromMatrix3Column: function ( m, index ) {
-
-			return this.fromArray( m.elements, index * 3 );
-
-		},
-
-		equals: function ( v ) {
-
-			return ( ( v.x === this.x ) && ( v.y === this.y ) && ( v.z === this.z ) );
-
-		},
-
-		fromArray: function ( array, offset ) {
-
-			if ( offset === undefined ) offset = 0;
-
-			this.x = array[ offset ];
-			this.y = array[ offset + 1 ];
-			this.z = array[ offset + 2 ];
-
-			return this;
-
-		},
-
-		toArray: function ( array, offset ) {
-
-			if ( array === undefined ) array = [];
-			if ( offset === undefined ) offset = 0;
-
-			array[ offset ] = this.x;
-			array[ offset + 1 ] = this.y;
-			array[ offset + 2 ] = this.z;
-
-			return array;
-
-		},
-
-		fromBufferAttribute: function ( attribute, index, offset ) {
-
-			if ( offset !== undefined ) {
-
-				console.warn( 'THREE.Vector3: offset has been removed from .fromBufferAttribute().' );
-
-			}
-
-			this.x = attribute.getX( index );
-			this.y = attribute.getY( index );
-			this.z = attribute.getZ( index );
-
-			return this;
-
-		},
-
-		random: function () {
-
-			this.x = Math.random();
-			this.y = Math.random();
-			this.z = Math.random();
-
-			return this;
-
-		}
-
-	} );
-
-	var _v1 = new Vector3();
-	var _m1 = new Matrix4();
-	var _zero = new Vector3( 0, 0, 0 );
-	var _one = new Vector3( 1, 1, 1 );
-	var _x = new Vector3();
-	var _y = new Vector3();
-	var _z = new Vector3();
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -4121,40 +3989,46 @@ var Spacekit = (function (exports) {
 
 		},
 
-		extractRotation: function ( m ) {
+		extractRotation: function () {
 
-			// this method does not support reflection matrices
+			var v1 = new Vector3();
 
-			var te = this.elements;
-			var me = m.elements;
+			return function extractRotation( m ) {
 
-			var scaleX = 1 / _v1.setFromMatrixColumn( m, 0 ).length();
-			var scaleY = 1 / _v1.setFromMatrixColumn( m, 1 ).length();
-			var scaleZ = 1 / _v1.setFromMatrixColumn( m, 2 ).length();
+				// this method does not support reflection matrices
 
-			te[ 0 ] = me[ 0 ] * scaleX;
-			te[ 1 ] = me[ 1 ] * scaleX;
-			te[ 2 ] = me[ 2 ] * scaleX;
-			te[ 3 ] = 0;
+				var te = this.elements;
+				var me = m.elements;
 
-			te[ 4 ] = me[ 4 ] * scaleY;
-			te[ 5 ] = me[ 5 ] * scaleY;
-			te[ 6 ] = me[ 6 ] * scaleY;
-			te[ 7 ] = 0;
+				var scaleX = 1 / v1.setFromMatrixColumn( m, 0 ).length();
+				var scaleY = 1 / v1.setFromMatrixColumn( m, 1 ).length();
+				var scaleZ = 1 / v1.setFromMatrixColumn( m, 2 ).length();
 
-			te[ 8 ] = me[ 8 ] * scaleZ;
-			te[ 9 ] = me[ 9 ] * scaleZ;
-			te[ 10 ] = me[ 10 ] * scaleZ;
-			te[ 11 ] = 0;
+				te[ 0 ] = me[ 0 ] * scaleX;
+				te[ 1 ] = me[ 1 ] * scaleX;
+				te[ 2 ] = me[ 2 ] * scaleX;
+				te[ 3 ] = 0;
 
-			te[ 12 ] = 0;
-			te[ 13 ] = 0;
-			te[ 14 ] = 0;
-			te[ 15 ] = 1;
+				te[ 4 ] = me[ 4 ] * scaleY;
+				te[ 5 ] = me[ 5 ] * scaleY;
+				te[ 6 ] = me[ 6 ] * scaleY;
+				te[ 7 ] = 0;
 
-			return this;
+				te[ 8 ] = me[ 8 ] * scaleZ;
+				te[ 9 ] = me[ 9 ] * scaleZ;
+				te[ 10 ] = me[ 10 ] * scaleZ;
+				te[ 11 ] = 0;
 
-		},
+				te[ 12 ] = 0;
+				te[ 13 ] = 0;
+				te[ 14 ] = 0;
+				te[ 15 ] = 1;
+
+				return this;
+
+			};
+
+		}(),
 
 		makeRotationFromEuler: function ( euler ) {
 
@@ -4284,58 +4158,73 @@ var Spacekit = (function (exports) {
 
 		},
 
-		makeRotationFromQuaternion: function ( q ) {
+		makeRotationFromQuaternion: function () {
 
-			return this.compose( _zero, q, _one );
+			var zero = new Vector3( 0, 0, 0 );
+			var one = new Vector3( 1, 1, 1 );
 
-		},
+			return function makeRotationFromQuaternion( q ) {
 
-		lookAt: function ( eye, target, up ) {
+				return this.compose( zero, q, one );
 
-			var te = this.elements;
+			};
 
-			_z.subVectors( eye, target );
+		}(),
 
-			if ( _z.lengthSq() === 0 ) {
+		lookAt: function () {
 
-				// eye and target are in the same position
+			var x = new Vector3();
+			var y = new Vector3();
+			var z = new Vector3();
 
-				_z.z = 1;
+			return function lookAt( eye, target, up ) {
 
-			}
+				var te = this.elements;
 
-			_z.normalize();
-			_x.crossVectors( up, _z );
+				z.subVectors( eye, target );
 
-			if ( _x.lengthSq() === 0 ) {
+				if ( z.lengthSq() === 0 ) {
 
-				// up and z are parallel
+					// eye and target are in the same position
 
-				if ( Math.abs( up.z ) === 1 ) {
-
-					_z.x += 0.0001;
-
-				} else {
-
-					_z.z += 0.0001;
+					z.z = 1;
 
 				}
 
-				_z.normalize();
-				_x.crossVectors( up, _z );
+				z.normalize();
+				x.crossVectors( up, z );
 
-			}
+				if ( x.lengthSq() === 0 ) {
 
-			_x.normalize();
-			_y.crossVectors( _z, _x );
+					// up and z are parallel
 
-			te[ 0 ] = _x.x; te[ 4 ] = _y.x; te[ 8 ] = _z.x;
-			te[ 1 ] = _x.y; te[ 5 ] = _y.y; te[ 9 ] = _z.y;
-			te[ 2 ] = _x.z; te[ 6 ] = _y.z; te[ 10 ] = _z.z;
+					if ( Math.abs( up.z ) === 1 ) {
 
-			return this;
+						z.x += 0.0001;
 
-		},
+					} else {
+
+						z.z += 0.0001;
+
+					}
+
+					z.normalize();
+					x.crossVectors( up, z );
+
+				}
+
+				x.normalize();
+				y.crossVectors( z, x );
+
+				te[ 0 ] = x.x; te[ 4 ] = y.x; te[ 8 ] = z.x;
+				te[ 1 ] = x.y; te[ 5 ] = y.y; te[ 9 ] = z.y;
+				te[ 2 ] = x.z; te[ 6 ] = y.z; te[ 10 ] = z.z;
+
+				return this;
+
+			};
+
+		}(),
 
 		multiply: function ( m, n ) {
 
@@ -4408,6 +4297,30 @@ var Spacekit = (function (exports) {
 			return this;
 
 		},
+
+		applyToBufferAttribute: function () {
+
+			var v1 = new Vector3();
+
+			return function applyToBufferAttribute( attribute ) {
+
+				for ( var i = 0, l = attribute.count; i < l; i ++ ) {
+
+					v1.x = attribute.getX( i );
+					v1.y = attribute.getY( i );
+					v1.z = attribute.getZ( i );
+
+					v1.applyMatrix4( this );
+
+					attribute.setXYZ( i, v1.x, v1.y, v1.z );
+
+				}
+
+				return attribute;
+
+			};
+
+		}(),
 
 		determinant: function () {
 
@@ -4500,12 +4413,6 @@ var Spacekit = (function (exports) {
 
 		getInverse: function ( m, throwOnDegenerate ) {
 
-			if ( throwOnDegenerate !== undefined ) {
-
-				console.warn( "THREE.Matrix4: .getInverse() can no longer be configured to throw on degenerate." );
-
-			}
-
 			// based on http://www.euclideanspace.com/maths/algebra/matrix/functions/inverse/fourD/index.htm
 			var te = this.elements,
 				me = m.elements,
@@ -4522,7 +4429,23 @@ var Spacekit = (function (exports) {
 
 			var det = n11 * t11 + n21 * t12 + n31 * t13 + n41 * t14;
 
-			if ( det === 0 ) return this.set( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 );
+			if ( det === 0 ) {
+
+				var msg = "THREE.Matrix4: .getInverse() can't invert matrix, determinant is 0";
+
+				if ( throwOnDegenerate === true ) {
+
+					throw new Error( msg );
+
+				} else {
+
+					console.warn( msg );
+
+				}
+
+				return this.identity();
+
+			}
 
 			var detInv = 1 / det;
 
@@ -4731,50 +4654,57 @@ var Spacekit = (function (exports) {
 
 		},
 
-		decompose: function ( position, quaternion, scale ) {
+		decompose: function () {
 
-			var te = this.elements;
+			var vector = new Vector3();
+			var matrix = new Matrix4();
 
-			var sx = _v1.set( te[ 0 ], te[ 1 ], te[ 2 ] ).length();
-			var sy = _v1.set( te[ 4 ], te[ 5 ], te[ 6 ] ).length();
-			var sz = _v1.set( te[ 8 ], te[ 9 ], te[ 10 ] ).length();
+			return function decompose( position, quaternion, scale ) {
 
-			// if determine is negative, we need to invert one scale
-			var det = this.determinant();
-			if ( det < 0 ) sx = - sx;
+				var te = this.elements;
 
-			position.x = te[ 12 ];
-			position.y = te[ 13 ];
-			position.z = te[ 14 ];
+				var sx = vector.set( te[ 0 ], te[ 1 ], te[ 2 ] ).length();
+				var sy = vector.set( te[ 4 ], te[ 5 ], te[ 6 ] ).length();
+				var sz = vector.set( te[ 8 ], te[ 9 ], te[ 10 ] ).length();
 
-			// scale the rotation part
-			_m1.copy( this );
+				// if determine is negative, we need to invert one scale
+				var det = this.determinant();
+				if ( det < 0 ) sx = - sx;
 
-			var invSX = 1 / sx;
-			var invSY = 1 / sy;
-			var invSZ = 1 / sz;
+				position.x = te[ 12 ];
+				position.y = te[ 13 ];
+				position.z = te[ 14 ];
 
-			_m1.elements[ 0 ] *= invSX;
-			_m1.elements[ 1 ] *= invSX;
-			_m1.elements[ 2 ] *= invSX;
+				// scale the rotation part
+				matrix.copy( this );
 
-			_m1.elements[ 4 ] *= invSY;
-			_m1.elements[ 5 ] *= invSY;
-			_m1.elements[ 6 ] *= invSY;
+				var invSX = 1 / sx;
+				var invSY = 1 / sy;
+				var invSZ = 1 / sz;
 
-			_m1.elements[ 8 ] *= invSZ;
-			_m1.elements[ 9 ] *= invSZ;
-			_m1.elements[ 10 ] *= invSZ;
+				matrix.elements[ 0 ] *= invSX;
+				matrix.elements[ 1 ] *= invSX;
+				matrix.elements[ 2 ] *= invSX;
 
-			quaternion.setFromRotationMatrix( _m1 );
+				matrix.elements[ 4 ] *= invSY;
+				matrix.elements[ 5 ] *= invSY;
+				matrix.elements[ 6 ] *= invSY;
 
-			scale.x = sx;
-			scale.y = sy;
-			scale.z = sz;
+				matrix.elements[ 8 ] *= invSZ;
+				matrix.elements[ 9 ] *= invSZ;
+				matrix.elements[ 10 ] *= invSZ;
 
-			return this;
+				quaternion.setFromRotationMatrix( matrix );
 
-		},
+				scale.x = sx;
+				scale.y = sy;
+				scale.z = sz;
+
+				return this;
+
+			};
+
+		}(),
 
 		makePerspective: function ( left, right, top, bottom, near, far ) {
 
@@ -4890,8 +4820,7 @@ var Spacekit = (function (exports) {
 	 * @author bhouston / http://clara.io
 	 */
 
-	var _matrix = new Matrix4();
-	var _quaternion$1 = new Quaternion();
+	var _matrix, _quaternion;
 
 	function Euler( x, y, z, order ) {
 
@@ -5016,7 +4945,7 @@ var Spacekit = (function (exports) {
 
 		setFromRotationMatrix: function ( m, order, update ) {
 
-			var clamp = MathUtils.clamp;
+			var clamp = _Math.clamp;
 
 			// assumes the upper 3x3 of m is a pure rotation matrix (i.e, unscaled)
 
@@ -5027,119 +4956,105 @@ var Spacekit = (function (exports) {
 
 			order = order || this._order;
 
-			switch ( order ) {
+			if ( order === 'XYZ' ) {
 
-				case 'XYZ':
+				this._y = Math.asin( clamp( m13, - 1, 1 ) );
 
-					this._y = Math.asin( clamp( m13, - 1, 1 ) );
+				if ( Math.abs( m13 ) < 0.99999 ) {
 
-					if ( Math.abs( m13 ) < 0.9999999 ) {
+					this._x = Math.atan2( - m23, m33 );
+					this._z = Math.atan2( - m12, m11 );
 
-						this._x = Math.atan2( - m23, m33 );
-						this._z = Math.atan2( - m12, m11 );
+				} else {
 
-					} else {
+					this._x = Math.atan2( m32, m22 );
+					this._z = 0;
 
-						this._x = Math.atan2( m32, m22 );
-						this._z = 0;
+				}
 
-					}
+			} else if ( order === 'YXZ' ) {
 
-					break;
+				this._x = Math.asin( - clamp( m23, - 1, 1 ) );
 
-				case 'YXZ':
+				if ( Math.abs( m23 ) < 0.99999 ) {
 
-					this._x = Math.asin( - clamp( m23, - 1, 1 ) );
+					this._y = Math.atan2( m13, m33 );
+					this._z = Math.atan2( m21, m22 );
 
-					if ( Math.abs( m23 ) < 0.9999999 ) {
+				} else {
 
-						this._y = Math.atan2( m13, m33 );
-						this._z = Math.atan2( m21, m22 );
+					this._y = Math.atan2( - m31, m11 );
+					this._z = 0;
 
-					} else {
+				}
 
-						this._y = Math.atan2( - m31, m11 );
-						this._z = 0;
+			} else if ( order === 'ZXY' ) {
 
-					}
+				this._x = Math.asin( clamp( m32, - 1, 1 ) );
 
-					break;
+				if ( Math.abs( m32 ) < 0.99999 ) {
 
-				case 'ZXY':
+					this._y = Math.atan2( - m31, m33 );
+					this._z = Math.atan2( - m12, m22 );
 
-					this._x = Math.asin( clamp( m32, - 1, 1 ) );
+				} else {
 
-					if ( Math.abs( m32 ) < 0.9999999 ) {
+					this._y = 0;
+					this._z = Math.atan2( m21, m11 );
 
-						this._y = Math.atan2( - m31, m33 );
-						this._z = Math.atan2( - m12, m22 );
+				}
 
-					} else {
+			} else if ( order === 'ZYX' ) {
 
-						this._y = 0;
-						this._z = Math.atan2( m21, m11 );
+				this._y = Math.asin( - clamp( m31, - 1, 1 ) );
 
-					}
+				if ( Math.abs( m31 ) < 0.99999 ) {
 
-					break;
+					this._x = Math.atan2( m32, m33 );
+					this._z = Math.atan2( m21, m11 );
 
-				case 'ZYX':
+				} else {
 
-					this._y = Math.asin( - clamp( m31, - 1, 1 ) );
+					this._x = 0;
+					this._z = Math.atan2( - m12, m22 );
 
-					if ( Math.abs( m31 ) < 0.9999999 ) {
+				}
 
-						this._x = Math.atan2( m32, m33 );
-						this._z = Math.atan2( m21, m11 );
+			} else if ( order === 'YZX' ) {
 
-					} else {
+				this._z = Math.asin( clamp( m21, - 1, 1 ) );
 
-						this._x = 0;
-						this._z = Math.atan2( - m12, m22 );
+				if ( Math.abs( m21 ) < 0.99999 ) {
 
-					}
+					this._x = Math.atan2( - m23, m22 );
+					this._y = Math.atan2( - m31, m11 );
 
-					break;
+				} else {
 
-				case 'YZX':
+					this._x = 0;
+					this._y = Math.atan2( m13, m33 );
 
-					this._z = Math.asin( clamp( m21, - 1, 1 ) );
+				}
 
-					if ( Math.abs( m21 ) < 0.9999999 ) {
+			} else if ( order === 'XZY' ) {
 
-						this._x = Math.atan2( - m23, m22 );
-						this._y = Math.atan2( - m31, m11 );
+				this._z = Math.asin( - clamp( m12, - 1, 1 ) );
 
-					} else {
+				if ( Math.abs( m12 ) < 0.99999 ) {
 
-						this._x = 0;
-						this._y = Math.atan2( m13, m33 );
+					this._x = Math.atan2( m32, m22 );
+					this._y = Math.atan2( m13, m11 );
 
-					}
+				} else {
 
-					break;
+					this._x = Math.atan2( - m23, m33 );
+					this._y = 0;
 
-				case 'XZY':
+				}
 
-					this._z = Math.asin( - clamp( m12, - 1, 1 ) );
+			} else {
 
-					if ( Math.abs( m12 ) < 0.9999999 ) {
-
-						this._x = Math.atan2( m32, m22 );
-						this._y = Math.atan2( m13, m11 );
-
-					} else {
-
-						this._x = Math.atan2( - m23, m33 );
-						this._y = 0;
-
-					}
-
-					break;
-
-				default:
-
-					console.warn( 'THREE.Euler: .setFromRotationMatrix() encountered an unknown order: ' + order );
+				console.warn( 'THREE.Euler: .setFromRotationMatrix() given unsupported order: ' + order );
 
 			}
 
@@ -5152,6 +5067,8 @@ var Spacekit = (function (exports) {
 		},
 
 		setFromQuaternion: function ( q, order, update ) {
+
+			if ( _matrix === undefined ) _matrix = new Matrix4();
 
 			_matrix.makeRotationFromQuaternion( q );
 
@@ -5169,9 +5086,11 @@ var Spacekit = (function (exports) {
 
 			// WARNING: this discards revolution information -bhouston
 
-			_quaternion$1.setFromEuler( this );
+			if ( _quaternion === undefined ) _quaternion = new Quaternion();
 
-			return this.setFromQuaternion( _quaternion$1, newOrder );
+			_quaternion.setFromEuler( this );
+
+			return this.setFromQuaternion( _quaternion, newOrder );
 
 		},
 
@@ -5258,12 +5177,6 @@ var Spacekit = (function (exports) {
 
 		},
 
-		enableAll: function () {
-
-			this.mask = 0xffffffff | 0;
-
-		},
-
 		toggle: function ( channel ) {
 
 			this.mask ^= 1 << channel | 0;
@@ -5276,12 +5189,6 @@ var Spacekit = (function (exports) {
 
 		},
 
-		disableAll: function () {
-
-			this.mask = 0;
-
-		},
-
 		test: function ( layers ) {
 
 			return ( this.mask & layers.mask ) !== 0;
@@ -5289,24 +5196,6 @@ var Spacekit = (function (exports) {
 		}
 
 	} );
-
-	var _object3DId = 0;
-
-	var _v1$1 = new Vector3();
-	var _q1 = new Quaternion();
-	var _m1$1 = new Matrix4();
-	var _target = new Vector3();
-
-	var _position = new Vector3();
-	var _scale = new Vector3();
-	var _quaternion$2 = new Quaternion();
-
-	var _xAxis = new Vector3( 1, 0, 0 );
-	var _yAxis = new Vector3( 0, 1, 0 );
-	var _zAxis = new Vector3( 0, 0, 1 );
-
-	var _addedEvent = { type: 'added' };
-	var _removedEvent = { type: 'removed' };
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -5316,11 +5205,13 @@ var Spacekit = (function (exports) {
 	 * @author elephantatwork / www.elephantatwork.ch
 	 */
 
+	var object3DId = 0;
+
 	function Object3D() {
 
-		Object.defineProperty( this, 'id', { value: _object3DId ++ } );
+		Object.defineProperty( this, 'id', { value: object3DId ++ } );
 
-		this.uuid = MathUtils.generateUUID();
+		this.uuid = _Math.generateUUID();
 
 		this.name = '';
 		this.type = 'Object3D';
@@ -5410,7 +5301,7 @@ var Spacekit = (function (exports) {
 		onBeforeRender: function () {},
 		onAfterRender: function () {},
 
-		applyMatrix4: function ( matrix ) {
+		applyMatrix: function ( matrix ) {
 
 			if ( this.matrixAutoUpdate ) this.updateMatrix();
 
@@ -5458,81 +5349,135 @@ var Spacekit = (function (exports) {
 
 		},
 
-		rotateOnAxis: function ( axis, angle ) {
+		rotateOnAxis: function () {
 
 			// rotate object on axis in object space
 			// axis is assumed to be normalized
 
-			_q1.setFromAxisAngle( axis, angle );
+			var q1 = new Quaternion();
 
-			this.quaternion.multiply( _q1 );
+			return function rotateOnAxis( axis, angle ) {
 
-			return this;
+				q1.setFromAxisAngle( axis, angle );
 
-		},
+				this.quaternion.multiply( q1 );
 
-		rotateOnWorldAxis: function ( axis, angle ) {
+				return this;
+
+			};
+
+		}(),
+
+		rotateOnWorldAxis: function () {
 
 			// rotate object on axis in world space
 			// axis is assumed to be normalized
 			// method assumes no rotated parent
 
-			_q1.setFromAxisAngle( axis, angle );
+			var q1 = new Quaternion();
 
-			this.quaternion.premultiply( _q1 );
+			return function rotateOnWorldAxis( axis, angle ) {
 
-			return this;
+				q1.setFromAxisAngle( axis, angle );
 
-		},
+				this.quaternion.premultiply( q1 );
 
-		rotateX: function ( angle ) {
+				return this;
 
-			return this.rotateOnAxis( _xAxis, angle );
+			};
 
-		},
+		}(),
 
-		rotateY: function ( angle ) {
+		rotateX: function () {
 
-			return this.rotateOnAxis( _yAxis, angle );
+			var v1 = new Vector3( 1, 0, 0 );
 
-		},
+			return function rotateX( angle ) {
 
-		rotateZ: function ( angle ) {
+				return this.rotateOnAxis( v1, angle );
 
-			return this.rotateOnAxis( _zAxis, angle );
+			};
 
-		},
+		}(),
 
-		translateOnAxis: function ( axis, distance ) {
+		rotateY: function () {
+
+			var v1 = new Vector3( 0, 1, 0 );
+
+			return function rotateY( angle ) {
+
+				return this.rotateOnAxis( v1, angle );
+
+			};
+
+		}(),
+
+		rotateZ: function () {
+
+			var v1 = new Vector3( 0, 0, 1 );
+
+			return function rotateZ( angle ) {
+
+				return this.rotateOnAxis( v1, angle );
+
+			};
+
+		}(),
+
+		translateOnAxis: function () {
 
 			// translate object by distance along axis in object space
 			// axis is assumed to be normalized
 
-			_v1$1.copy( axis ).applyQuaternion( this.quaternion );
+			var v1 = new Vector3();
 
-			this.position.add( _v1$1.multiplyScalar( distance ) );
+			return function translateOnAxis( axis, distance ) {
 
-			return this;
+				v1.copy( axis ).applyQuaternion( this.quaternion );
 
-		},
+				this.position.add( v1.multiplyScalar( distance ) );
 
-		translateX: function ( distance ) {
+				return this;
 
-			return this.translateOnAxis( _xAxis, distance );
+			};
 
-		},
+		}(),
 
-		translateY: function ( distance ) {
+		translateX: function () {
 
-			return this.translateOnAxis( _yAxis, distance );
+			var v1 = new Vector3( 1, 0, 0 );
 
-		},
+			return function translateX( distance ) {
 
-		translateZ: function ( distance ) {
+				return this.translateOnAxis( v1, distance );
 
-			return this.translateOnAxis( _zAxis, distance );
+			};
 
-		},
+		}(),
+
+		translateY: function () {
+
+			var v1 = new Vector3( 0, 1, 0 );
+
+			return function translateY( distance ) {
+
+				return this.translateOnAxis( v1, distance );
+
+			};
+
+		}(),
+
+		translateZ: function () {
+
+			var v1 = new Vector3( 0, 0, 1 );
+
+			return function translateZ( distance ) {
+
+				return this.translateOnAxis( v1, distance );
+
+			};
+
+		}(),
 
 		localToWorld: function ( vector ) {
 
@@ -5540,53 +5485,68 @@ var Spacekit = (function (exports) {
 
 		},
 
-		worldToLocal: function ( vector ) {
+		worldToLocal: function () {
 
-			return vector.applyMatrix4( _m1$1.getInverse( this.matrixWorld ) );
+			var m1 = new Matrix4();
 
-		},
+			return function worldToLocal( vector ) {
 
-		lookAt: function ( x, y, z ) {
+				return vector.applyMatrix4( m1.getInverse( this.matrixWorld ) );
+
+			};
+
+		}(),
+
+		lookAt: function () {
 
 			// This method does not support objects having non-uniformly-scaled parent(s)
 
-			if ( x.isVector3 ) {
+			var q1 = new Quaternion();
+			var m1 = new Matrix4();
+			var target = new Vector3();
+			var position = new Vector3();
 
-				_target.copy( x );
+			return function lookAt( x, y, z ) {
 
-			} else {
+				if ( x.isVector3 ) {
 
-				_target.set( x, y, z );
+					target.copy( x );
 
-			}
+				} else {
 
-			var parent = this.parent;
+					target.set( x, y, z );
 
-			this.updateWorldMatrix( true, false );
+				}
 
-			_position.setFromMatrixPosition( this.matrixWorld );
+				var parent = this.parent;
 
-			if ( this.isCamera || this.isLight ) {
+				this.updateWorldMatrix( true, false );
 
-				_m1$1.lookAt( _position, _target, this.up );
+				position.setFromMatrixPosition( this.matrixWorld );
 
-			} else {
+				if ( this.isCamera || this.isLight ) {
 
-				_m1$1.lookAt( _target, _position, this.up );
+					m1.lookAt( position, target, this.up );
 
-			}
+				} else {
 
-			this.quaternion.setFromRotationMatrix( _m1$1 );
+					m1.lookAt( target, position, this.up );
 
-			if ( parent ) {
+				}
 
-				_m1$1.extractRotation( parent.matrixWorld );
-				_q1.setFromRotationMatrix( _m1$1 );
-				this.quaternion.premultiply( _q1.inverse() );
+				this.quaternion.setFromRotationMatrix( m1 );
 
-			}
+				if ( parent ) {
 
-		},
+					m1.extractRotation( parent.matrixWorld );
+					q1.setFromRotationMatrix( m1 );
+					this.quaternion.premultiply( q1.inverse() );
+
+				}
+
+			};
+
+		}(),
 
 		add: function ( object ) {
 
@@ -5620,7 +5580,7 @@ var Spacekit = (function (exports) {
 				object.parent = this;
 				this.children.push( object );
 
-				object.dispatchEvent( _addedEvent );
+				object.dispatchEvent( { type: 'added' } );
 
 			} else {
 
@@ -5653,7 +5613,7 @@ var Spacekit = (function (exports) {
 				object.parent = null;
 				this.children.splice( index, 1 );
 
-				object.dispatchEvent( _removedEvent );
+				object.dispatchEvent( { type: 'removed' } );
 
 			}
 
@@ -5661,31 +5621,37 @@ var Spacekit = (function (exports) {
 
 		},
 
-		attach: function ( object ) {
+		attach: function () {
 
 			// adds object as a child of this, while maintaining the object's world transform
 
-			this.updateWorldMatrix( true, false );
+			var m = new Matrix4();
 
-			_m1$1.getInverse( this.matrixWorld );
+			return function attach( object ) {
 
-			if ( object.parent !== null ) {
+				this.updateWorldMatrix( true, false );
 
-				object.parent.updateWorldMatrix( true, false );
+				m.getInverse( this.matrixWorld );
 
-				_m1$1.multiply( object.parent.matrixWorld );
+				if ( object.parent !== null ) {
 
-			}
+					object.parent.updateWorldMatrix( true, false );
 
-			object.applyMatrix4( _m1$1 );
+					m.multiply( object.parent.matrixWorld );
 
-			object.updateWorldMatrix( false, false );
+				}
 
-			this.add( object );
+				object.applyMatrix( m );
 
-			return this;
+				object.updateWorldMatrix( false, false );
 
-		},
+				this.add( object );
+
+				return this;
+
+			};
+
+		}(),
 
 		getObjectById: function ( id ) {
 
@@ -5735,39 +5701,53 @@ var Spacekit = (function (exports) {
 
 		},
 
-		getWorldQuaternion: function ( target ) {
+		getWorldQuaternion: function () {
 
-			if ( target === undefined ) {
+			var position = new Vector3();
+			var scale = new Vector3();
 
-				console.warn( 'THREE.Object3D: .getWorldQuaternion() target is now required' );
-				target = new Quaternion();
+			return function getWorldQuaternion( target ) {
 
-			}
+				if ( target === undefined ) {
 
-			this.updateMatrixWorld( true );
+					console.warn( 'THREE.Object3D: .getWorldQuaternion() target is now required' );
+					target = new Quaternion();
 
-			this.matrixWorld.decompose( _position, target, _scale );
+				}
 
-			return target;
+				this.updateMatrixWorld( true );
 
-		},
+				this.matrixWorld.decompose( position, target, scale );
 
-		getWorldScale: function ( target ) {
+				return target;
 
-			if ( target === undefined ) {
+			};
 
-				console.warn( 'THREE.Object3D: .getWorldScale() target is now required' );
-				target = new Vector3();
+		}(),
 
-			}
+		getWorldScale: function () {
 
-			this.updateMatrixWorld( true );
+			var position = new Vector3();
+			var quaternion = new Quaternion();
 
-			this.matrixWorld.decompose( _position, _quaternion$2, target );
+			return function getWorldScale( target ) {
 
-			return target;
+				if ( target === undefined ) {
 
-		},
+					console.warn( 'THREE.Object3D: .getWorldScale() target is now required' );
+					target = new Vector3();
+
+				}
+
+				this.updateMatrixWorld( true );
+
+				this.matrixWorld.decompose( position, quaternion, target );
+
+				return target;
+
+			};
+
+		}(),
 
 		getWorldDirection: function ( target ) {
 
@@ -5963,13 +5943,7 @@ var Spacekit = (function (exports) {
 
 			// object specific properties
 
-			if ( this.isInstancedMesh ) {
-
-				object.type = 'InstancedMesh';
-				object.count = this.count;
-				object.instanceMatrix = this.instanceMatrix.toJSON();
-
-			}
+			if ( this.isMesh && this.drawMode !== TrianglesDrawMode ) object.drawMode = this.drawMode;
 
 			//
 
@@ -6084,7 +6058,6 @@ var Spacekit = (function (exports) {
 					values.push( data );
 
 				}
-
 				return values;
 
 			}
@@ -6154,9 +6127,7 @@ var Spacekit = (function (exports) {
 		this.type = 'Scene';
 
 		this.background = null;
-		this.environment = null;
 		this.fog = null;
-
 		this.overrideMaterial = null;
 
 		this.autoUpdate = true; // checked by the renderer
@@ -6180,9 +6151,7 @@ var Spacekit = (function (exports) {
 			Object3D.prototype.copy.call( this, source, recursive );
 
 			if ( source.background !== null ) this.background = source.background.clone();
-			if ( source.environment !== null ) this.environment = source.environment.clone();
 			if ( source.fog !== null ) this.fog = source.fog.clone();
-
 			if ( source.overrideMaterial !== null ) this.overrideMaterial = source.overrideMaterial.clone();
 
 			this.autoUpdate = source.autoUpdate;
@@ -6197,7 +6166,6 @@ var Spacekit = (function (exports) {
 			var data = Object3D.prototype.toJSON.call( this, meta );
 
 			if ( this.background !== null ) data.object.background = this.background.toJSON( meta );
-			if ( this.environment !== null ) data.object.environment = this.environment.toJSON( meta );
 			if ( this.fog !== null ) data.object.fog = this.fog.toJSON();
 
 			return data;
@@ -6212,38 +6180,6 @@ var Spacekit = (function (exports) {
 
 	} );
 
-	var _points = [
-		new Vector3(),
-		new Vector3(),
-		new Vector3(),
-		new Vector3(),
-		new Vector3(),
-		new Vector3(),
-		new Vector3(),
-		new Vector3()
-	];
-
-	var _vector$1 = new Vector3();
-
-	var _box = new Box3();
-
-	// triangle centered vertices
-
-	var _v0 = new Vector3();
-	var _v1$2 = new Vector3();
-	var _v2 = new Vector3();
-
-	// triangle edge vectors
-
-	var _f0 = new Vector3();
-	var _f1 = new Vector3();
-	var _f2 = new Vector3();
-
-	var _center = new Vector3();
-	var _extents = new Vector3();
-	var _triangleNormal = new Vector3();
-	var _testAxis = new Vector3();
-
 	/**
 	 * @author bhouston / http://clara.io
 	 * @author WestLangley / http://github.com/WestLangley
@@ -6255,7 +6191,6 @@ var Spacekit = (function (exports) {
 		this.max = ( max !== undefined ) ? max : new Vector3( - Infinity, - Infinity, - Infinity );
 
 	}
-
 
 	Object.assign( Box3.prototype, {
 
@@ -6350,16 +6285,22 @@ var Spacekit = (function (exports) {
 
 		},
 
-		setFromCenterAndSize: function ( center, size ) {
+		setFromCenterAndSize: function () {
 
-			var halfSize = _vector$1.copy( size ).multiplyScalar( 0.5 );
+			var v1 = new Vector3();
 
-			this.min.copy( center ).sub( halfSize );
-			this.max.copy( center ).add( halfSize );
+			return function setFromCenterAndSize( center, size ) {
 
-			return this;
+				var halfSize = v1.copy( size ).multiplyScalar( 0.5 );
 
-		},
+				this.min.copy( center ).sub( halfSize );
+				this.max.copy( center ).add( halfSize );
+
+				return this;
+
+			};
+
+		}(),
 
 		setFromObject: function ( object ) {
 
@@ -6454,41 +6395,69 @@ var Spacekit = (function (exports) {
 
 		},
 
-		expandByObject: function ( object ) {
+		expandByObject: function () {
 
 			// Computes the world-axis-aligned bounding box of an object (including its children),
 			// accounting for both the object's, and children's, world transforms
 
-			object.updateWorldMatrix( false, false );
+			var scope, i, l;
 
-			var geometry = object.geometry;
+			var v1 = new Vector3();
 
-			if ( geometry !== undefined ) {
+			function traverse( node ) {
 
-				if ( geometry.boundingBox === null ) {
+				var geometry = node.geometry;
 
-					geometry.computeBoundingBox();
+				if ( geometry !== undefined ) {
+
+					if ( geometry.isGeometry ) {
+
+						var vertices = geometry.vertices;
+
+						for ( i = 0, l = vertices.length; i < l; i ++ ) {
+
+							v1.copy( vertices[ i ] );
+							v1.applyMatrix4( node.matrixWorld );
+
+							scope.expandByPoint( v1 );
+
+						}
+
+					} else if ( geometry.isBufferGeometry ) {
+
+						var attribute = geometry.attributes.position;
+
+						if ( attribute !== undefined ) {
+
+							for ( i = 0, l = attribute.count; i < l; i ++ ) {
+
+								v1.fromBufferAttribute( attribute, i ).applyMatrix4( node.matrixWorld );
+
+								scope.expandByPoint( v1 );
+
+							}
+
+						}
+
+					}
 
 				}
 
-				_box.copy( geometry.boundingBox );
-				_box.applyMatrix4( object.matrixWorld );
-
-				this.union( _box );
-
 			}
 
-			var children = object.children;
+			return function expandByObject( object ) {
 
-			for ( var i = 0, l = children.length; i < l; i ++ ) {
+				scope = this;
 
-				this.expandByObject( children[ i ] );
+				object.updateMatrixWorld( true );
 
-			}
+				object.traverse( traverse );
 
-			return this;
+				return this;
 
-		},
+			};
+
+		}(),
 
 		containsPoint: function ( point ) {
 
@@ -6535,15 +6504,21 @@ var Spacekit = (function (exports) {
 
 		},
 
-		intersectsSphere: function ( sphere ) {
+		intersectsSphere: ( function () {
 
-			// Find the point on the AABB closest to the sphere center.
-			this.clampPoint( sphere.center, _vector$1 );
+			var closestPoint = new Vector3();
 
-			// If that point is inside the sphere, the AABB and sphere intersect.
-			return _vector$1.distanceToSquared( sphere.center ) <= ( sphere.radius * sphere.radius );
+			return function intersectsSphere( sphere ) {
 
-		},
+				// Find the point on the AABB closest to the sphere center.
+				this.clampPoint( sphere.center, closestPoint );
+
+				// If that point is inside the sphere, the AABB and sphere intersect.
+				return closestPoint.distanceToSquared( sphere.center ) <= ( sphere.radius * sphere.radius );
+
+			};
+
+		} )(),
 
 		intersectsPlane: function ( plane ) {
 
@@ -6592,58 +6567,106 @@ var Spacekit = (function (exports) {
 
 		},
 
-		intersectsTriangle: function ( triangle ) {
+		intersectsTriangle: ( function () {
 
-			if ( this.isEmpty() ) {
+			// triangle centered vertices
+			var v0 = new Vector3();
+			var v1 = new Vector3();
+			var v2 = new Vector3();
 
-				return false;
+			// triangle edge vectors
+			var f0 = new Vector3();
+			var f1 = new Vector3();
+			var f2 = new Vector3();
+
+			var testAxis = new Vector3();
+
+			var center = new Vector3();
+			var extents = new Vector3();
+
+			var triangleNormal = new Vector3();
+
+			function satForAxes( axes ) {
+
+				var i, j;
+
+				for ( i = 0, j = axes.length - 3; i <= j; i += 3 ) {
+
+					testAxis.fromArray( axes, i );
+					// project the aabb onto the seperating axis
+					var r = extents.x * Math.abs( testAxis.x ) + extents.y * Math.abs( testAxis.y ) + extents.z * Math.abs( testAxis.z );
+					// project all 3 vertices of the triangle onto the seperating axis
+					var p0 = v0.dot( testAxis );
+					var p1 = v1.dot( testAxis );
+					var p2 = v2.dot( testAxis );
+					// actual test, basically see if either of the most extreme of the triangle points intersects r
+					if ( Math.max( - Math.max( p0, p1, p2 ), Math.min( p0, p1, p2 ) ) > r ) {
+
+						// points of the projected triangle are outside the projected half-length of the aabb
+						// the axis is seperating and we can exit
+						return false;
+
+					}
+
+				}
+
+				return true;
 
 			}
 
-			// compute box center and extents
-			this.getCenter( _center );
-			_extents.subVectors( this.max, _center );
+			return function intersectsTriangle( triangle ) {
 
-			// translate triangle to aabb origin
-			_v0.subVectors( triangle.a, _center );
-			_v1$2.subVectors( triangle.b, _center );
-			_v2.subVectors( triangle.c, _center );
+				if ( this.isEmpty() ) {
 
-			// compute edge vectors for triangle
-			_f0.subVectors( _v1$2, _v0 );
-			_f1.subVectors( _v2, _v1$2 );
-			_f2.subVectors( _v0, _v2 );
+					return false;
 
-			// test against axes that are given by cross product combinations of the edges of the triangle and the edges of the aabb
-			// make an axis testing of each of the 3 sides of the aabb against each of the 3 sides of the triangle = 9 axis of separation
-			// axis_ij = u_i x f_j (u0, u1, u2 = face normals of aabb = x,y,z axes vectors since aabb is axis aligned)
-			var axes = [
-				0, - _f0.z, _f0.y, 0, - _f1.z, _f1.y, 0, - _f2.z, _f2.y,
-				_f0.z, 0, - _f0.x, _f1.z, 0, - _f1.x, _f2.z, 0, - _f2.x,
-				- _f0.y, _f0.x, 0, - _f1.y, _f1.x, 0, - _f2.y, _f2.x, 0
-			];
-			if ( ! satForAxes( axes, _v0, _v1$2, _v2, _extents ) ) {
+				}
 
-				return false;
+				// compute box center and extents
+				this.getCenter( center );
+				extents.subVectors( this.max, center );
 
-			}
+				// translate triangle to aabb origin
+				v0.subVectors( triangle.a, center );
+				v1.subVectors( triangle.b, center );
+				v2.subVectors( triangle.c, center );
 
-			// test 3 face normals from the aabb
-			axes = [ 1, 0, 0, 0, 1, 0, 0, 0, 1 ];
-			if ( ! satForAxes( axes, _v0, _v1$2, _v2, _extents ) ) {
+				// compute edge vectors for triangle
+				f0.subVectors( v1, v0 );
+				f1.subVectors( v2, v1 );
+				f2.subVectors( v0, v2 );
 
-				return false;
+				// test against axes that are given by cross product combinations of the edges of the triangle and the edges of the aabb
+				// make an axis testing of each of the 3 sides of the aabb against each of the 3 sides of the triangle = 9 axis of separation
+				// axis_ij = u_i x f_j (u0, u1, u2 = face normals of aabb = x,y,z axes vectors since aabb is axis aligned)
+				var axes = [
+					0, - f0.z, f0.y, 0, - f1.z, f1.y, 0, - f2.z, f2.y,
+					f0.z, 0, - f0.x, f1.z, 0, - f1.x, f2.z, 0, - f2.x,
+					- f0.y, f0.x, 0, - f1.y, f1.x, 0, - f2.y, f2.x, 0
+				];
+				if ( ! satForAxes( axes ) ) {
 
-			}
+					return false;
 
-			// finally testing the face normal of the triangle
-			// use already existing triangle edge vectors here
-			_triangleNormal.crossVectors( _f0, _f1 );
-			axes = [ _triangleNormal.x, _triangleNormal.y, _triangleNormal.z ];
+				}
 
-			return satForAxes( axes, _v0, _v1$2, _v2, _extents );
+				// test 3 face normals from the aabb
+				axes = [ 1, 0, 0, 0, 1, 0, 0, 0, 1 ];
+				if ( ! satForAxes( axes ) ) {
 
-		},
+					return false;
+
+				}
+
+				// finally testing the face normal of the triangle
+				// use already existing triangle edge vectors here
+				triangleNormal.crossVectors( f0, f1 );
+				axes = [ triangleNormal.x, triangleNormal.y, triangleNormal.z ];
+				return satForAxes( axes );
+
+			};
+
+		} )(),
 
 		clampPoint: function ( point, target ) {
 
@@ -6658,30 +6681,41 @@ var Spacekit = (function (exports) {
 
 		},
 
-		distanceToPoint: function ( point ) {
+		distanceToPoint: function () {
 
-			var clampedPoint = _vector$1.copy( point ).clamp( this.min, this.max );
+			var v1 = new Vector3();
 
-			return clampedPoint.sub( point ).length();
+			return function distanceToPoint( point ) {
 
-		},
+				var clampedPoint = v1.copy( point ).clamp( this.min, this.max );
+				return clampedPoint.sub( point ).length();
 
-		getBoundingSphere: function ( target ) {
+			};
 
-			if ( target === undefined ) {
+		}(),
 
-				console.error( 'THREE.Box3: .getBoundingSphere() target is now required' );
-				//target = new Sphere(); // removed to avoid cyclic dependency
+		getBoundingSphere: function () {
 
-			}
+			var v1 = new Vector3();
 
-			this.getCenter( target.center );
+			return function getBoundingSphere( target ) {
 
-			target.radius = this.getSize( _vector$1 ).length() * 0.5;
+				if ( target === undefined ) {
 
-			return target;
+					console.error( 'THREE.Box3: .getBoundingSphere() target is now required' );
+					//target = new Sphere(); // removed to avoid cyclic dependency
 
-		},
+				}
+
+				this.getCenter( target.center );
+
+				target.radius = this.getSize( v1 ).length() * 0.5;
+
+				return target;
+
+			};
+
+		}(),
 
 		intersect: function ( box ) {
 
@@ -6704,26 +6738,41 @@ var Spacekit = (function (exports) {
 
 		},
 
-		applyMatrix4: function ( matrix ) {
+		applyMatrix4: function () {
 
-			// transform of empty box is an empty box.
-			if ( this.isEmpty() ) return this;
+			var points = [
+				new Vector3(),
+				new Vector3(),
+				new Vector3(),
+				new Vector3(),
+				new Vector3(),
+				new Vector3(),
+				new Vector3(),
+				new Vector3()
+			];
 
-			// NOTE: I am using a binary pattern to specify all 2^3 combinations below
-			_points[ 0 ].set( this.min.x, this.min.y, this.min.z ).applyMatrix4( matrix ); // 000
-			_points[ 1 ].set( this.min.x, this.min.y, this.max.z ).applyMatrix4( matrix ); // 001
-			_points[ 2 ].set( this.min.x, this.max.y, this.min.z ).applyMatrix4( matrix ); // 010
-			_points[ 3 ].set( this.min.x, this.max.y, this.max.z ).applyMatrix4( matrix ); // 011
-			_points[ 4 ].set( this.max.x, this.min.y, this.min.z ).applyMatrix4( matrix ); // 100
-			_points[ 5 ].set( this.max.x, this.min.y, this.max.z ).applyMatrix4( matrix ); // 101
-			_points[ 6 ].set( this.max.x, this.max.y, this.min.z ).applyMatrix4( matrix ); // 110
-			_points[ 7 ].set( this.max.x, this.max.y, this.max.z ).applyMatrix4( matrix ); // 111
+			return function applyMatrix4( matrix ) {
 
-			this.setFromPoints( _points );
+				// transform of empty box is an empty box.
+				if ( this.isEmpty() ) return this;
 
-			return this;
+				// NOTE: I am using a binary pattern to specify all 2^3 combinations below
+				points[ 0 ].set( this.min.x, this.min.y, this.min.z ).applyMatrix4( matrix ); // 000
+				points[ 1 ].set( this.min.x, this.min.y, this.max.z ).applyMatrix4( matrix ); // 001
+				points[ 2 ].set( this.min.x, this.max.y, this.min.z ).applyMatrix4( matrix ); // 010
+				points[ 3 ].set( this.min.x, this.max.y, this.max.z ).applyMatrix4( matrix ); // 011
+				points[ 4 ].set( this.max.x, this.min.y, this.min.z ).applyMatrix4( matrix ); // 100
+				points[ 5 ].set( this.max.x, this.min.y, this.max.z ).applyMatrix4( matrix ); // 101
+				points[ 6 ].set( this.max.x, this.max.y, this.min.z ).applyMatrix4( matrix ); // 110
+				points[ 7 ].set( this.max.x, this.max.y, this.max.z ).applyMatrix4( matrix ); // 111
 
-		},
+				this.setFromPoints( points );
+
+				return this;
+
+			};
+
+		}(),
 
 		translate: function ( offset ) {
 
@@ -6742,45 +6791,17 @@ var Spacekit = (function (exports) {
 
 	} );
 
-	function satForAxes( axes, v0, v1, v2, extents ) {
-
-		var i, j;
-
-		for ( i = 0, j = axes.length - 3; i <= j; i += 3 ) {
-
-			_testAxis.fromArray( axes, i );
-			// project the aabb onto the seperating axis
-			var r = extents.x * Math.abs( _testAxis.x ) + extents.y * Math.abs( _testAxis.y ) + extents.z * Math.abs( _testAxis.z );
-			// project all 3 vertices of the triangle onto the seperating axis
-			var p0 = v0.dot( _testAxis );
-			var p1 = v1.dot( _testAxis );
-			var p2 = v2.dot( _testAxis );
-			// actual test, basically see if either of the most extreme of the triangle points intersects r
-			if ( Math.max( - Math.max( p0, p1, p2 ), Math.min( p0, p1, p2 ) ) > r ) {
-
-				// points of the projected triangle are outside the projected half-length of the aabb
-				// the axis is seperating and we can exit
-				return false;
-
-			}
-
-		}
-
-		return true;
-
-	}
-
-	var _box$1 = new Box3();
-
 	/**
 	 * @author bhouston / http://clara.io
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
+	var _box;
+
 	function Sphere( center, radius ) {
 
 		this.center = ( center !== undefined ) ? center : new Vector3();
-		this.radius = ( radius !== undefined ) ? radius : - 1;
+		this.radius = ( radius !== undefined ) ? radius : 0;
 
 	}
 
@@ -6797,6 +6818,8 @@ var Spacekit = (function (exports) {
 
 		setFromPoints: function ( points, optionalCenter ) {
 
+			if ( _box === undefined ) _box = new Box3();
+
 			var center = this.center;
 
 			if ( optionalCenter !== undefined ) {
@@ -6805,7 +6828,7 @@ var Spacekit = (function (exports) {
 
 			} else {
 
-				_box$1.setFromPoints( points ).getCenter( center );
+				_box.setFromPoints( points ).getCenter( center );
 
 			}
 
@@ -6838,18 +6861,9 @@ var Spacekit = (function (exports) {
 
 		},
 
-		isEmpty: function () {
+		empty: function () {
 
-			return ( this.radius < 0 );
-
-		},
-
-		makeEmpty: function () {
-
-			this.center.set( 0, 0, 0 );
-			this.radius = - 1;
-
-			return this;
+			return ( this.radius <= 0 );
 
 		},
 
@@ -6918,14 +6932,6 @@ var Spacekit = (function (exports) {
 
 			}
 
-			if ( this.isEmpty() ) {
-
-				// Empty sphere produces empty bounding box
-				target.makeEmpty();
-				return target;
-
-			}
-
 			target.set( this.center, this.center );
 			target.expandByScalar( this.radius );
 
@@ -6958,15 +6964,6 @@ var Spacekit = (function (exports) {
 
 	} );
 
-	var _vector$2 = new Vector3();
-	var _segCenter = new Vector3();
-	var _segDir = new Vector3();
-	var _diff = new Vector3();
-
-	var _edge1 = new Vector3();
-	var _edge2 = new Vector3();
-	var _normal = new Vector3();
-
 	/**
 	 * @author bhouston / http://clara.io
 	 */
@@ -6974,7 +6971,7 @@ var Spacekit = (function (exports) {
 	function Ray( origin, direction ) {
 
 		this.origin = ( origin !== undefined ) ? origin : new Vector3();
-		this.direction = ( direction !== undefined ) ? direction : new Vector3( 0, 0, - 1 );
+		this.direction = ( direction !== undefined ) ? direction : new Vector3();
 
 	}
 
@@ -7025,13 +7022,19 @@ var Spacekit = (function (exports) {
 
 		},
 
-		recast: function ( t ) {
+		recast: function () {
 
-			this.origin.copy( this.at( t, _vector$2 ) );
+			var v1 = new Vector3();
 
-			return this;
+			return function recast( t ) {
 
-		},
+				this.origin.copy( this.at( t, v1 ) );
+
+				return this;
+
+			};
+
+		}(),
 
 		closestPointToPoint: function ( point, target ) {
 
@@ -7062,72 +7065,94 @@ var Spacekit = (function (exports) {
 
 		},
 
-		distanceSqToPoint: function ( point ) {
+		distanceSqToPoint: function () {
 
-			var directionDistance = _vector$2.subVectors( point, this.origin ).dot( this.direction );
+			var v1 = new Vector3();
 
-			// point behind the ray
+			return function distanceSqToPoint( point ) {
 
-			if ( directionDistance < 0 ) {
+				var directionDistance = v1.subVectors( point, this.origin ).dot( this.direction );
 
-				return this.origin.distanceToSquared( point );
+				// point behind the ray
 
-			}
+				if ( directionDistance < 0 ) {
 
-			_vector$2.copy( this.direction ).multiplyScalar( directionDistance ).add( this.origin );
+					return this.origin.distanceToSquared( point );
 
-			return _vector$2.distanceToSquared( point );
+				}
 
-		},
+				v1.copy( this.direction ).multiplyScalar( directionDistance ).add( this.origin );
 
-		distanceSqToSegment: function ( v0, v1, optionalPointOnRay, optionalPointOnSegment ) {
+				return v1.distanceToSquared( point );
 
-			// from http://www.geometrictools.com/GTEngine/Include/Mathematics/GteDistRaySegment.h
-			// It returns the min distance between the ray and the segment
-			// defined by v0 and v1
-			// It can also set two optional targets :
-			// - The closest point on the ray
-			// - The closest point on the segment
+			};
 
-			_segCenter.copy( v0 ).add( v1 ).multiplyScalar( 0.5 );
-			_segDir.copy( v1 ).sub( v0 ).normalize();
-			_diff.copy( this.origin ).sub( _segCenter );
+		}(),
 
-			var segExtent = v0.distanceTo( v1 ) * 0.5;
-			var a01 = - this.direction.dot( _segDir );
-			var b0 = _diff.dot( this.direction );
-			var b1 = - _diff.dot( _segDir );
-			var c = _diff.lengthSq();
-			var det = Math.abs( 1 - a01 * a01 );
-			var s0, s1, sqrDist, extDet;
+		distanceSqToSegment: function () {
 
-			if ( det > 0 ) {
+			var segCenter = new Vector3();
+			var segDir = new Vector3();
+			var diff = new Vector3();
 
-				// The ray and segment are not parallel.
+			return function distanceSqToSegment( v0, v1, optionalPointOnRay, optionalPointOnSegment ) {
 
-				s0 = a01 * b1 - b0;
-				s1 = a01 * b0 - b1;
-				extDet = segExtent * det;
+				// from http://www.geometrictools.com/GTEngine/Include/Mathematics/GteDistRaySegment.h
+				// It returns the min distance between the ray and the segment
+				// defined by v0 and v1
+				// It can also set two optional targets :
+				// - The closest point on the ray
+				// - The closest point on the segment
 
-				if ( s0 >= 0 ) {
+				segCenter.copy( v0 ).add( v1 ).multiplyScalar( 0.5 );
+				segDir.copy( v1 ).sub( v0 ).normalize();
+				diff.copy( this.origin ).sub( segCenter );
 
-					if ( s1 >= - extDet ) {
+				var segExtent = v0.distanceTo( v1 ) * 0.5;
+				var a01 = - this.direction.dot( segDir );
+				var b0 = diff.dot( this.direction );
+				var b1 = - diff.dot( segDir );
+				var c = diff.lengthSq();
+				var det = Math.abs( 1 - a01 * a01 );
+				var s0, s1, sqrDist, extDet;
 
-						if ( s1 <= extDet ) {
+				if ( det > 0 ) {
 
-							// region 0
-							// Minimum at interior points of ray and segment.
+					// The ray and segment are not parallel.
 
-							var invDet = 1 / det;
-							s0 *= invDet;
-							s1 *= invDet;
-							sqrDist = s0 * ( s0 + a01 * s1 + 2 * b0 ) + s1 * ( a01 * s0 + s1 + 2 * b1 ) + c;
+					s0 = a01 * b1 - b0;
+					s1 = a01 * b0 - b1;
+					extDet = segExtent * det;
+
+					if ( s0 >= 0 ) {
+
+						if ( s1 >= - extDet ) {
+
+							if ( s1 <= extDet ) {
+
+								// region 0
+								// Minimum at interior points of ray and segment.
+
+								var invDet = 1 / det;
+								s0 *= invDet;
+								s1 *= invDet;
+								sqrDist = s0 * ( s0 + a01 * s1 + 2 * b0 ) + s1 * ( a01 * s0 + s1 + 2 * b1 ) + c;
+
+							} else {
+
+								// region 1
+
+								s1 = segExtent;
+								s0 = Math.max( 0, - ( a01 * s1 + b0 ) );
+								sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
+
+							}
 
 						} else {
 
-							// region 1
+							// region 5
 
-							s1 = segExtent;
+							s1 = - segExtent;
 							s0 = Math.max( 0, - ( a01 * s1 + b0 ) );
 							sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
 
@@ -7135,99 +7160,97 @@ var Spacekit = (function (exports) {
 
 					} else {
 
-						// region 5
+						if ( s1 <= - extDet ) {
 
-						s1 = - segExtent;
-						s0 = Math.max( 0, - ( a01 * s1 + b0 ) );
-						sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
+							// region 4
+
+							s0 = Math.max( 0, - ( - a01 * segExtent + b0 ) );
+							s1 = ( s0 > 0 ) ? - segExtent : Math.min( Math.max( - segExtent, - b1 ), segExtent );
+							sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
+
+						} else if ( s1 <= extDet ) {
+
+							// region 3
+
+							s0 = 0;
+							s1 = Math.min( Math.max( - segExtent, - b1 ), segExtent );
+							sqrDist = s1 * ( s1 + 2 * b1 ) + c;
+
+						} else {
+
+							// region 2
+
+							s0 = Math.max( 0, - ( a01 * segExtent + b0 ) );
+							s1 = ( s0 > 0 ) ? segExtent : Math.min( Math.max( - segExtent, - b1 ), segExtent );
+							sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
+
+						}
 
 					}
 
 				} else {
 
-					if ( s1 <= - extDet ) {
+					// Ray and segment are parallel.
 
-						// region 4
-
-						s0 = Math.max( 0, - ( - a01 * segExtent + b0 ) );
-						s1 = ( s0 > 0 ) ? - segExtent : Math.min( Math.max( - segExtent, - b1 ), segExtent );
-						sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
-
-					} else if ( s1 <= extDet ) {
-
-						// region 3
-
-						s0 = 0;
-						s1 = Math.min( Math.max( - segExtent, - b1 ), segExtent );
-						sqrDist = s1 * ( s1 + 2 * b1 ) + c;
-
-					} else {
-
-						// region 2
-
-						s0 = Math.max( 0, - ( a01 * segExtent + b0 ) );
-						s1 = ( s0 > 0 ) ? segExtent : Math.min( Math.max( - segExtent, - b1 ), segExtent );
-						sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
-
-					}
+					s1 = ( a01 > 0 ) ? - segExtent : segExtent;
+					s0 = Math.max( 0, - ( a01 * s1 + b0 ) );
+					sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
 
 				}
 
-			} else {
+				if ( optionalPointOnRay ) {
 
-				// Ray and segment are parallel.
+					optionalPointOnRay.copy( this.direction ).multiplyScalar( s0 ).add( this.origin );
 
-				s1 = ( a01 > 0 ) ? - segExtent : segExtent;
-				s0 = Math.max( 0, - ( a01 * s1 + b0 ) );
-				sqrDist = - s0 * s0 + s1 * ( s1 + 2 * b1 ) + c;
+				}
 
-			}
+				if ( optionalPointOnSegment ) {
 
-			if ( optionalPointOnRay ) {
+					optionalPointOnSegment.copy( segDir ).multiplyScalar( s1 ).add( segCenter );
 
-				optionalPointOnRay.copy( this.direction ).multiplyScalar( s0 ).add( this.origin );
+				}
 
-			}
+				return sqrDist;
 
-			if ( optionalPointOnSegment ) {
+			};
 
-				optionalPointOnSegment.copy( _segDir ).multiplyScalar( s1 ).add( _segCenter );
+		}(),
 
-			}
+		intersectSphere: function () {
 
-			return sqrDist;
+			var v1 = new Vector3();
 
-		},
+			return function intersectSphere( sphere, target ) {
 
-		intersectSphere: function ( sphere, target ) {
+				v1.subVectors( sphere.center, this.origin );
+				var tca = v1.dot( this.direction );
+				var d2 = v1.dot( v1 ) - tca * tca;
+				var radius2 = sphere.radius * sphere.radius;
 
-			_vector$2.subVectors( sphere.center, this.origin );
-			var tca = _vector$2.dot( this.direction );
-			var d2 = _vector$2.dot( _vector$2 ) - tca * tca;
-			var radius2 = sphere.radius * sphere.radius;
+				if ( d2 > radius2 ) return null;
 
-			if ( d2 > radius2 ) return null;
+				var thc = Math.sqrt( radius2 - d2 );
 
-			var thc = Math.sqrt( radius2 - d2 );
+				// t0 = first intersect point - entrance on front of sphere
+				var t0 = tca - thc;
 
-			// t0 = first intersect point - entrance on front of sphere
-			var t0 = tca - thc;
+				// t1 = second intersect point - exit point on back of sphere
+				var t1 = tca + thc;
 
-			// t1 = second intersect point - exit point on back of sphere
-			var t1 = tca + thc;
+				// test to see if both t0 and t1 are behind the ray - if so, return null
+				if ( t0 < 0 && t1 < 0 ) return null;
 
-			// test to see if both t0 and t1 are behind the ray - if so, return null
-			if ( t0 < 0 && t1 < 0 ) return null;
+				// test to see if t0 is behind the ray:
+				// if it is, the ray is inside the sphere, so return the second exit point scaled by t1,
+				// in order to always return an intersect point that is in front of the ray.
+				if ( t0 < 0 ) return this.at( t1, target );
 
-			// test to see if t0 is behind the ray:
-			// if it is, the ray is inside the sphere, so return the second exit point scaled by t1,
-			// in order to always return an intersect point that is in front of the ray.
-			if ( t0 < 0 ) return this.at( t1, target );
+				// else t0 is in front of the ray, so return the first collision point scaled by t0
+				return this.at( t0, target );
 
-			// else t0 is in front of the ray, so return the first collision point scaled by t0
-			return this.at( t0, target );
+			};
 
-		},
+		}(),
 
 		intersectsSphere: function ( sphere ) {
 
@@ -7371,86 +7394,100 @@ var Spacekit = (function (exports) {
 
 		},
 
-		intersectsBox: function ( box ) {
+		intersectsBox: ( function () {
 
-			return this.intersectBox( box, _vector$2 ) !== null;
+			var v = new Vector3();
 
-		},
+			return function intersectsBox( box ) {
 
-		intersectTriangle: function ( a, b, c, backfaceCulling, target ) {
+				return this.intersectBox( box, v ) !== null;
+
+			};
+
+		} )(),
+
+		intersectTriangle: function () {
 
 			// Compute the offset origin, edges, and normal.
+			var diff = new Vector3();
+			var edge1 = new Vector3();
+			var edge2 = new Vector3();
+			var normal = new Vector3();
 
-			// from http://www.geometrictools.com/GTEngine/Include/Mathematics/GteIntrRay3Triangle3.h
+			return function intersectTriangle( a, b, c, backfaceCulling, target ) {
 
-			_edge1.subVectors( b, a );
-			_edge2.subVectors( c, a );
-			_normal.crossVectors( _edge1, _edge2 );
+				// from http://www.geometrictools.com/GTEngine/Include/Mathematics/GteIntrRay3Triangle3.h
 
-			// Solve Q + t*D = b1*E1 + b2*E2 (Q = kDiff, D = ray direction,
-			// E1 = kEdge1, E2 = kEdge2, N = Cross(E1,E2)) by
-			//   |Dot(D,N)|*b1 = sign(Dot(D,N))*Dot(D,Cross(Q,E2))
-			//   |Dot(D,N)|*b2 = sign(Dot(D,N))*Dot(D,Cross(E1,Q))
-			//   |Dot(D,N)|*t = -sign(Dot(D,N))*Dot(Q,N)
-			var DdN = this.direction.dot( _normal );
-			var sign;
+				edge1.subVectors( b, a );
+				edge2.subVectors( c, a );
+				normal.crossVectors( edge1, edge2 );
 
-			if ( DdN > 0 ) {
+				// Solve Q + t*D = b1*E1 + b2*E2 (Q = kDiff, D = ray direction,
+				// E1 = kEdge1, E2 = kEdge2, N = Cross(E1,E2)) by
+				//   |Dot(D,N)|*b1 = sign(Dot(D,N))*Dot(D,Cross(Q,E2))
+				//   |Dot(D,N)|*b2 = sign(Dot(D,N))*Dot(D,Cross(E1,Q))
+				//   |Dot(D,N)|*t = -sign(Dot(D,N))*Dot(Q,N)
+				var DdN = this.direction.dot( normal );
+				var sign;
 
-				if ( backfaceCulling ) return null;
-				sign = 1;
+				if ( DdN > 0 ) {
 
-			} else if ( DdN < 0 ) {
+					if ( backfaceCulling ) return null;
+					sign = 1;
 
-				sign = - 1;
-				DdN = - DdN;
+				} else if ( DdN < 0 ) {
 
-			} else {
+					sign = - 1;
+					DdN = - DdN;
 
-				return null;
+				} else {
 
-			}
+					return null;
 
-			_diff.subVectors( this.origin, a );
-			var DdQxE2 = sign * this.direction.dot( _edge2.crossVectors( _diff, _edge2 ) );
+				}
 
-			// b1 < 0, no intersection
-			if ( DdQxE2 < 0 ) {
+				diff.subVectors( this.origin, a );
+				var DdQxE2 = sign * this.direction.dot( edge2.crossVectors( diff, edge2 ) );
 
-				return null;
+				// b1 < 0, no intersection
+				if ( DdQxE2 < 0 ) {
 
-			}
+					return null;
 
-			var DdE1xQ = sign * this.direction.dot( _edge1.cross( _diff ) );
+				}
 
-			// b2 < 0, no intersection
-			if ( DdE1xQ < 0 ) {
+				var DdE1xQ = sign * this.direction.dot( edge1.cross( diff ) );
 
-				return null;
+				// b2 < 0, no intersection
+				if ( DdE1xQ < 0 ) {
 
-			}
+					return null;
 
-			// b1+b2 > 1, no intersection
-			if ( DdQxE2 + DdE1xQ > DdN ) {
+				}
 
-				return null;
+				// b1+b2 > 1, no intersection
+				if ( DdQxE2 + DdE1xQ > DdN ) {
 
-			}
+					return null;
 
-			// Line intersects triangle, check if ray does.
-			var QdN = - sign * _diff.dot( _normal );
+				}
 
-			// t < 0, no intersection
-			if ( QdN < 0 ) {
+				// Line intersects triangle, check if ray does.
+				var QdN = - sign * diff.dot( normal );
 
-				return null;
+				// t < 0, no intersection
+				if ( QdN < 0 ) {
 
-			}
+					return null;
 
-			// Ray intersects triangle.
-			return this.at( QdN / DdN, target );
+				}
 
-		},
+				// Ray intersects triangle.
+				return this.at( QdN / DdN, target );
+
+			};
+
+		}(),
 
 		applyMatrix4: function ( matrix4 ) {
 
@@ -7471,246 +7508,8 @@ var Spacekit = (function (exports) {
 
 	/**
 	 * @author bhouston / http://clara.io
-	 */
-
-	var _vector1 = new Vector3();
-	var _vector2 = new Vector3();
-	var _normalMatrix = new Matrix3();
-
-	function Plane( normal, constant ) {
-
-		// normal is assumed to be normalized
-
-		this.normal = ( normal !== undefined ) ? normal : new Vector3( 1, 0, 0 );
-		this.constant = ( constant !== undefined ) ? constant : 0;
-
-	}
-
-	Object.assign( Plane.prototype, {
-
-		isPlane: true,
-
-		set: function ( normal, constant ) {
-
-			this.normal.copy( normal );
-			this.constant = constant;
-
-			return this;
-
-		},
-
-		setComponents: function ( x, y, z, w ) {
-
-			this.normal.set( x, y, z );
-			this.constant = w;
-
-			return this;
-
-		},
-
-		setFromNormalAndCoplanarPoint: function ( normal, point ) {
-
-			this.normal.copy( normal );
-			this.constant = - point.dot( this.normal );
-
-			return this;
-
-		},
-
-		setFromCoplanarPoints: function ( a, b, c ) {
-
-			var normal = _vector1.subVectors( c, b ).cross( _vector2.subVectors( a, b ) ).normalize();
-
-			// Q: should an error be thrown if normal is zero (e.g. degenerate plane)?
-
-			this.setFromNormalAndCoplanarPoint( normal, a );
-
-			return this;
-
-		},
-
-		clone: function () {
-
-			return new this.constructor().copy( this );
-
-		},
-
-		copy: function ( plane ) {
-
-			this.normal.copy( plane.normal );
-			this.constant = plane.constant;
-
-			return this;
-
-		},
-
-		normalize: function () {
-
-			// Note: will lead to a divide by zero if the plane is invalid.
-
-			var inverseNormalLength = 1.0 / this.normal.length();
-			this.normal.multiplyScalar( inverseNormalLength );
-			this.constant *= inverseNormalLength;
-
-			return this;
-
-		},
-
-		negate: function () {
-
-			this.constant *= - 1;
-			this.normal.negate();
-
-			return this;
-
-		},
-
-		distanceToPoint: function ( point ) {
-
-			return this.normal.dot( point ) + this.constant;
-
-		},
-
-		distanceToSphere: function ( sphere ) {
-
-			return this.distanceToPoint( sphere.center ) - sphere.radius;
-
-		},
-
-		projectPoint: function ( point, target ) {
-
-			if ( target === undefined ) {
-
-				console.warn( 'THREE.Plane: .projectPoint() target is now required' );
-				target = new Vector3();
-
-			}
-
-			return target.copy( this.normal ).multiplyScalar( - this.distanceToPoint( point ) ).add( point );
-
-		},
-
-		intersectLine: function ( line, target ) {
-
-			if ( target === undefined ) {
-
-				console.warn( 'THREE.Plane: .intersectLine() target is now required' );
-				target = new Vector3();
-
-			}
-
-			var direction = line.delta( _vector1 );
-
-			var denominator = this.normal.dot( direction );
-
-			if ( denominator === 0 ) {
-
-				// line is coplanar, return origin
-				if ( this.distanceToPoint( line.start ) === 0 ) {
-
-					return target.copy( line.start );
-
-				}
-
-				// Unsure if this is the correct method to handle this case.
-				return undefined;
-
-			}
-
-			var t = - ( line.start.dot( this.normal ) + this.constant ) / denominator;
-
-			if ( t < 0 || t > 1 ) {
-
-				return undefined;
-
-			}
-
-			return target.copy( direction ).multiplyScalar( t ).add( line.start );
-
-		},
-
-		intersectsLine: function ( line ) {
-
-			// Note: this tests if a line intersects the plane, not whether it (or its end-points) are coplanar with it.
-
-			var startSign = this.distanceToPoint( line.start );
-			var endSign = this.distanceToPoint( line.end );
-
-			return ( startSign < 0 && endSign > 0 ) || ( endSign < 0 && startSign > 0 );
-
-		},
-
-		intersectsBox: function ( box ) {
-
-			return box.intersectsPlane( this );
-
-		},
-
-		intersectsSphere: function ( sphere ) {
-
-			return sphere.intersectsPlane( this );
-
-		},
-
-		coplanarPoint: function ( target ) {
-
-			if ( target === undefined ) {
-
-				console.warn( 'THREE.Plane: .coplanarPoint() target is now required' );
-				target = new Vector3();
-
-			}
-
-			return target.copy( this.normal ).multiplyScalar( - this.constant );
-
-		},
-
-		applyMatrix4: function ( matrix, optionalNormalMatrix ) {
-
-			var normalMatrix = optionalNormalMatrix || _normalMatrix.getNormalMatrix( matrix );
-
-			var referencePoint = this.coplanarPoint( _vector1 ).applyMatrix4( matrix );
-
-			var normal = this.normal.applyMatrix3( normalMatrix ).normalize();
-
-			this.constant = - referencePoint.dot( normal );
-
-			return this;
-
-		},
-
-		translate: function ( offset ) {
-
-			this.constant -= offset.dot( this.normal );
-
-			return this;
-
-		},
-
-		equals: function ( plane ) {
-
-			return plane.normal.equals( this.normal ) && ( plane.constant === this.constant );
-
-		}
-
-	} );
-
-	/**
-	 * @author bhouston / http://clara.io
 	 * @author mrdoob / http://mrdoob.com/
 	 */
-
-	var _v0$1 = new Vector3();
-	var _v1$3 = new Vector3();
-	var _v2$1 = new Vector3();
-	var _v3 = new Vector3();
-
-	var _vab = new Vector3();
-	var _vac = new Vector3();
-	var _vbc = new Vector3();
-	var _vap = new Vector3();
-	var _vbp = new Vector3();
-	var _vcp = new Vector3();
 
 	function Triangle( a, b, c ) {
 
@@ -7722,101 +7521,134 @@ var Spacekit = (function (exports) {
 
 	Object.assign( Triangle, {
 
-		getNormal: function ( a, b, c, target ) {
+		getNormal: function () {
 
-			if ( target === undefined ) {
+			var v0 = new Vector3();
 
-				console.warn( 'THREE.Triangle: .getNormal() target is now required' );
-				target = new Vector3();
+			return function getNormal( a, b, c, target ) {
 
-			}
+				if ( target === undefined ) {
 
-			target.subVectors( c, b );
-			_v0$1.subVectors( a, b );
-			target.cross( _v0$1 );
+					console.warn( 'THREE.Triangle: .getNormal() target is now required' );
+					target = new Vector3();
 
-			var targetLengthSq = target.lengthSq();
-			if ( targetLengthSq > 0 ) {
+				}
 
-				return target.multiplyScalar( 1 / Math.sqrt( targetLengthSq ) );
+				target.subVectors( c, b );
+				v0.subVectors( a, b );
+				target.cross( v0 );
 
-			}
+				var targetLengthSq = target.lengthSq();
+				if ( targetLengthSq > 0 ) {
 
-			return target.set( 0, 0, 0 );
+					return target.multiplyScalar( 1 / Math.sqrt( targetLengthSq ) );
 
-		},
+				}
+
+				return target.set( 0, 0, 0 );
+
+			};
+
+		}(),
 
 		// static/instance method to calculate barycentric coordinates
 		// based on: http://www.blackpawn.com/texts/pointinpoly/default.html
-		getBarycoord: function ( point, a, b, c, target ) {
+		getBarycoord: function () {
 
-			_v0$1.subVectors( c, a );
-			_v1$3.subVectors( b, a );
-			_v2$1.subVectors( point, a );
+			var v0 = new Vector3();
+			var v1 = new Vector3();
+			var v2 = new Vector3();
 
-			var dot00 = _v0$1.dot( _v0$1 );
-			var dot01 = _v0$1.dot( _v1$3 );
-			var dot02 = _v0$1.dot( _v2$1 );
-			var dot11 = _v1$3.dot( _v1$3 );
-			var dot12 = _v1$3.dot( _v2$1 );
+			return function getBarycoord( point, a, b, c, target ) {
 
-			var denom = ( dot00 * dot11 - dot01 * dot01 );
+				v0.subVectors( c, a );
+				v1.subVectors( b, a );
+				v2.subVectors( point, a );
 
-			if ( target === undefined ) {
+				var dot00 = v0.dot( v0 );
+				var dot01 = v0.dot( v1 );
+				var dot02 = v0.dot( v2 );
+				var dot11 = v1.dot( v1 );
+				var dot12 = v1.dot( v2 );
 
-				console.warn( 'THREE.Triangle: .getBarycoord() target is now required' );
-				target = new Vector3();
+				var denom = ( dot00 * dot11 - dot01 * dot01 );
 
-			}
+				if ( target === undefined ) {
 
-			// collinear or singular triangle
-			if ( denom === 0 ) {
+					console.warn( 'THREE.Triangle: .getBarycoord() target is now required' );
+					target = new Vector3();
 
-				// arbitrary location outside of triangle?
-				// not sure if this is the best idea, maybe should be returning undefined
-				return target.set( - 2, - 1, - 1 );
+				}
 
-			}
+				// collinear or singular triangle
+				if ( denom === 0 ) {
 
-			var invDenom = 1 / denom;
-			var u = ( dot11 * dot02 - dot01 * dot12 ) * invDenom;
-			var v = ( dot00 * dot12 - dot01 * dot02 ) * invDenom;
+					// arbitrary location outside of triangle?
+					// not sure if this is the best idea, maybe should be returning undefined
+					return target.set( - 2, - 1, - 1 );
 
-			// barycentric coordinates must always sum to 1
-			return target.set( 1 - u - v, v, u );
+				}
 
-		},
+				var invDenom = 1 / denom;
+				var u = ( dot11 * dot02 - dot01 * dot12 ) * invDenom;
+				var v = ( dot00 * dot12 - dot01 * dot02 ) * invDenom;
 
-		containsPoint: function ( point, a, b, c ) {
+				// barycentric coordinates must always sum to 1
+				return target.set( 1 - u - v, v, u );
 
-			Triangle.getBarycoord( point, a, b, c, _v3 );
+			};
 
-			return ( _v3.x >= 0 ) && ( _v3.y >= 0 ) && ( ( _v3.x + _v3.y ) <= 1 );
+		}(),
 
-		},
+		containsPoint: function () {
 
-		getUV: function ( point, p1, p2, p3, uv1, uv2, uv3, target ) {
+			var v1 = new Vector3();
 
-			this.getBarycoord( point, p1, p2, p3, _v3 );
+			return function containsPoint( point, a, b, c ) {
 
-			target.set( 0, 0 );
-			target.addScaledVector( uv1, _v3.x );
-			target.addScaledVector( uv2, _v3.y );
-			target.addScaledVector( uv3, _v3.z );
+				Triangle.getBarycoord( point, a, b, c, v1 );
 
-			return target;
+				return ( v1.x >= 0 ) && ( v1.y >= 0 ) && ( ( v1.x + v1.y ) <= 1 );
 
-		},
+			};
 
-		isFrontFacing: function ( a, b, c, direction ) {
+		}(),
 
-			_v0$1.subVectors( c, b );
-			_v1$3.subVectors( a, b );
+		getUV: function () {
 
-			// strictly front facing
-			return ( _v0$1.cross( _v1$3 ).dot( direction ) < 0 ) ? true : false;
+			var barycoord = new Vector3();
 
-		}
+			return function getUV( point, p1, p2, p3, uv1, uv2, uv3, target ) {
+
+				this.getBarycoord( point, p1, p2, p3, barycoord );
+
+				target.set( 0, 0 );
+				target.addScaledVector( uv1, barycoord.x );
+				target.addScaledVector( uv2, barycoord.y );
+				target.addScaledVector( uv3, barycoord.z );
+
+				return target;
+
+			};
+
+		}(),
+
+		isFrontFacing: function () {
+
+			var v0 = new Vector3();
+			var v1 = new Vector3();
+
+			return function isFrontFacing( a, b, c, direction ) {
+
+				v0.subVectors( c, b );
+				v1.subVectors( a, b );
+
+				// strictly front facing
+				return ( v0.cross( v1 ).dot( direction ) < 0 ) ? true : false;
+
+			};
+
+		}()
 
 	} );
 
@@ -7860,12 +7692,19 @@ var Spacekit = (function (exports) {
 
 		getArea: function () {
 
-			_v0$1.subVectors( this.c, this.b );
-			_v1$3.subVectors( this.a, this.b );
+			var v0 = new Vector3();
+			var v1 = new Vector3();
 
-			return _v0$1.cross( _v1$3 ).length() * 0.5;
+			return function getArea() {
 
-		},
+				v0.subVectors( this.c, this.b );
+				v1.subVectors( this.a, this.b );
+
+				return v0.cross( v1 ).length() * 0.5;
+
+			};
+
+		}(),
 
 		getMidpoint: function ( target ) {
 
@@ -7891,7 +7730,7 @@ var Spacekit = (function (exports) {
 			if ( target === undefined ) {
 
 				console.warn( 'THREE.Triangle: .getPlane() target is now required' );
-				target = new Plane();
+				target = new Vector3();
 
 			}
 
@@ -7929,93 +7768,103 @@ var Spacekit = (function (exports) {
 
 		},
 
-		closestPointToPoint: function ( p, target ) {
+		closestPointToPoint: function () {
 
-			if ( target === undefined ) {
+			var vab = new Vector3();
+			var vac = new Vector3();
+			var vbc = new Vector3();
+			var vap = new Vector3();
+			var vbp = new Vector3();
+			var vcp = new Vector3();
 
-				console.warn( 'THREE.Triangle: .closestPointToPoint() target is now required' );
-				target = new Vector3();
+			return function closestPointToPoint( p, target ) {
 
-			}
+				if ( target === undefined ) {
 
-			var a = this.a, b = this.b, c = this.c;
-			var v, w;
+					console.warn( 'THREE.Triangle: .closestPointToPoint() target is now required' );
+					target = new Vector3();
 
-			// algorithm thanks to Real-Time Collision Detection by Christer Ericson,
-			// published by Morgan Kaufmann Publishers, (c) 2005 Elsevier Inc.,
-			// under the accompanying license; see chapter 5.1.5 for detailed explanation.
-			// basically, we're distinguishing which of the voronoi regions of the triangle
-			// the point lies in with the minimum amount of redundant computation.
+				}
 
-			_vab.subVectors( b, a );
-			_vac.subVectors( c, a );
-			_vap.subVectors( p, a );
-			var d1 = _vab.dot( _vap );
-			var d2 = _vac.dot( _vap );
-			if ( d1 <= 0 && d2 <= 0 ) {
+				var a = this.a, b = this.b, c = this.c;
+				var v, w;
 
-				// vertex region of A; barycentric coords (1, 0, 0)
-				return target.copy( a );
+				// algorithm thanks to Real-Time Collision Detection by Christer Ericson,
+				// published by Morgan Kaufmann Publishers, (c) 2005 Elsevier Inc.,
+				// under the accompanying license; see chapter 5.1.5 for detailed explanation.
+				// basically, we're distinguishing which of the voronoi regions of the triangle
+				// the point lies in with the minimum amount of redundant computation.
 
-			}
+				vab.subVectors( b, a );
+				vac.subVectors( c, a );
+				vap.subVectors( p, a );
+				var d1 = vab.dot( vap );
+				var d2 = vac.dot( vap );
+				if ( d1 <= 0 && d2 <= 0 ) {
 
-			_vbp.subVectors( p, b );
-			var d3 = _vab.dot( _vbp );
-			var d4 = _vac.dot( _vbp );
-			if ( d3 >= 0 && d4 <= d3 ) {
+					// vertex region of A; barycentric coords (1, 0, 0)
+					return target.copy( a );
 
-				// vertex region of B; barycentric coords (0, 1, 0)
-				return target.copy( b );
+				}
 
-			}
+				vbp.subVectors( p, b );
+				var d3 = vab.dot( vbp );
+				var d4 = vac.dot( vbp );
+				if ( d3 >= 0 && d4 <= d3 ) {
 
-			var vc = d1 * d4 - d3 * d2;
-			if ( vc <= 0 && d1 >= 0 && d3 <= 0 ) {
+					// vertex region of B; barycentric coords (0, 1, 0)
+					return target.copy( b );
 
-				v = d1 / ( d1 - d3 );
-				// edge region of AB; barycentric coords (1-v, v, 0)
-				return target.copy( a ).addScaledVector( _vab, v );
+				}
 
-			}
+				var vc = d1 * d4 - d3 * d2;
+				if ( vc <= 0 && d1 >= 0 && d3 <= 0 ) {
 
-			_vcp.subVectors( p, c );
-			var d5 = _vab.dot( _vcp );
-			var d6 = _vac.dot( _vcp );
-			if ( d6 >= 0 && d5 <= d6 ) {
+					v = d1 / ( d1 - d3 );
+					// edge region of AB; barycentric coords (1-v, v, 0)
+					return target.copy( a ).addScaledVector( vab, v );
 
-				// vertex region of C; barycentric coords (0, 0, 1)
-				return target.copy( c );
+				}
 
-			}
+				vcp.subVectors( p, c );
+				var d5 = vab.dot( vcp );
+				var d6 = vac.dot( vcp );
+				if ( d6 >= 0 && d5 <= d6 ) {
 
-			var vb = d5 * d2 - d1 * d6;
-			if ( vb <= 0 && d2 >= 0 && d6 <= 0 ) {
+					// vertex region of C; barycentric coords (0, 0, 1)
+					return target.copy( c );
 
-				w = d2 / ( d2 - d6 );
-				// edge region of AC; barycentric coords (1-w, 0, w)
-				return target.copy( a ).addScaledVector( _vac, w );
+				}
 
-			}
+				var vb = d5 * d2 - d1 * d6;
+				if ( vb <= 0 && d2 >= 0 && d6 <= 0 ) {
 
-			var va = d3 * d6 - d5 * d4;
-			if ( va <= 0 && ( d4 - d3 ) >= 0 && ( d5 - d6 ) >= 0 ) {
+					w = d2 / ( d2 - d6 );
+					// edge region of AC; barycentric coords (1-w, 0, w)
+					return target.copy( a ).addScaledVector( vac, w );
 
-				_vbc.subVectors( c, b );
-				w = ( d4 - d3 ) / ( ( d4 - d3 ) + ( d5 - d6 ) );
-				// edge region of BC; barycentric coords (0, 1-w, w)
-				return target.copy( b ).addScaledVector( _vbc, w ); // edge region of BC
+				}
 
-			}
+				var va = d3 * d6 - d5 * d4;
+				if ( va <= 0 && ( d4 - d3 ) >= 0 && ( d5 - d6 ) >= 0 ) {
 
-			// face region
-			var denom = 1 / ( va + vb + vc );
-			// u = va * denom
-			v = vb * denom;
-			w = vc * denom;
+					vbc.subVectors( c, b );
+					w = ( d4 - d3 ) / ( ( d4 - d3 ) + ( d5 - d6 ) );
+					// edge region of BC; barycentric coords (0, 1-w, w)
+					return target.copy( b ).addScaledVector( vbc, w ); // edge region of BC
 
-			return target.copy( a ).addScaledVector( _vab, v ).addScaledVector( _vac, w );
+				}
 
-		},
+				// face region
+				var denom = 1 / ( va + vb + vc );
+				// u = va * denom
+				v = vb * denom;
+				w = vc * denom;
+				return target.copy( a ).addScaledVector( vab, v ).addScaledVector( vac, w );
+
+			};
+
+		}(),
 
 		equals: function ( triangle ) {
 
@@ -8029,7 +7878,7 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-	var _colorKeywords = { 'aliceblue': 0xF0F8FF, 'antiquewhite': 0xFAEBD7, 'aqua': 0x00FFFF, 'aquamarine': 0x7FFFD4, 'azure': 0xF0FFFF,
+	var ColorKeywords = { 'aliceblue': 0xF0F8FF, 'antiquewhite': 0xFAEBD7, 'aqua': 0x00FFFF, 'aquamarine': 0x7FFFD4, 'azure': 0xF0FFFF,
 		'beige': 0xF5F5DC, 'bisque': 0xFFE4C4, 'black': 0x000000, 'blanchedalmond': 0xFFEBCD, 'blue': 0x0000FF, 'blueviolet': 0x8A2BE2,
 		'brown': 0xA52A2A, 'burlywood': 0xDEB887, 'cadetblue': 0x5F9EA0, 'chartreuse': 0x7FFF00, 'chocolate': 0xD2691E, 'coral': 0xFF7F50,
 		'cornflowerblue': 0x6495ED, 'cornsilk': 0xFFF8DC, 'crimson': 0xDC143C, 'cyan': 0x00FFFF, 'darkblue': 0x00008B, 'darkcyan': 0x008B8B,
@@ -8053,9 +7902,6 @@ var Spacekit = (function (exports) {
 		'sienna': 0xA0522D, 'silver': 0xC0C0C0, 'skyblue': 0x87CEEB, 'slateblue': 0x6A5ACD, 'slategray': 0x708090, 'slategrey': 0x708090, 'snow': 0xFFFAFA,
 		'springgreen': 0x00FF7F, 'steelblue': 0x4682B4, 'tan': 0xD2B48C, 'teal': 0x008080, 'thistle': 0xD8BFD8, 'tomato': 0xFF6347, 'turquoise': 0x40E0D0,
 		'violet': 0xEE82EE, 'wheat': 0xF5DEB3, 'white': 0xFFFFFF, 'whitesmoke': 0xF5F5F5, 'yellow': 0xFFFF00, 'yellowgreen': 0x9ACD32 };
-
-	var _hslA = { h: 0, s: 0, l: 0 };
-	var _hslB = { h: 0, s: 0, l: 0 };
 
 	function Color( r, g, b ) {
 
@@ -8154,9 +8000,9 @@ var Spacekit = (function (exports) {
 		setHSL: function ( h, s, l ) {
 
 			// h,s,l ranges are in 0.0 - 1.0
-			h = MathUtils.euclideanModulo( h, 1 );
-			s = MathUtils.clamp( s, 0, 1 );
-			l = MathUtils.clamp( l, 0, 1 );
+			h = _Math.euclideanModulo( h, 1 );
+			s = _Math.clamp( s, 0, 1 );
+			l = _Math.clamp( l, 0, 1 );
 
 			if ( s === 0 ) {
 
@@ -8286,28 +8132,20 @@ var Spacekit = (function (exports) {
 
 			if ( style && style.length > 0 ) {
 
-				return this.setColorName( style );
+				// color keywords
+				var hex = ColorKeywords[ style ];
 
-			}
+				if ( hex !== undefined ) {
 
-			return this;
+					// red
+					this.setHex( hex );
 
-		},
+				} else {
 
-		setColorName: function ( style ) {
+					// unknown color
+					console.warn( 'THREE.Color: Unknown color ' + style );
 
-			// color keywords
-			var hex = _colorKeywords[ style ];
-
-			if ( hex !== undefined ) {
-
-				// red
-				this.setHex( hex );
-
-			} else {
-
-				// unknown color
-				console.warn( 'THREE.Color: Unknown color ' + style );
+				}
 
 			}
 
@@ -8477,17 +8315,23 @@ var Spacekit = (function (exports) {
 
 		},
 
-		offsetHSL: function ( h, s, l ) {
+		offsetHSL: function () {
 
-			this.getHSL( _hslA );
+			var hsl = {};
 
-			_hslA.h += h; _hslA.s += s; _hslA.l += l;
+			return function ( h, s, l ) {
 
-			this.setHSL( _hslA.h, _hslA.s, _hslA.l );
+				this.getHSL( hsl );
 
-			return this;
+				hsl.h += h; hsl.s += s; hsl.l += l;
 
-		},
+				this.setHSL( hsl.h, hsl.s, hsl.l );
+
+				return this;
+
+			};
+
+		}(),
 
 		add: function ( color ) {
 
@@ -8559,20 +8403,27 @@ var Spacekit = (function (exports) {
 
 		},
 
-		lerpHSL: function ( color, alpha ) {
+		lerpHSL: function () {
 
-			this.getHSL( _hslA );
-			color.getHSL( _hslB );
+			var hslA = { h: 0, s: 0, l: 0 };
+			var hslB = { h: 0, s: 0, l: 0 };
 
-			var h = MathUtils.lerp( _hslA.h, _hslB.h, alpha );
-			var s = MathUtils.lerp( _hslA.s, _hslB.s, alpha );
-			var l = MathUtils.lerp( _hslA.l, _hslB.l, alpha );
+			return function lerpHSL( color, alpha ) {
 
-			this.setHSL( h, s, l );
+				this.getHSL( hslA );
+				color.getHSL( hslB );
 
-			return this;
+				var h = _Math.lerp( hslA.h, hslB.h, alpha );
+				var s = _Math.lerp( hslA.s, hslB.s, alpha );
+				var l = _Math.lerp( hslA.l, hslB.l, alpha );
 
-		},
+				this.setHSL( h, s, l );
+
+				return this;
+
+			};
+
+		}(),
 
 		equals: function ( c ) {
 
@@ -8612,8 +8463,6 @@ var Spacekit = (function (exports) {
 		}
 
 	} );
-
-	Color.NAMES = _colorKeywords;
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -8684,17 +8533,19 @@ var Spacekit = (function (exports) {
 
 		Object.defineProperty( this, 'id', { value: materialId ++ } );
 
-		this.uuid = MathUtils.generateUUID();
+		this.uuid = _Math.generateUUID();
 
 		this.name = '';
 		this.type = 'Material';
 
 		this.fog = true;
+		this.lights = true;
 
 		this.blending = NormalBlending;
 		this.side = FrontSide;
 		this.flatShading = false;
-		this.vertexColors = false;
+		this.vertexTangents = false;
+		this.vertexColors = NoColors; // THREE.NoColors, THREE.VertexColors, THREE.FaceColors
 
 		this.opacity = 1;
 		this.transparent = false;
@@ -8710,10 +8561,9 @@ var Spacekit = (function (exports) {
 		this.depthTest = true;
 		this.depthWrite = true;
 
-		this.stencilWriteMask = 0xff;
 		this.stencilFunc = AlwaysStencilFunc;
 		this.stencilRef = 0;
-		this.stencilFuncMask = 0xff;
+		this.stencilMask = 0xff;
 		this.stencilFail = KeepStencilOp;
 		this.stencilZFail = KeepStencilOp;
 		this.stencilZPass = KeepStencilOp;
@@ -8740,11 +8590,9 @@ var Spacekit = (function (exports) {
 
 		this.visible = true;
 
-		this.toneMapped = true;
-
 		this.userData = {};
 
-		this.version = 0;
+		this.needsUpdate = true;
 
 	}
 
@@ -8839,33 +8687,13 @@ var Spacekit = (function (exports) {
 			if ( this.roughness !== undefined ) data.roughness = this.roughness;
 			if ( this.metalness !== undefined ) data.metalness = this.metalness;
 
-			if ( this.sheen && this.sheen.isColor ) data.sheen = this.sheen.getHex();
 			if ( this.emissive && this.emissive.isColor ) data.emissive = this.emissive.getHex();
 			if ( this.emissiveIntensity && this.emissiveIntensity !== 1 ) data.emissiveIntensity = this.emissiveIntensity;
 
 			if ( this.specular && this.specular.isColor ) data.specular = this.specular.getHex();
 			if ( this.shininess !== undefined ) data.shininess = this.shininess;
-			if ( this.clearcoat !== undefined ) data.clearcoat = this.clearcoat;
-			if ( this.clearcoatRoughness !== undefined ) data.clearcoatRoughness = this.clearcoatRoughness;
-
-			if ( this.clearcoatMap && this.clearcoatMap.isTexture ) {
-
-				data.clearcoatMap = this.clearcoatMap.toJSON( meta ).uuid;
-
-			}
-
-			if ( this.clearcoatRoughnessMap && this.clearcoatRoughnessMap.isTexture ) {
-
-				data.clearcoatRoughnessMap = this.clearcoatRoughnessMap.toJSON( meta ).uuid;
-
-			}
-
-			if ( this.clearcoatNormalMap && this.clearcoatNormalMap.isTexture ) {
-
-				data.clearcoatNormalMap = this.clearcoatNormalMap.toJSON( meta ).uuid;
-				data.clearcoatNormalScale = this.clearcoatNormalScale.toArray();
-
-			}
+			if ( this.clearCoat !== undefined ) data.clearCoat = this.clearCoat;
+			if ( this.clearCoatRoughness !== undefined ) data.clearCoatRoughness = this.clearCoatRoughness;
 
 			if ( this.map && this.map.isTexture ) data.map = this.map.toJSON( meta ).uuid;
 			if ( this.matcap && this.matcap.isTexture ) data.matcap = this.matcap.toJSON( meta ).uuid;
@@ -8931,7 +8759,7 @@ var Spacekit = (function (exports) {
 			if ( this.blending !== NormalBlending ) data.blending = this.blending;
 			if ( this.flatShading === true ) data.flatShading = this.flatShading;
 			if ( this.side !== FrontSide ) data.side = this.side;
-			if ( this.vertexColors ) data.vertexColors = true;
+			if ( this.vertexColors !== NoColors ) data.vertexColors = this.vertexColors;
 
 			if ( this.opacity < 1 ) data.opacity = this.opacity;
 			if ( this.transparent === true ) data.transparent = this.transparent;
@@ -8941,10 +8769,9 @@ var Spacekit = (function (exports) {
 			data.depthWrite = this.depthWrite;
 
 			data.stencilWrite = this.stencilWrite;
-			data.stencilWriteMask = this.stencilWriteMask;
 			data.stencilFunc = this.stencilFunc;
 			data.stencilRef = this.stencilRef;
-			data.stencilFuncMask = this.stencilFuncMask;
+			data.stencilMask = this.stencilMask;
 			data.stencilFail = this.stencilFail;
 			data.stencilZFail = this.stencilZFail;
 			data.stencilZPass = this.stencilZPass;
@@ -8976,9 +8803,6 @@ var Spacekit = (function (exports) {
 			if ( this.skinning === true ) data.skinning = true;
 
 			if ( this.visible === false ) data.visible = false;
-
-			if ( this.toneMapped === false ) data.toneMapped = false;
-
 			if ( JSON.stringify( this.userData ) !== '{}' ) data.userData = this.userData;
 
 			// TODO: Copied from Object3D.toJSON
@@ -9024,6 +8848,7 @@ var Spacekit = (function (exports) {
 			this.name = source.name;
 
 			this.fog = source.fog;
+			this.lights = source.lights;
 
 			this.blending = source.blending;
 			this.side = source.side;
@@ -9044,33 +8869,13 @@ var Spacekit = (function (exports) {
 			this.depthTest = source.depthTest;
 			this.depthWrite = source.depthWrite;
 
-			this.stencilWriteMask = source.stencilWriteMask;
+			this.stencilWrite = source.stencilWrite;
 			this.stencilFunc = source.stencilFunc;
 			this.stencilRef = source.stencilRef;
-			this.stencilFuncMask = source.stencilFuncMask;
+			this.stencilMask = source.stencilMask;
 			this.stencilFail = source.stencilFail;
 			this.stencilZFail = source.stencilZFail;
 			this.stencilZPass = source.stencilZPass;
-			this.stencilWrite = source.stencilWrite;
-
-			var srcPlanes = source.clippingPlanes,
-				dstPlanes = null;
-
-			if ( srcPlanes !== null ) {
-
-				var n = srcPlanes.length;
-				dstPlanes = new Array( n );
-
-				for ( var i = 0; i !== n; ++ i )
-					dstPlanes[ i ] = srcPlanes[ i ].clone();
-
-			}
-
-			this.clippingPlanes = dstPlanes;
-			this.clipIntersection = source.clipIntersection;
-			this.clipShadows = source.clipShadows;
-
-			this.shadowSide = source.shadowSide;
 
 			this.colorWrite = source.colorWrite;
 
@@ -9086,10 +8891,27 @@ var Spacekit = (function (exports) {
 			this.premultipliedAlpha = source.premultipliedAlpha;
 
 			this.visible = source.visible;
-
-			this.toneMapped = source.toneMapped;
-
 			this.userData = JSON.parse( JSON.stringify( source.userData ) );
+
+			this.clipShadows = source.clipShadows;
+			this.clipIntersection = source.clipIntersection;
+
+			var srcPlanes = source.clippingPlanes,
+				dstPlanes = null;
+
+			if ( srcPlanes !== null ) {
+
+				var n = srcPlanes.length;
+				dstPlanes = new Array( n );
+
+				for ( var i = 0; i !== n; ++ i )
+					dstPlanes[ i ] = srcPlanes[ i ].clone();
+
+			}
+
+			this.clippingPlanes = dstPlanes;
+
+			this.shadowSide = source.shadowSide;
 
 			return this;
 
@@ -9098,16 +8920,6 @@ var Spacekit = (function (exports) {
 		dispose: function () {
 
 			this.dispatchEvent( { type: 'dispose' } );
-
-		}
-
-	} );
-
-	Object.defineProperty( Material.prototype, 'needsUpdate', {
-
-		set: function ( value ) {
-
-			if ( value === true ) this.version ++;
 
 		}
 
@@ -9181,6 +8993,8 @@ var Spacekit = (function (exports) {
 		this.skinning = false;
 		this.morphTargets = false;
 
+		this.lights = false;
+
 		this.setValues( parameters );
 
 	}
@@ -9229,8 +9043,6 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-	var _vector$3 = new Vector3();
-
 	function BufferAttribute( array, itemSize, normalized ) {
 
 		if ( Array.isArray( array ) ) {
@@ -9246,7 +9058,7 @@ var Spacekit = (function (exports) {
 		this.count = array !== undefined ? array.length / itemSize : 0;
 		this.normalized = normalized === true;
 
-		this.usage = StaticDrawUsage;
+		this.dynamic = false;
 		this.updateRange = { offset: 0, count: - 1 };
 
 		this.version = 0;
@@ -9269,9 +9081,24 @@ var Spacekit = (function (exports) {
 
 		onUploadCallback: function () {},
 
-		setUsage: function ( value ) {
+		setArray: function ( array ) {
 
-			this.usage = value;
+			if ( Array.isArray( array ) ) {
+
+				throw new TypeError( 'THREE.BufferAttribute: array should be a Typed Array.' );
+
+			}
+
+			this.count = array !== undefined ? array.length / this.itemSize : 0;
+			this.array = array;
+
+			return this;
+
+		},
+
+		setDynamic: function ( value ) {
+
+			this.dynamic = value;
 
 			return this;
 
@@ -9285,7 +9112,7 @@ var Spacekit = (function (exports) {
 			this.count = source.count;
 			this.normalized = source.normalized;
 
-			this.usage = source.usage;
+			this.dynamic = source.dynamic;
 
 			return this;
 
@@ -9407,78 +9234,6 @@ var Spacekit = (function (exports) {
 				array[ offset ++ ] = vector.y;
 				array[ offset ++ ] = vector.z;
 				array[ offset ++ ] = vector.w;
-
-			}
-
-			return this;
-
-		},
-
-		applyMatrix3: function ( m ) {
-
-			for ( var i = 0, l = this.count; i < l; i ++ ) {
-
-				_vector$3.x = this.getX( i );
-				_vector$3.y = this.getY( i );
-				_vector$3.z = this.getZ( i );
-
-				_vector$3.applyMatrix3( m );
-
-				this.setXYZ( i, _vector$3.x, _vector$3.y, _vector$3.z );
-
-			}
-
-			return this;
-
-		},
-
-		applyMatrix4: function ( m ) {
-
-			for ( var i = 0, l = this.count; i < l; i ++ ) {
-
-				_vector$3.x = this.getX( i );
-				_vector$3.y = this.getY( i );
-				_vector$3.z = this.getZ( i );
-
-				_vector$3.applyMatrix4( m );
-
-				this.setXYZ( i, _vector$3.x, _vector$3.y, _vector$3.z );
-
-			}
-
-			return this;
-
-		},
-
-		applyNormalMatrix: function ( m ) {
-
-			for ( var i = 0, l = this.count; i < l; i ++ ) {
-
-				_vector$3.x = this.getX( i );
-				_vector$3.y = this.getY( i );
-				_vector$3.z = this.getZ( i );
-
-				_vector$3.applyNormalMatrix( m );
-
-				this.setXYZ( i, _vector$3.x, _vector$3.y, _vector$3.z );
-
-			}
-
-			return this;
-
-		},
-
-		transformDirection: function ( m ) {
-
-			for ( var i = 0, l = this.count; i < l; i ++ ) {
-
-				_vector$3.x = this.getX( i );
-				_vector$3.y = this.getY( i );
-				_vector$3.z = this.getZ( i );
-
-				_vector$3.transformDirection( m );
-
-				this.setXYZ( i, _vector$3.x, _vector$3.y, _vector$3.z );
 
 			}
 
@@ -10013,20 +9768,13 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-	var _bufferGeometryId = 1; // BufferGeometry uses odd numbers as Id
-
-	var _m1$2 = new Matrix4();
-	var _obj = new Object3D();
-	var _offset = new Vector3();
-	var _box$2 = new Box3();
-	var _boxMorphTargets = new Box3();
-	var _vector$4 = new Vector3();
+	var bufferGeometryId = 1; // BufferGeometry uses odd numbers as Id
 
 	function BufferGeometry() {
 
-		Object.defineProperty( this, 'id', { value: _bufferGeometryId += 2 } );
+		Object.defineProperty( this, 'id', { value: bufferGeometryId += 2 } );
 
-		this.uuid = MathUtils.generateUUID();
+		this.uuid = _Math.generateUUID();
 
 		this.name = '';
 		this.type = 'BufferGeometry';
@@ -10035,7 +9783,6 @@ var Spacekit = (function (exports) {
 		this.attributes = {};
 
 		this.morphAttributes = {};
-		this.morphTargetsRelative = false;
 
 		this.groups = [];
 
@@ -10074,13 +9821,24 @@ var Spacekit = (function (exports) {
 
 		},
 
-		getAttribute: function ( name ) {
+		addAttribute: function ( name, attribute ) {
 
-			return this.attributes[ name ];
+			if ( ! ( attribute && attribute.isBufferAttribute ) && ! ( attribute && attribute.isInterleavedBufferAttribute ) ) {
 
-		},
+				console.warn( 'THREE.BufferGeometry: .addAttribute() now expects ( name, attribute ).' );
 
-		setAttribute: function ( name, attribute ) {
+				return this.addAttribute( name, new BufferAttribute( arguments[ 1 ], arguments[ 2 ] ) );
+
+			}
+
+			if ( name === 'index' ) {
+
+				console.warn( 'THREE.BufferGeometry.addAttribute: Use .setIndex() for index attribute.' );
+				this.setIndex( attribute );
+
+				return this;
+
+			}
 
 			this.attributes[ name ] = attribute;
 
@@ -10088,7 +9846,13 @@ var Spacekit = (function (exports) {
 
 		},
 
-		deleteAttribute: function ( name ) {
+		getAttribute: function ( name ) {
+
+			return this.attributes[ name ];
+
+		},
+
+		removeAttribute: function ( name ) {
 
 			delete this.attributes[ name ];
 
@@ -10121,14 +9885,13 @@ var Spacekit = (function (exports) {
 
 		},
 
-		applyMatrix4: function ( matrix ) {
+		applyMatrix: function ( matrix ) {
 
 			var position = this.attributes.position;
 
 			if ( position !== undefined ) {
 
-				position.applyMatrix4( matrix );
-
+				matrix.applyToBufferAttribute( position );
 				position.needsUpdate = true;
 
 			}
@@ -10139,8 +9902,7 @@ var Spacekit = (function (exports) {
 
 				var normalMatrix = new Matrix3().getNormalMatrix( matrix );
 
-				normal.applyNormalMatrix( normalMatrix );
-
+				normalMatrix.applyToBufferAttribute( normal );
 				normal.needsUpdate = true;
 
 			}
@@ -10149,8 +9911,10 @@ var Spacekit = (function (exports) {
 
 			if ( tangent !== undefined ) {
 
-				tangent.transformDirection( matrix );
+				var normalMatrix = new Matrix3().getNormalMatrix( matrix );
 
+				// Tangent is vec4, but the '.w' component is a sign value (+1/-1).
+				normalMatrix.applyToBufferAttribute( tangent );
 				tangent.needsUpdate = true;
 
 			}
@@ -10171,89 +9935,129 @@ var Spacekit = (function (exports) {
 
 		},
 
-		rotateX: function ( angle ) {
+		rotateX: function () {
 
 			// rotate geometry around world x-axis
 
-			_m1$2.makeRotationX( angle );
+			var m1 = new Matrix4();
 
-			this.applyMatrix4( _m1$2 );
+			return function rotateX( angle ) {
 
-			return this;
+				m1.makeRotationX( angle );
 
-		},
+				this.applyMatrix( m1 );
 
-		rotateY: function ( angle ) {
+				return this;
+
+			};
+
+		}(),
+
+		rotateY: function () {
 
 			// rotate geometry around world y-axis
 
-			_m1$2.makeRotationY( angle );
+			var m1 = new Matrix4();
 
-			this.applyMatrix4( _m1$2 );
+			return function rotateY( angle ) {
 
-			return this;
+				m1.makeRotationY( angle );
 
-		},
+				this.applyMatrix( m1 );
 
-		rotateZ: function ( angle ) {
+				return this;
+
+			};
+
+		}(),
+
+		rotateZ: function () {
 
 			// rotate geometry around world z-axis
 
-			_m1$2.makeRotationZ( angle );
+			var m1 = new Matrix4();
 
-			this.applyMatrix4( _m1$2 );
+			return function rotateZ( angle ) {
 
-			return this;
+				m1.makeRotationZ( angle );
 
-		},
+				this.applyMatrix( m1 );
 
-		translate: function ( x, y, z ) {
+				return this;
+
+			};
+
+		}(),
+
+		translate: function () {
 
 			// translate geometry
 
-			_m1$2.makeTranslation( x, y, z );
+			var m1 = new Matrix4();
 
-			this.applyMatrix4( _m1$2 );
+			return function translate( x, y, z ) {
 
-			return this;
+				m1.makeTranslation( x, y, z );
 
-		},
+				this.applyMatrix( m1 );
 
-		scale: function ( x, y, z ) {
+				return this;
+
+			};
+
+		}(),
+
+		scale: function () {
 
 			// scale geometry
 
-			_m1$2.makeScale( x, y, z );
+			var m1 = new Matrix4();
 
-			this.applyMatrix4( _m1$2 );
+			return function scale( x, y, z ) {
 
-			return this;
+				m1.makeScale( x, y, z );
 
-		},
+				this.applyMatrix( m1 );
 
-		lookAt: function ( vector ) {
+				return this;
 
-			_obj.lookAt( vector );
+			};
 
-			_obj.updateMatrix();
+		}(),
 
-			this.applyMatrix4( _obj.matrix );
+		lookAt: function () {
 
-			return this;
+			var obj = new Object3D();
 
-		},
+			return function lookAt( vector ) {
+
+				obj.lookAt( vector );
+
+				obj.updateMatrix();
+
+				this.applyMatrix( obj.matrix );
+
+			};
+
+		}(),
 
 		center: function () {
 
-			this.computeBoundingBox();
+			var offset = new Vector3();
 
-			this.boundingBox.getCenter( _offset ).negate();
+			return function center() {
 
-			this.translate( _offset.x, _offset.y, _offset.z );
+				this.computeBoundingBox();
 
-			return this;
+				this.boundingBox.getCenter( offset ).negate();
 
-		},
+				this.translate( offset.x, offset.y, offset.z );
+
+				return this;
+
+			};
+
+		}(),
 
 		setFromObject: function ( object ) {
 
@@ -10266,14 +10070,14 @@ var Spacekit = (function (exports) {
 				var positions = new Float32BufferAttribute( geometry.vertices.length * 3, 3 );
 				var colors = new Float32BufferAttribute( geometry.colors.length * 3, 3 );
 
-				this.setAttribute( 'position', positions.copyVector3sArray( geometry.vertices ) );
-				this.setAttribute( 'color', colors.copyColorsArray( geometry.colors ) );
+				this.addAttribute( 'position', positions.copyVector3sArray( geometry.vertices ) );
+				this.addAttribute( 'color', colors.copyColorsArray( geometry.colors ) );
 
 				if ( geometry.lineDistances && geometry.lineDistances.length === geometry.vertices.length ) {
 
 					var lineDistances = new Float32BufferAttribute( geometry.lineDistances.length, 1 );
 
-					this.setAttribute( 'lineDistance', lineDistances.copyArray( geometry.lineDistances ) );
+					this.addAttribute( 'lineDistance', lineDistances.copyArray( geometry.lineDistances ) );
 
 				}
 
@@ -10314,7 +10118,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			this.setAttribute( 'position', new Float32BufferAttribute( position, 3 ) );
+			this.addAttribute( 'position', new Float32BufferAttribute( position, 3 ) );
 
 			return this;
 
@@ -10458,33 +10262,33 @@ var Spacekit = (function (exports) {
 		fromDirectGeometry: function ( geometry ) {
 
 			var positions = new Float32Array( geometry.vertices.length * 3 );
-			this.setAttribute( 'position', new BufferAttribute( positions, 3 ).copyVector3sArray( geometry.vertices ) );
+			this.addAttribute( 'position', new BufferAttribute( positions, 3 ).copyVector3sArray( geometry.vertices ) );
 
 			if ( geometry.normals.length > 0 ) {
 
 				var normals = new Float32Array( geometry.normals.length * 3 );
-				this.setAttribute( 'normal', new BufferAttribute( normals, 3 ).copyVector3sArray( geometry.normals ) );
+				this.addAttribute( 'normal', new BufferAttribute( normals, 3 ).copyVector3sArray( geometry.normals ) );
 
 			}
 
 			if ( geometry.colors.length > 0 ) {
 
 				var colors = new Float32Array( geometry.colors.length * 3 );
-				this.setAttribute( 'color', new BufferAttribute( colors, 3 ).copyColorsArray( geometry.colors ) );
+				this.addAttribute( 'color', new BufferAttribute( colors, 3 ).copyColorsArray( geometry.colors ) );
 
 			}
 
 			if ( geometry.uvs.length > 0 ) {
 
 				var uvs = new Float32Array( geometry.uvs.length * 2 );
-				this.setAttribute( 'uv', new BufferAttribute( uvs, 2 ).copyVector2sArray( geometry.uvs ) );
+				this.addAttribute( 'uv', new BufferAttribute( uvs, 2 ).copyVector2sArray( geometry.uvs ) );
 
 			}
 
 			if ( geometry.uvs2.length > 0 ) {
 
 				var uvs2 = new Float32Array( geometry.uvs2.length * 2 );
-				this.setAttribute( 'uv2', new BufferAttribute( uvs2, 2 ).copyVector2sArray( geometry.uvs2 ) );
+				this.addAttribute( 'uv2', new BufferAttribute( uvs2, 2 ).copyVector2sArray( geometry.uvs2 ) );
 
 			}
 
@@ -10519,14 +10323,14 @@ var Spacekit = (function (exports) {
 			if ( geometry.skinIndices.length > 0 ) {
 
 				var skinIndices = new Float32BufferAttribute( geometry.skinIndices.length * 4, 4 );
-				this.setAttribute( 'skinIndex', skinIndices.copyVector4sArray( geometry.skinIndices ) );
+				this.addAttribute( 'skinIndex', skinIndices.copyVector4sArray( geometry.skinIndices ) );
 
 			}
 
 			if ( geometry.skinWeights.length > 0 ) {
 
 				var skinWeights = new Float32BufferAttribute( geometry.skinWeights.length * 4, 4 );
-				this.setAttribute( 'skinWeight', skinWeights.copyVector4sArray( geometry.skinWeights ) );
+				this.addAttribute( 'skinWeight', skinWeights.copyVector4sArray( geometry.skinWeights ) );
 
 			}
 
@@ -10550,162 +10354,144 @@ var Spacekit = (function (exports) {
 
 		computeBoundingBox: function () {
 
-			if ( this.boundingBox === null ) {
+			var box = new Box3();
 
-				this.boundingBox = new Box3();
+			return function computeBoundingBox() {
 
-			}
+				if ( this.boundingBox === null ) {
 
-			var position = this.attributes.position;
-			var morphAttributesPosition = this.morphAttributes.position;
+					this.boundingBox = new Box3();
 
-			if ( position !== undefined ) {
+				}
 
-				this.boundingBox.setFromBufferAttribute( position );
+				var position = this.attributes.position;
+				var morphAttributesPosition = this.morphAttributes.position;
 
-				// process morph attributes if present
+				if ( position !== undefined ) {
 
-				if ( morphAttributesPosition ) {
+					this.boundingBox.setFromBufferAttribute( position );
 
-					for ( var i = 0, il = morphAttributesPosition.length; i < il; i ++ ) {
+					// process morph attributes if present
 
-						var morphAttribute = morphAttributesPosition[ i ];
-						_box$2.setFromBufferAttribute( morphAttribute );
+					if ( morphAttributesPosition ) {
 
-						if ( this.morphTargetsRelative ) {
+						for ( var i = 0, il = morphAttributesPosition.length; i < il; i ++ ) {
 
-							_vector$4.addVectors( this.boundingBox.min, _box$2.min );
-							this.boundingBox.expandByPoint( _vector$4 );
+							var morphAttribute = morphAttributesPosition[ i ];
+							box.setFromBufferAttribute( morphAttribute );
 
-							_vector$4.addVectors( this.boundingBox.max, _box$2.max );
-							this.boundingBox.expandByPoint( _vector$4 );
-
-						} else {
-
-							this.boundingBox.expandByPoint( _box$2.min );
-							this.boundingBox.expandByPoint( _box$2.max );
+							this.boundingBox.expandByPoint( box.min );
+							this.boundingBox.expandByPoint( box.max );
 
 						}
 
 					}
 
+				} else {
+
+					this.boundingBox.makeEmpty();
+
 				}
 
-			} else {
+				if ( isNaN( this.boundingBox.min.x ) || isNaN( this.boundingBox.min.y ) || isNaN( this.boundingBox.min.z ) ) {
 
-				this.boundingBox.makeEmpty();
+					console.error( 'THREE.BufferGeometry.computeBoundingBox: Computed min/max have NaN values. The "position" attribute is likely to have NaN values.', this );
 
-			}
+				}
 
-			if ( isNaN( this.boundingBox.min.x ) || isNaN( this.boundingBox.min.y ) || isNaN( this.boundingBox.min.z ) ) {
+			};
 
-				console.error( 'THREE.BufferGeometry.computeBoundingBox: Computed min/max have NaN values. The "position" attribute is likely to have NaN values.', this );
-
-			}
-
-		},
+		}(),
 
 		computeBoundingSphere: function () {
 
-			if ( this.boundingSphere === null ) {
+			var box = new Box3();
+			var boxMorphTargets = new Box3();
+			var vector = new Vector3();
 
-				this.boundingSphere = new Sphere();
+			return function computeBoundingSphere() {
 
-			}
+				if ( this.boundingSphere === null ) {
 
-			var position = this.attributes.position;
-			var morphAttributesPosition = this.morphAttributes.position;
+					this.boundingSphere = new Sphere();
 
-			if ( position ) {
+				}
 
-				// first, find the center of the bounding sphere
+				var position = this.attributes.position;
+				var morphAttributesPosition = this.morphAttributes.position;
 
-				var center = this.boundingSphere.center;
+				if ( position ) {
 
-				_box$2.setFromBufferAttribute( position );
+					// first, find the center of the bounding sphere
 
-				// process morph attributes if present
+					var center = this.boundingSphere.center;
 
-				if ( morphAttributesPosition ) {
+					box.setFromBufferAttribute( position );
 
-					for ( var i = 0, il = morphAttributesPosition.length; i < il; i ++ ) {
+					// process morph attributes if present
 
-						var morphAttribute = morphAttributesPosition[ i ];
-						_boxMorphTargets.setFromBufferAttribute( morphAttribute );
+					if ( morphAttributesPosition ) {
 
-						if ( this.morphTargetsRelative ) {
+						for ( var i = 0, il = morphAttributesPosition.length; i < il; i ++ ) {
 
-							_vector$4.addVectors( _box$2.min, _boxMorphTargets.min );
-							_box$2.expandByPoint( _vector$4 );
+							var morphAttribute = morphAttributesPosition[ i ];
+							boxMorphTargets.setFromBufferAttribute( morphAttribute );
 
-							_vector$4.addVectors( _box$2.max, _boxMorphTargets.max );
-							_box$2.expandByPoint( _vector$4 );
-
-						} else {
-
-							_box$2.expandByPoint( _boxMorphTargets.min );
-							_box$2.expandByPoint( _boxMorphTargets.max );
+							box.expandByPoint( boxMorphTargets.min );
+							box.expandByPoint( boxMorphTargets.max );
 
 						}
 
 					}
 
-				}
+					box.getCenter( center );
 
-				_box$2.getCenter( center );
+					// second, try to find a boundingSphere with a radius smaller than the
+					// boundingSphere of the boundingBox: sqrt(3) smaller in the best case
 
-				// second, try to find a boundingSphere with a radius smaller than the
-				// boundingSphere of the boundingBox: sqrt(3) smaller in the best case
+					var maxRadiusSq = 0;
 
-				var maxRadiusSq = 0;
+					for ( var i = 0, il = position.count; i < il; i ++ ) {
 
-				for ( var i = 0, il = position.count; i < il; i ++ ) {
+						vector.fromBufferAttribute( position, i );
 
-					_vector$4.fromBufferAttribute( position, i );
+						maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( vector ) );
 
-					maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( _vector$4 ) );
+					}
 
-				}
+					// process morph attributes if present
 
-				// process morph attributes if present
+					if ( morphAttributesPosition ) {
 
-				if ( morphAttributesPosition ) {
+						for ( var i = 0, il = morphAttributesPosition.length; i < il; i ++ ) {
 
-					for ( var i = 0, il = morphAttributesPosition.length; i < il; i ++ ) {
+							var morphAttribute = morphAttributesPosition[ i ];
 
-						var morphAttribute = morphAttributesPosition[ i ];
-						var morphTargetsRelative = this.morphTargetsRelative;
+							for ( var j = 0, jl = morphAttribute.count; j < jl; j ++ ) {
 
-						for ( var j = 0, jl = morphAttribute.count; j < jl; j ++ ) {
+								vector.fromBufferAttribute( morphAttribute, j );
 
-							_vector$4.fromBufferAttribute( morphAttribute, j );
-
-							if ( morphTargetsRelative ) {
-
-								_offset.fromBufferAttribute( position, j );
-								_vector$4.add( _offset );
+								maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( vector ) );
 
 							}
 
-							maxRadiusSq = Math.max( maxRadiusSq, center.distanceToSquared( _vector$4 ) );
-
 						}
+
+					}
+
+					this.boundingSphere.radius = Math.sqrt( maxRadiusSq );
+
+					if ( isNaN( this.boundingSphere.radius ) ) {
+
+						console.error( 'THREE.BufferGeometry.computeBoundingSphere(): Computed radius is NaN. The "position" attribute is likely to have NaN values.', this );
 
 					}
 
 				}
 
-				this.boundingSphere.radius = Math.sqrt( maxRadiusSq );
+			};
 
-				if ( isNaN( this.boundingSphere.radius ) ) {
-
-					console.error( 'THREE.BufferGeometry.computeBoundingSphere(): Computed radius is NaN. The "position" attribute is likely to have NaN values.', this );
-
-				}
-
-			}
-
-		},
+		}(),
 
 		computeFaceNormals: function () {
 
@@ -10724,7 +10510,7 @@ var Spacekit = (function (exports) {
 
 				if ( attributes.normal === undefined ) {
 
-					this.setAttribute( 'normal', new BufferAttribute( new Float32Array( positions.length ), 3 ) );
+					this.addAttribute( 'normal', new BufferAttribute( new Float32Array( positions.length ), 3 ) );
 
 				} else {
 
@@ -10867,21 +10653,27 @@ var Spacekit = (function (exports) {
 
 		normalizeNormals: function () {
 
-			var normals = this.attributes.normal;
+			var vector = new Vector3();
 
-			for ( var i = 0, il = normals.count; i < il; i ++ ) {
+			return function normalizeNormals() {
 
-				_vector$4.x = normals.getX( i );
-				_vector$4.y = normals.getY( i );
-				_vector$4.z = normals.getZ( i );
+				var normals = this.attributes.normal;
 
-				_vector$4.normalize();
+				for ( var i = 0, il = normals.count; i < il; i ++ ) {
 
-				normals.setXYZ( i, _vector$4.x, _vector$4.y, _vector$4.z );
+					vector.x = normals.getX( i );
+					vector.y = normals.getY( i );
+					vector.z = normals.getZ( i );
 
-			}
+					vector.normalize();
 
-		},
+					normals.setXYZ( i, vector.x, vector.y, vector.z );
+
+				}
+
+			};
+
+		}(),
 
 		toNonIndexed: function () {
 
@@ -10932,7 +10724,7 @@ var Spacekit = (function (exports) {
 
 				var newAttribute = convertBufferAttribute( attribute, indices );
 
-				geometry2.setAttribute( name, newAttribute );
+				geometry2.addAttribute( name, newAttribute );
 
 			}
 
@@ -10958,8 +10750,6 @@ var Spacekit = (function (exports) {
 				geometry2.morphAttributes[ name ] = morphArray;
 
 			}
-
-			geometry2.morphTargetsRelative = this.morphTargetsRelative;
 
 			// groups
 
@@ -11065,12 +10855,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			if ( hasMorphAttributes ) {
-
-				data.data.morphAttributes = morphAttributes;
-				data.data.morphTargetsRelative = this.morphTargetsRelative;
-
-			}
+			if ( hasMorphAttributes ) data.data.morphAttributes = morphAttributes;
 
 			var groups = this.groups;
 
@@ -11159,7 +10944,7 @@ var Spacekit = (function (exports) {
 			for ( name in attributes ) {
 
 				var attribute = attributes[ name ];
-				this.setAttribute( name, attribute.clone() );
+				this.addAttribute( name, attribute.clone() );
 
 			}
 
@@ -11181,8 +10966,6 @@ var Spacekit = (function (exports) {
 				this.morphAttributes[ name ] = array;
 
 			}
-
-			this.morphTargetsRelative = source.morphTargetsRelative;
 
 			// groups
 
@@ -11243,29 +11026,6 @@ var Spacekit = (function (exports) {
 	 * @author jonobr1 / http://jonobr1.com/
 	 */
 
-	var _inverseMatrix = new Matrix4();
-	var _ray = new Ray();
-	var _sphere = new Sphere();
-
-	var _vA = new Vector3();
-	var _vB = new Vector3();
-	var _vC = new Vector3();
-
-	var _tempA = new Vector3();
-	var _tempB = new Vector3();
-	var _tempC = new Vector3();
-
-	var _morphA = new Vector3();
-	var _morphB = new Vector3();
-	var _morphC = new Vector3();
-
-	var _uvA = new Vector2();
-	var _uvB = new Vector2();
-	var _uvC = new Vector2();
-
-	var _intersectionPoint = new Vector3();
-	var _intersectionPointWorld = new Vector3();
-
 	function Mesh( geometry, material ) {
 
 		Object3D.call( this );
@@ -11273,7 +11033,9 @@ var Spacekit = (function (exports) {
 		this.type = 'Mesh';
 
 		this.geometry = geometry !== undefined ? geometry : new BufferGeometry();
-		this.material = material !== undefined ? material : new MeshBasicMaterial();
+		this.material = material !== undefined ? material : new MeshBasicMaterial( { color: Math.random() * 0xffffff } );
+
+		this.drawMode = TrianglesDrawMode;
 
 		this.updateMorphTargets();
 
@@ -11285,9 +11047,17 @@ var Spacekit = (function (exports) {
 
 		isMesh: true,
 
+		setDrawMode: function ( value ) {
+
+			this.drawMode = value;
+
+		},
+
 		copy: function ( source ) {
 
 			Object3D.prototype.copy.call( this, source );
+
+			this.drawMode = source.drawMode;
 
 			if ( source.morphTargetInfluences !== undefined ) {
 
@@ -11351,79 +11121,230 @@ var Spacekit = (function (exports) {
 
 		},
 
-		raycast: function ( raycaster, intersects ) {
+		raycast: ( function () {
 
-			var geometry = this.geometry;
-			var material = this.material;
-			var matrixWorld = this.matrixWorld;
+			var inverseMatrix = new Matrix4();
+			var ray = new Ray();
+			var sphere = new Sphere();
 
-			if ( material === undefined ) return;
+			var vA = new Vector3();
+			var vB = new Vector3();
+			var vC = new Vector3();
 
-			// Checking boundingSphere distance to ray
+			var tempA = new Vector3();
+			var tempB = new Vector3();
+			var tempC = new Vector3();
 
-			if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
+			var morphA = new Vector3();
+			var morphB = new Vector3();
+			var morphC = new Vector3();
 
-			_sphere.copy( geometry.boundingSphere );
-			_sphere.applyMatrix4( matrixWorld );
+			var uvA = new Vector2();
+			var uvB = new Vector2();
+			var uvC = new Vector2();
 
-			if ( raycaster.ray.intersectsSphere( _sphere ) === false ) return;
+			var intersectionPoint = new Vector3();
+			var intersectionPointWorld = new Vector3();
 
-			//
+			function checkIntersection( object, material, raycaster, ray, pA, pB, pC, point ) {
 
-			_inverseMatrix.getInverse( matrixWorld );
-			_ray.copy( raycaster.ray ).applyMatrix4( _inverseMatrix );
+				var intersect;
 
-			// Check boundingBox before continuing
+				if ( material.side === BackSide ) {
 
-			if ( geometry.boundingBox !== null ) {
+					intersect = ray.intersectTriangle( pC, pB, pA, true, point );
 
-				if ( _ray.intersectsBox( geometry.boundingBox ) === false ) return;
+				} else {
+
+					intersect = ray.intersectTriangle( pA, pB, pC, material.side !== DoubleSide, point );
+
+				}
+
+				if ( intersect === null ) return null;
+
+				intersectionPointWorld.copy( point );
+				intersectionPointWorld.applyMatrix4( object.matrixWorld );
+
+				var distance = raycaster.ray.origin.distanceTo( intersectionPointWorld );
+
+				if ( distance < raycaster.near || distance > raycaster.far ) return null;
+
+				return {
+					distance: distance,
+					point: intersectionPointWorld.clone(),
+					object: object
+				};
 
 			}
 
-			var intersection;
+			function checkBufferGeometryIntersection( object, material, raycaster, ray, position, morphPosition, uv, uv2, a, b, c ) {
 
-			if ( geometry.isBufferGeometry ) {
+				vA.fromBufferAttribute( position, a );
+				vB.fromBufferAttribute( position, b );
+				vC.fromBufferAttribute( position, c );
 
-				var a, b, c;
-				var index = geometry.index;
-				var position = geometry.attributes.position;
-				var morphPosition = geometry.morphAttributes.position;
-				var morphTargetsRelative = geometry.morphTargetsRelative;
-				var uv = geometry.attributes.uv;
-				var uv2 = geometry.attributes.uv2;
-				var groups = geometry.groups;
-				var drawRange = geometry.drawRange;
-				var i, j, il, jl;
-				var group, groupMaterial;
-				var start, end;
+				var morphInfluences = object.morphTargetInfluences;
 
-				if ( index !== null ) {
+				if ( material.morphTargets && morphPosition && morphInfluences ) {
 
-					// indexed buffer geometry
+					morphA.set( 0, 0, 0 );
+					morphB.set( 0, 0, 0 );
+					morphC.set( 0, 0, 0 );
 
-					if ( Array.isArray( material ) ) {
+					for ( var i = 0, il = morphPosition.length; i < il; i ++ ) {
 
-						for ( i = 0, il = groups.length; i < il; i ++ ) {
+						var influence = morphInfluences[ i ];
+						var morphAttribute = morphPosition[ i ];
 
-							group = groups[ i ];
-							groupMaterial = material[ group.materialIndex ];
+						if ( influence === 0 ) continue;
 
-							start = Math.max( group.start, drawRange.start );
-							end = Math.min( ( group.start + group.count ), ( drawRange.start + drawRange.count ) );
+						tempA.fromBufferAttribute( morphAttribute, a );
+						tempB.fromBufferAttribute( morphAttribute, b );
+						tempC.fromBufferAttribute( morphAttribute, c );
 
-							for ( j = start, jl = end; j < jl; j += 3 ) {
+						morphA.addScaledVector( tempA.sub( vA ), influence );
+						morphB.addScaledVector( tempB.sub( vB ), influence );
+						morphC.addScaledVector( tempC.sub( vC ), influence );
 
-								a = index.getX( j );
-								b = index.getX( j + 1 );
-								c = index.getX( j + 2 );
+					}
 
-								intersection = checkBufferGeometryIntersection( this, groupMaterial, raycaster, _ray, position, morphPosition, morphTargetsRelative, uv, uv2, a, b, c );
+					vA.add( morphA );
+					vB.add( morphB );
+					vC.add( morphC );
+
+				}
+
+				var intersection = checkIntersection( object, material, raycaster, ray, vA, vB, vC, intersectionPoint );
+
+				if ( intersection ) {
+
+					if ( uv ) {
+
+						uvA.fromBufferAttribute( uv, a );
+						uvB.fromBufferAttribute( uv, b );
+						uvC.fromBufferAttribute( uv, c );
+
+						intersection.uv = Triangle.getUV( intersectionPoint, vA, vB, vC, uvA, uvB, uvC, new Vector2() );
+
+					}
+
+					if ( uv2 ) {
+
+						uvA.fromBufferAttribute( uv2, a );
+						uvB.fromBufferAttribute( uv2, b );
+						uvC.fromBufferAttribute( uv2, c );
+
+						intersection.uv2 = Triangle.getUV( intersectionPoint, vA, vB, vC, uvA, uvB, uvC, new Vector2() );
+
+					}
+
+					var face = new Face3( a, b, c );
+					Triangle.getNormal( vA, vB, vC, face.normal );
+
+					intersection.face = face;
+
+				}
+
+				return intersection;
+
+			}
+
+			return function raycast( raycaster, intersects ) {
+
+				var geometry = this.geometry;
+				var material = this.material;
+				var matrixWorld = this.matrixWorld;
+
+				if ( material === undefined ) return;
+
+				// Checking boundingSphere distance to ray
+
+				if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
+
+				sphere.copy( geometry.boundingSphere );
+				sphere.applyMatrix4( matrixWorld );
+
+				if ( raycaster.ray.intersectsSphere( sphere ) === false ) return;
+
+				//
+
+				inverseMatrix.getInverse( matrixWorld );
+				ray.copy( raycaster.ray ).applyMatrix4( inverseMatrix );
+
+				// Check boundingBox before continuing
+
+				if ( geometry.boundingBox !== null ) {
+
+					if ( ray.intersectsBox( geometry.boundingBox ) === false ) return;
+
+				}
+
+				var intersection;
+
+				if ( geometry.isBufferGeometry ) {
+
+					var a, b, c;
+					var index = geometry.index;
+					var position = geometry.attributes.position;
+					var morphPosition = geometry.morphAttributes.position;
+					var uv = geometry.attributes.uv;
+					var uv2 = geometry.attributes.uv2;
+					var groups = geometry.groups;
+					var drawRange = geometry.drawRange;
+					var i, j, il, jl;
+					var group, groupMaterial;
+					var start, end;
+
+					if ( index !== null ) {
+
+						// indexed buffer geometry
+
+						if ( Array.isArray( material ) ) {
+
+							for ( i = 0, il = groups.length; i < il; i ++ ) {
+
+								group = groups[ i ];
+								groupMaterial = material[ group.materialIndex ];
+
+								start = Math.max( group.start, drawRange.start );
+								end = Math.min( ( group.start + group.count ), ( drawRange.start + drawRange.count ) );
+
+								for ( j = start, jl = end; j < jl; j += 3 ) {
+
+									a = index.getX( j );
+									b = index.getX( j + 1 );
+									c = index.getX( j + 2 );
+
+									intersection = checkBufferGeometryIntersection( this, groupMaterial, raycaster, ray, position, morphPosition, uv, uv2, a, b, c );
+
+									if ( intersection ) {
+
+										intersection.faceIndex = Math.floor( j / 3 ); // triangle number in indexed buffer semantics
+										intersection.face.materialIndex = group.materialIndex;
+										intersects.push( intersection );
+
+									}
+
+								}
+
+							}
+
+						} else {
+
+							start = Math.max( 0, drawRange.start );
+							end = Math.min( index.count, ( drawRange.start + drawRange.count ) );
+
+							for ( i = start, il = end; i < il; i += 3 ) {
+
+								a = index.getX( i );
+								b = index.getX( i + 1 );
+								c = index.getX( i + 2 );
+
+								intersection = checkBufferGeometryIntersection( this, material, raycaster, ray, position, morphPosition, uv, uv2, a, b, c );
 
 								if ( intersection ) {
 
-									intersection.faceIndex = Math.floor( j / 3 ); // triangle number in indexed buffer semantics
-									intersection.face.materialIndex = group.materialIndex;
+									intersection.faceIndex = Math.floor( i / 3 ); // triangle number in indexed buffer semantics
 									intersects.push( intersection );
 
 								}
@@ -11432,56 +11353,56 @@ var Spacekit = (function (exports) {
 
 						}
 
-					} else {
+					} else if ( position !== undefined ) {
 
-						start = Math.max( 0, drawRange.start );
-						end = Math.min( index.count, ( drawRange.start + drawRange.count ) );
+						// non-indexed buffer geometry
 
-						for ( i = start, il = end; i < il; i += 3 ) {
+						if ( Array.isArray( material ) ) {
 
-							a = index.getX( i );
-							b = index.getX( i + 1 );
-							c = index.getX( i + 2 );
+							for ( i = 0, il = groups.length; i < il; i ++ ) {
 
-							intersection = checkBufferGeometryIntersection( this, material, raycaster, _ray, position, morphPosition, morphTargetsRelative, uv, uv2, a, b, c );
+								group = groups[ i ];
+								groupMaterial = material[ group.materialIndex ];
 
-							if ( intersection ) {
+								start = Math.max( group.start, drawRange.start );
+								end = Math.min( ( group.start + group.count ), ( drawRange.start + drawRange.count ) );
 
-								intersection.faceIndex = Math.floor( i / 3 ); // triangle number in indexed buffer semantics
-								intersects.push( intersection );
+								for ( j = start, jl = end; j < jl; j += 3 ) {
+
+									a = j;
+									b = j + 1;
+									c = j + 2;
+
+									intersection = checkBufferGeometryIntersection( this, groupMaterial, raycaster, ray, position, morphPosition, uv, uv2, a, b, c );
+
+									if ( intersection ) {
+
+										intersection.faceIndex = Math.floor( j / 3 ); // triangle number in non-indexed buffer semantics
+										intersection.face.materialIndex = group.materialIndex;
+										intersects.push( intersection );
+
+									}
+
+								}
 
 							}
 
-						}
+						} else {
 
-					}
+							start = Math.max( 0, drawRange.start );
+							end = Math.min( position.count, ( drawRange.start + drawRange.count ) );
 
-				} else if ( position !== undefined ) {
+							for ( i = start, il = end; i < il; i += 3 ) {
 
-					// non-indexed buffer geometry
+								a = i;
+								b = i + 1;
+								c = i + 2;
 
-					if ( Array.isArray( material ) ) {
-
-						for ( i = 0, il = groups.length; i < il; i ++ ) {
-
-							group = groups[ i ];
-							groupMaterial = material[ group.materialIndex ];
-
-							start = Math.max( group.start, drawRange.start );
-							end = Math.min( ( group.start + group.count ), ( drawRange.start + drawRange.count ) );
-
-							for ( j = start, jl = end; j < jl; j += 3 ) {
-
-								a = j;
-								b = j + 1;
-								c = j + 2;
-
-								intersection = checkBufferGeometryIntersection( this, groupMaterial, raycaster, _ray, position, morphPosition, morphTargetsRelative, uv, uv2, a, b, c );
+								intersection = checkBufferGeometryIntersection( this, material, raycaster, ray, position, morphPosition, uv, uv2, a, b, c );
 
 								if ( intersection ) {
 
-									intersection.faceIndex = Math.floor( j / 3 ); // triangle number in non-indexed buffer semantics
-									intersection.face.materialIndex = group.materialIndex;
+									intersection.faceIndex = Math.floor( i / 3 ); // triangle number in non-indexed buffer semantics
 									intersects.push( intersection );
 
 								}
@@ -11490,81 +11411,59 @@ var Spacekit = (function (exports) {
 
 						}
 
-					} else {
+					}
 
-						start = Math.max( 0, drawRange.start );
-						end = Math.min( position.count, ( drawRange.start + drawRange.count ) );
+				} else if ( geometry.isGeometry ) {
 
-						for ( i = start, il = end; i < il; i += 3 ) {
+					var fvA, fvB, fvC;
+					var isMultiMaterial = Array.isArray( material );
 
-							a = i;
-							b = i + 1;
-							c = i + 2;
+					var vertices = geometry.vertices;
+					var faces = geometry.faces;
+					var uvs;
 
-							intersection = checkBufferGeometryIntersection( this, material, raycaster, _ray, position, morphPosition, morphTargetsRelative, uv, uv2, a, b, c );
+					var faceVertexUvs = geometry.faceVertexUvs[ 0 ];
+					if ( faceVertexUvs.length > 0 ) uvs = faceVertexUvs;
 
-							if ( intersection ) {
+					for ( var f = 0, fl = faces.length; f < fl; f ++ ) {
 
-								intersection.faceIndex = Math.floor( i / 3 ); // triangle number in non-indexed buffer semantics
-								intersects.push( intersection );
+						var face = faces[ f ];
+						var faceMaterial = isMultiMaterial ? material[ face.materialIndex ] : material;
+
+						if ( faceMaterial === undefined ) continue;
+
+						fvA = vertices[ face.a ];
+						fvB = vertices[ face.b ];
+						fvC = vertices[ face.c ];
+
+						intersection = checkIntersection( this, faceMaterial, raycaster, ray, fvA, fvB, fvC, intersectionPoint );
+
+						if ( intersection ) {
+
+							if ( uvs && uvs[ f ] ) {
+
+								var uvs_f = uvs[ f ];
+								uvA.copy( uvs_f[ 0 ] );
+								uvB.copy( uvs_f[ 1 ] );
+								uvC.copy( uvs_f[ 2 ] );
+
+								intersection.uv = Triangle.getUV( intersectionPoint, fvA, fvB, fvC, uvA, uvB, uvC, new Vector2() );
 
 							}
 
+							intersection.face = face;
+							intersection.faceIndex = f;
+							intersects.push( intersection );
+
 						}
 
 					}
 
 				}
 
-			} else if ( geometry.isGeometry ) {
+			};
 
-				var fvA, fvB, fvC;
-				var isMultiMaterial = Array.isArray( material );
-
-				var vertices = geometry.vertices;
-				var faces = geometry.faces;
-				var uvs;
-
-				var faceVertexUvs = geometry.faceVertexUvs[ 0 ];
-				if ( faceVertexUvs.length > 0 ) uvs = faceVertexUvs;
-
-				for ( var f = 0, fl = faces.length; f < fl; f ++ ) {
-
-					var face = faces[ f ];
-					var faceMaterial = isMultiMaterial ? material[ face.materialIndex ] : material;
-
-					if ( faceMaterial === undefined ) continue;
-
-					fvA = vertices[ face.a ];
-					fvB = vertices[ face.b ];
-					fvC = vertices[ face.c ];
-
-					intersection = checkIntersection( this, faceMaterial, raycaster, _ray, fvA, fvB, fvC, _intersectionPoint );
-
-					if ( intersection ) {
-
-						if ( uvs && uvs[ f ] ) {
-
-							var uvs_f = uvs[ f ];
-							_uvA.copy( uvs_f[ 0 ] );
-							_uvB.copy( uvs_f[ 1 ] );
-							_uvC.copy( uvs_f[ 2 ] );
-
-							intersection.uv = Triangle.getUV( _intersectionPoint, fvA, fvB, fvC, _uvA, _uvB, _uvC, new Vector2() );
-
-						}
-
-						intersection.face = face;
-						intersection.faceIndex = f;
-						intersects.push( intersection );
-
-					}
-
-				}
-
-			}
-
-		},
+		}() ),
 
 		clone: function () {
 
@@ -11573,127 +11472,6 @@ var Spacekit = (function (exports) {
 		}
 
 	} );
-
-	function checkIntersection( object, material, raycaster, ray, pA, pB, pC, point ) {
-
-		var intersect;
-
-		if ( material.side === BackSide ) {
-
-			intersect = ray.intersectTriangle( pC, pB, pA, true, point );
-
-		} else {
-
-			intersect = ray.intersectTriangle( pA, pB, pC, material.side !== DoubleSide, point );
-
-		}
-
-		if ( intersect === null ) return null;
-
-		_intersectionPointWorld.copy( point );
-		_intersectionPointWorld.applyMatrix4( object.matrixWorld );
-
-		var distance = raycaster.ray.origin.distanceTo( _intersectionPointWorld );
-
-		if ( distance < raycaster.near || distance > raycaster.far ) return null;
-
-		return {
-			distance: distance,
-			point: _intersectionPointWorld.clone(),
-			object: object
-		};
-
-	}
-
-	function checkBufferGeometryIntersection( object, material, raycaster, ray, position, morphPosition, morphTargetsRelative, uv, uv2, a, b, c ) {
-
-		_vA.fromBufferAttribute( position, a );
-		_vB.fromBufferAttribute( position, b );
-		_vC.fromBufferAttribute( position, c );
-
-		var morphInfluences = object.morphTargetInfluences;
-
-		if ( material.morphTargets && morphPosition && morphInfluences ) {
-
-			_morphA.set( 0, 0, 0 );
-			_morphB.set( 0, 0, 0 );
-			_morphC.set( 0, 0, 0 );
-
-			for ( var i = 0, il = morphPosition.length; i < il; i ++ ) {
-
-				var influence = morphInfluences[ i ];
-				var morphAttribute = morphPosition[ i ];
-
-				if ( influence === 0 ) continue;
-
-				_tempA.fromBufferAttribute( morphAttribute, a );
-				_tempB.fromBufferAttribute( morphAttribute, b );
-				_tempC.fromBufferAttribute( morphAttribute, c );
-
-				if ( morphTargetsRelative ) {
-
-					_morphA.addScaledVector( _tempA, influence );
-					_morphB.addScaledVector( _tempB, influence );
-					_morphC.addScaledVector( _tempC, influence );
-
-				} else {
-
-					_morphA.addScaledVector( _tempA.sub( _vA ), influence );
-					_morphB.addScaledVector( _tempB.sub( _vB ), influence );
-					_morphC.addScaledVector( _tempC.sub( _vC ), influence );
-
-				}
-
-			}
-
-			_vA.add( _morphA );
-			_vB.add( _morphB );
-			_vC.add( _morphC );
-
-		}
-
-		if ( object.isSkinnedMesh ) {
-
-			object.boneTransform( a, _vA );
-			object.boneTransform( b, _vB );
-			object.boneTransform( c, _vC );
-
-		}
-
-		var intersection = checkIntersection( object, material, raycaster, ray, _vA, _vB, _vC, _intersectionPoint );
-
-		if ( intersection ) {
-
-			if ( uv ) {
-
-				_uvA.fromBufferAttribute( uv, a );
-				_uvB.fromBufferAttribute( uv, b );
-				_uvC.fromBufferAttribute( uv, c );
-
-				intersection.uv = Triangle.getUV( _intersectionPoint, _vA, _vB, _vC, _uvA, _uvB, _uvC, new Vector2() );
-
-			}
-
-			if ( uv2 ) {
-
-				_uvA.fromBufferAttribute( uv2, a );
-				_uvB.fromBufferAttribute( uv2, b );
-				_uvC.fromBufferAttribute( uv2, c );
-
-				intersection.uv2 = Triangle.getUV( _intersectionPoint, _vA, _vB, _vC, _uvA, _uvB, _uvC, new Vector2() );
-
-			}
-
-			var face = new Face3( a, b, c );
-			Triangle.getNormal( _vA, _vB, _vC, face.normal );
-
-			intersection.face = face;
-
-		}
-
-		return intersection;
-
-	}
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -11704,16 +11482,13 @@ var Spacekit = (function (exports) {
 	 * @author bhouston / http://clara.io
 	 */
 
-	var _geometryId = 0; // Geometry uses even numbers as Id
-	var _m1$3 = new Matrix4();
-	var _obj$1 = new Object3D();
-	var _offset$1 = new Vector3();
+	var geometryId = 0; // Geometry uses even numbers as Id
 
 	function Geometry() {
 
-		Object.defineProperty( this, 'id', { value: _geometryId += 2 } );
+		Object.defineProperty( this, 'id', { value: geometryId += 2 } );
 
-		this.uuid = MathUtils.generateUUID();
+		this.uuid = _Math.generateUUID();
 
 		this.name = '';
 		this.type = 'Geometry';
@@ -11752,7 +11527,7 @@ var Spacekit = (function (exports) {
 
 		isGeometry: true,
 
-		applyMatrix4: function ( matrix ) {
+		applyMatrix: function ( matrix ) {
 
 			var normalMatrix = new Matrix3().getNormalMatrix( matrix );
 
@@ -11795,77 +11570,111 @@ var Spacekit = (function (exports) {
 
 		},
 
-		rotateX: function ( angle ) {
+		rotateX: function () {
 
 			// rotate geometry around world x-axis
 
-			_m1$3.makeRotationX( angle );
+			var m1 = new Matrix4();
 
-			this.applyMatrix4( _m1$3 );
+			return function rotateX( angle ) {
 
-			return this;
+				m1.makeRotationX( angle );
 
-		},
+				this.applyMatrix( m1 );
 
-		rotateY: function ( angle ) {
+				return this;
+
+			};
+
+		}(),
+
+		rotateY: function () {
 
 			// rotate geometry around world y-axis
 
-			_m1$3.makeRotationY( angle );
+			var m1 = new Matrix4();
 
-			this.applyMatrix4( _m1$3 );
+			return function rotateY( angle ) {
 
-			return this;
+				m1.makeRotationY( angle );
 
-		},
+				this.applyMatrix( m1 );
 
-		rotateZ: function ( angle ) {
+				return this;
+
+			};
+
+		}(),
+
+		rotateZ: function () {
 
 			// rotate geometry around world z-axis
 
-			_m1$3.makeRotationZ( angle );
+			var m1 = new Matrix4();
 
-			this.applyMatrix4( _m1$3 );
+			return function rotateZ( angle ) {
 
-			return this;
+				m1.makeRotationZ( angle );
 
-		},
+				this.applyMatrix( m1 );
 
-		translate: function ( x, y, z ) {
+				return this;
+
+			};
+
+		}(),
+
+		translate: function () {
 
 			// translate geometry
 
-			_m1$3.makeTranslation( x, y, z );
+			var m1 = new Matrix4();
 
-			this.applyMatrix4( _m1$3 );
+			return function translate( x, y, z ) {
 
-			return this;
+				m1.makeTranslation( x, y, z );
 
-		},
+				this.applyMatrix( m1 );
 
-		scale: function ( x, y, z ) {
+				return this;
+
+			};
+
+		}(),
+
+		scale: function () {
 
 			// scale geometry
 
-			_m1$3.makeScale( x, y, z );
+			var m1 = new Matrix4();
 
-			this.applyMatrix4( _m1$3 );
+			return function scale( x, y, z ) {
 
-			return this;
+				m1.makeScale( x, y, z );
 
-		},
+				this.applyMatrix( m1 );
 
-		lookAt: function ( vector ) {
+				return this;
 
-			_obj$1.lookAt( vector );
+			};
 
-			_obj$1.updateMatrix();
+		}(),
 
-			this.applyMatrix4( _obj$1.matrix );
+		lookAt: function () {
 
-			return this;
+			var obj = new Object3D();
 
-		},
+			return function lookAt( vector ) {
+
+				obj.lookAt( vector );
+
+				obj.updateMatrix();
+
+				this.applyMatrix( obj.matrix );
+
+			};
+
+		}(),
 
 		fromBufferGeometry: function ( geometry ) {
 
@@ -11873,13 +11682,6 @@ var Spacekit = (function (exports) {
 
 			var indices = geometry.index !== null ? geometry.index.array : undefined;
 			var attributes = geometry.attributes;
-
-			if ( attributes.position === undefined ) {
-
-				console.error( 'THREE.Geometry.fromBufferGeometry(): Position attribute required for conversion.' );
-				return this;
-
-			}
 
 			var positions = attributes.position.array;
 			var normals = attributes.normal !== undefined ? attributes.normal.array : undefined;
@@ -12009,15 +11811,21 @@ var Spacekit = (function (exports) {
 
 		center: function () {
 
-			this.computeBoundingBox();
+			var offset = new Vector3();
 
-			this.boundingBox.getCenter( _offset$1 ).negate();
+			return function center() {
 
-			this.translate( _offset$1.x, _offset$1.y, _offset$1.z );
+				this.computeBoundingBox();
 
-			return this;
+				this.boundingBox.getCenter( offset ).negate();
 
-		},
+				this.translate( offset.x, offset.y, offset.z );
+
+				return this;
+
+			};
+
+		}(),
 
 		normalize: function () {
 
@@ -12036,7 +11844,7 @@ var Spacekit = (function (exports) {
 				0, 0, 0, 1
 			);
 
-			this.applyMatrix4( matrix );
+			this.applyMatrix( matrix );
 
 			return this;
 
@@ -13093,196 +12901,194 @@ var Spacekit = (function (exports) {
 
 	// BoxGeometry
 
-	class BoxGeometry extends Geometry {
+	function BoxGeometry( width, height, depth, widthSegments, heightSegments, depthSegments ) {
 
-		constructor( width, height, depth, widthSegments, heightSegments, depthSegments ) {
+		Geometry.call( this );
 
-			super();
+		this.type = 'BoxGeometry';
 
-			this.type = 'BoxGeometry';
+		this.parameters = {
+			width: width,
+			height: height,
+			depth: depth,
+			widthSegments: widthSegments,
+			heightSegments: heightSegments,
+			depthSegments: depthSegments
+		};
 
-			this.parameters = {
-				width: width,
-				height: height,
-				depth: depth,
-				widthSegments: widthSegments,
-				heightSegments: heightSegments,
-				depthSegments: depthSegments
-			};
-
-			this.fromBufferGeometry( new BoxBufferGeometry( width, height, depth, widthSegments, heightSegments, depthSegments ) );
-			this.mergeVertices();
-
-		}
+		this.fromBufferGeometry( new BoxBufferGeometry( width, height, depth, widthSegments, heightSegments, depthSegments ) );
+		this.mergeVertices();
 
 	}
+
+	BoxGeometry.prototype = Object.create( Geometry.prototype );
+	BoxGeometry.prototype.constructor = BoxGeometry;
 
 	// BoxBufferGeometry
 
-	class BoxBufferGeometry extends BufferGeometry {
+	function BoxBufferGeometry( width, height, depth, widthSegments, heightSegments, depthSegments ) {
 
-		constructor( width, height, depth, widthSegments, heightSegments, depthSegments ) {
+		BufferGeometry.call( this );
 
-			super();
+		this.type = 'BoxBufferGeometry';
 
-			this.type = 'BoxBufferGeometry';
+		this.parameters = {
+			width: width,
+			height: height,
+			depth: depth,
+			widthSegments: widthSegments,
+			heightSegments: heightSegments,
+			depthSegments: depthSegments
+		};
 
-			this.parameters = {
-				width: width,
-				height: height,
-				depth: depth,
-				widthSegments: widthSegments,
-				heightSegments: heightSegments,
-				depthSegments: depthSegments
-			};
+		var scope = this;
 
-			var scope = this;
+		width = width || 1;
+		height = height || 1;
+		depth = depth || 1;
 
-			width = width || 1;
-			height = height || 1;
-			depth = depth || 1;
+		// segments
 
-			// segments
+		widthSegments = Math.floor( widthSegments ) || 1;
+		heightSegments = Math.floor( heightSegments ) || 1;
+		depthSegments = Math.floor( depthSegments ) || 1;
 
-			widthSegments = Math.floor( widthSegments ) || 1;
-			heightSegments = Math.floor( heightSegments ) || 1;
-			depthSegments = Math.floor( depthSegments ) || 1;
+		// buffers
 
-			// buffers
+		var indices = [];
+		var vertices = [];
+		var normals = [];
+		var uvs = [];
 
-			var indices = [];
-			var vertices = [];
-			var normals = [];
-			var uvs = [];
+		// helper variables
 
-			// helper variables
+		var numberOfVertices = 0;
+		var groupStart = 0;
 
-			var numberOfVertices = 0;
-			var groupStart = 0;
+		// build each side of the box geometry
 
-			// build each side of the box geometry
+		buildPlane( 'z', 'y', 'x', - 1, - 1, depth, height, width, depthSegments, heightSegments, 0 ); // px
+		buildPlane( 'z', 'y', 'x', 1, - 1, depth, height, - width, depthSegments, heightSegments, 1 ); // nx
+		buildPlane( 'x', 'z', 'y', 1, 1, width, depth, height, widthSegments, depthSegments, 2 ); // py
+		buildPlane( 'x', 'z', 'y', 1, - 1, width, depth, - height, widthSegments, depthSegments, 3 ); // ny
+		buildPlane( 'x', 'y', 'z', 1, - 1, width, height, depth, widthSegments, heightSegments, 4 ); // pz
+		buildPlane( 'x', 'y', 'z', - 1, - 1, width, height, - depth, widthSegments, heightSegments, 5 ); // nz
 
-			buildPlane( 'z', 'y', 'x', - 1, - 1, depth, height, width, depthSegments, heightSegments, 0 ); // px
-			buildPlane( 'z', 'y', 'x', 1, - 1, depth, height, - width, depthSegments, heightSegments, 1 ); // nx
-			buildPlane( 'x', 'z', 'y', 1, 1, width, depth, height, widthSegments, depthSegments, 2 ); // py
-			buildPlane( 'x', 'z', 'y', 1, - 1, width, depth, - height, widthSegments, depthSegments, 3 ); // ny
-			buildPlane( 'x', 'y', 'z', 1, - 1, width, height, depth, widthSegments, heightSegments, 4 ); // pz
-			buildPlane( 'x', 'y', 'z', - 1, - 1, width, height, - depth, widthSegments, heightSegments, 5 ); // nz
+		// build geometry
 
-			// build geometry
+		this.setIndex( indices );
+		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
-			this.setIndex( indices );
-			this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-			this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-			this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		function buildPlane( u, v, w, udir, vdir, width, height, depth, gridX, gridY, materialIndex ) {
 
-			function buildPlane( u, v, w, udir, vdir, width, height, depth, gridX, gridY, materialIndex ) {
+			var segmentWidth = width / gridX;
+			var segmentHeight = height / gridY;
 
-				var segmentWidth = width / gridX;
-				var segmentHeight = height / gridY;
+			var widthHalf = width / 2;
+			var heightHalf = height / 2;
+			var depthHalf = depth / 2;
 
-				var widthHalf = width / 2;
-				var heightHalf = height / 2;
-				var depthHalf = depth / 2;
+			var gridX1 = gridX + 1;
+			var gridY1 = gridY + 1;
 
-				var gridX1 = gridX + 1;
-				var gridY1 = gridY + 1;
+			var vertexCounter = 0;
+			var groupCount = 0;
 
-				var vertexCounter = 0;
-				var groupCount = 0;
+			var ix, iy;
 
-				var ix, iy;
+			var vector = new Vector3();
 
-				var vector = new Vector3();
+			// generate vertices, normals and uvs
 
-				// generate vertices, normals and uvs
+			for ( iy = 0; iy < gridY1; iy ++ ) {
 
-				for ( iy = 0; iy < gridY1; iy ++ ) {
+				var y = iy * segmentHeight - heightHalf;
 
-					var y = iy * segmentHeight - heightHalf;
+				for ( ix = 0; ix < gridX1; ix ++ ) {
 
-					for ( ix = 0; ix < gridX1; ix ++ ) {
+					var x = ix * segmentWidth - widthHalf;
 
-						var x = ix * segmentWidth - widthHalf;
+					// set values to correct vector component
 
-						// set values to correct vector component
+					vector[ u ] = x * udir;
+					vector[ v ] = y * vdir;
+					vector[ w ] = depthHalf;
 
-						vector[ u ] = x * udir;
-						vector[ v ] = y * vdir;
-						vector[ w ] = depthHalf;
+					// now apply vector to vertex buffer
 
-						// now apply vector to vertex buffer
+					vertices.push( vector.x, vector.y, vector.z );
 
-						vertices.push( vector.x, vector.y, vector.z );
+					// set values to correct vector component
 
-						// set values to correct vector component
+					vector[ u ] = 0;
+					vector[ v ] = 0;
+					vector[ w ] = depth > 0 ? 1 : - 1;
 
-						vector[ u ] = 0;
-						vector[ v ] = 0;
-						vector[ w ] = depth > 0 ? 1 : - 1;
+					// now apply vector to normal buffer
 
-						// now apply vector to normal buffer
+					normals.push( vector.x, vector.y, vector.z );
 
-						normals.push( vector.x, vector.y, vector.z );
+					// uvs
 
-						// uvs
+					uvs.push( ix / gridX );
+					uvs.push( 1 - ( iy / gridY ) );
 
-						uvs.push( ix / gridX );
-						uvs.push( 1 - ( iy / gridY ) );
+					// counters
 
-						// counters
-
-						vertexCounter += 1;
-
-					}
+					vertexCounter += 1;
 
 				}
-
-				// indices
-
-				// 1. you need three indices to draw a single face
-				// 2. a single segment consists of two faces
-				// 3. so we need to generate six (2*3) indices per segment
-
-				for ( iy = 0; iy < gridY; iy ++ ) {
-
-					for ( ix = 0; ix < gridX; ix ++ ) {
-
-						var a = numberOfVertices + ix + gridX1 * iy;
-						var b = numberOfVertices + ix + gridX1 * ( iy + 1 );
-						var c = numberOfVertices + ( ix + 1 ) + gridX1 * ( iy + 1 );
-						var d = numberOfVertices + ( ix + 1 ) + gridX1 * iy;
-
-						// faces
-
-						indices.push( a, b, d );
-						indices.push( b, c, d );
-
-						// increase counter
-
-						groupCount += 6;
-
-					}
-
-				}
-
-				// add a group to the geometry. this will ensure multi material support
-
-				scope.addGroup( groupStart, groupCount, materialIndex );
-
-				// calculate new start value for groups
-
-				groupStart += groupCount;
-
-				// update total number of vertices
-
-				numberOfVertices += vertexCounter;
 
 			}
+
+			// indices
+
+			// 1. you need three indices to draw a single face
+			// 2. a single segment consists of two faces
+			// 3. so we need to generate six (2*3) indices per segment
+
+			for ( iy = 0; iy < gridY; iy ++ ) {
+
+				for ( ix = 0; ix < gridX; ix ++ ) {
+
+					var a = numberOfVertices + ix + gridX1 * iy;
+					var b = numberOfVertices + ix + gridX1 * ( iy + 1 );
+					var c = numberOfVertices + ( ix + 1 ) + gridX1 * ( iy + 1 );
+					var d = numberOfVertices + ( ix + 1 ) + gridX1 * iy;
+
+					// faces
+
+					indices.push( a, b, d );
+					indices.push( b, c, d );
+
+					// increase counter
+
+					groupCount += 6;
+
+				}
+
+			}
+
+			// add a group to the geometry. this will ensure multi material support
+
+			scope.addGroup( groupStart, groupCount, materialIndex );
+
+			// calculate new start value for groups
+
+			groupStart += groupCount;
+
+			// update total number of vertices
+
+			numberOfVertices += vertexCounter;
 
 		}
 
 	}
+
+	BoxBufferGeometry.prototype = Object.create( BufferGeometry.prototype );
+	BoxBufferGeometry.prototype.constructor = BoxBufferGeometry;
 
 	/**
 	 * Uniform Utilities
@@ -13618,14 +13424,6 @@ var Spacekit = (function (exports) {
 
 		},
 
-		updateWorldMatrix: function ( updateParents, updateChildren ) {
-
-			Object3D.prototype.updateWorldMatrix.call( this, updateParents, updateChildren );
-
-			this.matrixWorldInverse.getInverse( this.matrixWorld );
-
-		},
-
 		clone: function () {
 
 			return new this.constructor().copy( this );
@@ -13704,7 +13502,7 @@ var Spacekit = (function (exports) {
 			// see http://www.bobatkins.com/photography/technical/field_of_view.html
 			var vExtentSlope = 0.5 * this.getFilmHeight() / focalLength;
 
-			this.fov = MathUtils.RAD2DEG * 2 * Math.atan( vExtentSlope );
+			this.fov = _Math.RAD2DEG * 2 * Math.atan( vExtentSlope );
 			this.updateProjectionMatrix();
 
 		},
@@ -13714,7 +13512,7 @@ var Spacekit = (function (exports) {
 		 */
 		getFocalLength: function () {
 
-			var vExtentSlope = Math.tan( MathUtils.DEG2RAD * 0.5 * this.fov );
+			var vExtentSlope = Math.tan( _Math.DEG2RAD * 0.5 * this.fov );
 
 			return 0.5 * this.getFilmHeight() / vExtentSlope;
 
@@ -13722,8 +13520,8 @@ var Spacekit = (function (exports) {
 
 		getEffectiveFOV: function () {
 
-			return MathUtils.RAD2DEG * 2 * Math.atan(
-				Math.tan( MathUtils.DEG2RAD * 0.5 * this.fov ) / this.zoom );
+			return _Math.RAD2DEG * 2 * Math.atan(
+				Math.tan( _Math.DEG2RAD * 0.5 * this.fov ) / this.zoom );
 
 		},
 
@@ -13821,7 +13619,7 @@ var Spacekit = (function (exports) {
 		updateProjectionMatrix: function () {
 
 			var near = this.near,
-				top = near * Math.tan( MathUtils.DEG2RAD * 0.5 * this.fov ) / this.zoom,
+				top = near * Math.tan( _Math.DEG2RAD * 0.5 * this.fov ) / this.zoom,
 				height = 2 * top,
 				width = this.aspect * height,
 				left = - 0.5 * width,
@@ -13919,7 +13717,7 @@ var Spacekit = (function (exports) {
 
 		options = options || { format: RGBFormat, magFilter: LinearFilter, minFilter: LinearFilter };
 
-		this.renderTarget = new WebGLCubeRenderTarget( cubeResolution, options );
+		this.renderTarget = new WebGLRenderTargetCube( cubeResolution, cubeResolution, options );
 		this.renderTarget.texture.name = "CubeCamera";
 
 		this.update = function ( renderer, scene ) {
@@ -13985,26 +13783,18 @@ var Spacekit = (function (exports) {
 	 * @author WestLangley / http://github.com/WestLangley
 	 */
 
-	function WebGLCubeRenderTarget( size, options, dummy ) {
+	function WebGLRenderTargetCube( width, height, options ) {
 
-		if ( Number.isInteger( options ) ) {
-
-			console.warn( 'THREE.WebGLCubeRenderTarget: constructor signature is now WebGLCubeRenderTarget( size, options )' );
-
-			options = dummy;
-
-		}
-
-		WebGLRenderTarget.call( this, size, size, options );
+		WebGLRenderTarget.call( this, width, height, options );
 
 	}
 
-	WebGLCubeRenderTarget.prototype = Object.create( WebGLRenderTarget.prototype );
-	WebGLCubeRenderTarget.prototype.constructor = WebGLCubeRenderTarget;
+	WebGLRenderTargetCube.prototype = Object.create( WebGLRenderTarget.prototype );
+	WebGLRenderTargetCube.prototype.constructor = WebGLRenderTargetCube;
 
-	WebGLCubeRenderTarget.prototype.isWebGLCubeRenderTarget = true;
+	WebGLRenderTargetCube.prototype.isWebGLRenderTargetCube = true;
 
-	WebGLCubeRenderTarget.prototype.fromEquirectangularTexture = function ( renderer, texture ) {
+	WebGLRenderTargetCube.prototype.fromEquirectangularTexture = function ( renderer, texture ) {
 
 		this.texture.type = texture.type;
 		this.texture.format = texture.format;
@@ -14105,7 +13895,7 @@ var Spacekit = (function (exports) {
 
 		Texture.call( this, null, mapping, wrapS, wrapT, magFilter, minFilter, format, type, anisotropy, encoding );
 
-		this.image = { data: data || null, width: width || 1, height: height || 1 };
+		this.image = { data: data, width: width, height: height };
 
 		this.magFilter = magFilter !== undefined ? magFilter : NearestFilter;
 		this.minFilter = minFilter !== undefined ? minFilter : NearestFilter;
@@ -14113,8 +13903,6 @@ var Spacekit = (function (exports) {
 		this.generateMipmaps = false;
 		this.flipY = false;
 		this.unpackAlignment = 1;
-
-		this.needsUpdate = true;
 
 	}
 
@@ -14124,13 +13912,252 @@ var Spacekit = (function (exports) {
 	DataTexture.prototype.isDataTexture = true;
 
 	/**
+	 * @author bhouston / http://clara.io
+	 */
+
+	function Plane( normal, constant ) {
+
+		// normal is assumed to be normalized
+
+		this.normal = ( normal !== undefined ) ? normal : new Vector3( 1, 0, 0 );
+		this.constant = ( constant !== undefined ) ? constant : 0;
+
+	}
+
+	Object.assign( Plane.prototype, {
+
+		isPlane: true,
+
+		set: function ( normal, constant ) {
+
+			this.normal.copy( normal );
+			this.constant = constant;
+
+			return this;
+
+		},
+
+		setComponents: function ( x, y, z, w ) {
+
+			this.normal.set( x, y, z );
+			this.constant = w;
+
+			return this;
+
+		},
+
+		setFromNormalAndCoplanarPoint: function ( normal, point ) {
+
+			this.normal.copy( normal );
+			this.constant = - point.dot( this.normal );
+
+			return this;
+
+		},
+
+		setFromCoplanarPoints: function () {
+
+			var v1 = new Vector3();
+			var v2 = new Vector3();
+
+			return function setFromCoplanarPoints( a, b, c ) {
+
+				var normal = v1.subVectors( c, b ).cross( v2.subVectors( a, b ) ).normalize();
+
+				// Q: should an error be thrown if normal is zero (e.g. degenerate plane)?
+
+				this.setFromNormalAndCoplanarPoint( normal, a );
+
+				return this;
+
+			};
+
+		}(),
+
+		clone: function () {
+
+			return new this.constructor().copy( this );
+
+		},
+
+		copy: function ( plane ) {
+
+			this.normal.copy( plane.normal );
+			this.constant = plane.constant;
+
+			return this;
+
+		},
+
+		normalize: function () {
+
+			// Note: will lead to a divide by zero if the plane is invalid.
+
+			var inverseNormalLength = 1.0 / this.normal.length();
+			this.normal.multiplyScalar( inverseNormalLength );
+			this.constant *= inverseNormalLength;
+
+			return this;
+
+		},
+
+		negate: function () {
+
+			this.constant *= - 1;
+			this.normal.negate();
+
+			return this;
+
+		},
+
+		distanceToPoint: function ( point ) {
+
+			return this.normal.dot( point ) + this.constant;
+
+		},
+
+		distanceToSphere: function ( sphere ) {
+
+			return this.distanceToPoint( sphere.center ) - sphere.radius;
+
+		},
+
+		projectPoint: function ( point, target ) {
+
+			if ( target === undefined ) {
+
+				console.warn( 'THREE.Plane: .projectPoint() target is now required' );
+				target = new Vector3();
+
+			}
+
+			return target.copy( this.normal ).multiplyScalar( - this.distanceToPoint( point ) ).add( point );
+
+		},
+
+		intersectLine: function () {
+
+			var v1 = new Vector3();
+
+			return function intersectLine( line, target ) {
+
+				if ( target === undefined ) {
+
+					console.warn( 'THREE.Plane: .intersectLine() target is now required' );
+					target = new Vector3();
+
+				}
+
+				var direction = line.delta( v1 );
+
+				var denominator = this.normal.dot( direction );
+
+				if ( denominator === 0 ) {
+
+					// line is coplanar, return origin
+					if ( this.distanceToPoint( line.start ) === 0 ) {
+
+						return target.copy( line.start );
+
+					}
+
+					// Unsure if this is the correct method to handle this case.
+					return undefined;
+
+				}
+
+				var t = - ( line.start.dot( this.normal ) + this.constant ) / denominator;
+
+				if ( t < 0 || t > 1 ) {
+
+					return undefined;
+
+				}
+
+				return target.copy( direction ).multiplyScalar( t ).add( line.start );
+
+			};
+
+		}(),
+
+		intersectsLine: function ( line ) {
+
+			// Note: this tests if a line intersects the plane, not whether it (or its end-points) are coplanar with it.
+
+			var startSign = this.distanceToPoint( line.start );
+			var endSign = this.distanceToPoint( line.end );
+
+			return ( startSign < 0 && endSign > 0 ) || ( endSign < 0 && startSign > 0 );
+
+		},
+
+		intersectsBox: function ( box ) {
+
+			return box.intersectsPlane( this );
+
+		},
+
+		intersectsSphere: function ( sphere ) {
+
+			return sphere.intersectsPlane( this );
+
+		},
+
+		coplanarPoint: function ( target ) {
+
+			if ( target === undefined ) {
+
+				console.warn( 'THREE.Plane: .coplanarPoint() target is now required' );
+				target = new Vector3();
+
+			}
+
+			return target.copy( this.normal ).multiplyScalar( - this.constant );
+
+		},
+
+		applyMatrix4: function () {
+
+			var v1 = new Vector3();
+			var m1 = new Matrix3();
+
+			return function applyMatrix4( matrix, optionalNormalMatrix ) {
+
+				var normalMatrix = optionalNormalMatrix || m1.getNormalMatrix( matrix );
+
+				var referencePoint = this.coplanarPoint( v1 ).applyMatrix4( matrix );
+
+				var normal = this.normal.applyMatrix3( normalMatrix ).normalize();
+
+				this.constant = - referencePoint.dot( normal );
+
+				return this;
+
+			};
+
+		}(),
+
+		translate: function ( offset ) {
+
+			this.constant -= offset.dot( this.normal );
+
+			return this;
+
+		},
+
+		equals: function ( plane ) {
+
+			return plane.normal.equals( this.normal ) && ( plane.constant === this.constant );
+
+		}
+
+	} );
+
+	/**
 	 * @author mrdoob / http://mrdoob.com/
 	 * @author alteredq / http://alteredqualia.com/
 	 * @author bhouston / http://clara.io
 	 */
-
-	var _sphere$1 = new Sphere();
-	var _vector$5 = new Vector3();
 
 	function Frustum( p0, p1, p2, p3, p4, p5 ) {
 
@@ -14184,7 +14211,7 @@ var Spacekit = (function (exports) {
 
 		},
 
-		setFromProjectionMatrix: function ( m ) {
+		setFromMatrix: function ( m ) {
 
 			var planes = this.planes;
 			var me = m.elements;
@@ -14204,27 +14231,41 @@ var Spacekit = (function (exports) {
 
 		},
 
-		intersectsObject: function ( object ) {
+		intersectsObject: function () {
 
-			var geometry = object.geometry;
+			var sphere = new Sphere();
 
-			if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
+			return function intersectsObject( object ) {
 
-			_sphere$1.copy( geometry.boundingSphere ).applyMatrix4( object.matrixWorld );
+				var geometry = object.geometry;
 
-			return this.intersectsSphere( _sphere$1 );
+				if ( geometry.boundingSphere === null )
+					geometry.computeBoundingSphere();
 
-		},
+				sphere.copy( geometry.boundingSphere )
+					.applyMatrix4( object.matrixWorld );
 
-		intersectsSprite: function ( sprite ) {
+				return this.intersectsSphere( sphere );
 
-			_sphere$1.center.set( 0, 0, 0 );
-			_sphere$1.radius = 0.7071067811865476;
-			_sphere$1.applyMatrix4( sprite.matrixWorld );
+			};
 
-			return this.intersectsSphere( _sphere$1 );
+		}(),
 
-		},
+		intersectsSprite: function () {
+
+			var sphere = new Sphere();
+
+			return function intersectsSprite( sprite ) {
+
+				sphere.center.set( 0, 0, 0 );
+				sphere.radius = 0.7071067811865476;
+				sphere.applyMatrix4( sprite.matrixWorld );
+
+				return this.intersectsSphere( sphere );
+
+			};
+
+		}(),
 
 		intersectsSphere: function ( sphere ) {
 
@@ -14248,31 +14289,37 @@ var Spacekit = (function (exports) {
 
 		},
 
-		intersectsBox: function ( box ) {
+		intersectsBox: function () {
 
-			var planes = this.planes;
+			var p = new Vector3();
 
-			for ( var i = 0; i < 6; i ++ ) {
+			return function intersectsBox( box ) {
 
-				var plane = planes[ i ];
+				var planes = this.planes;
 
-				// corner at max distance
+				for ( var i = 0; i < 6; i ++ ) {
 
-				_vector$5.x = plane.normal.x > 0 ? box.max.x : box.min.x;
-				_vector$5.y = plane.normal.y > 0 ? box.max.y : box.min.y;
-				_vector$5.z = plane.normal.z > 0 ? box.max.z : box.min.z;
+					var plane = planes[ i ];
 
-				if ( plane.distanceToPoint( _vector$5 ) < 0 ) {
+					// corner at max distance
 
-					return false;
+					p.x = plane.normal.x > 0 ? box.max.x : box.min.x;
+					p.y = plane.normal.y > 0 ? box.max.y : box.min.y;
+					p.z = plane.normal.z > 0 ? box.max.z : box.min.z;
+
+					if ( plane.distanceToPoint( p ) < 0 ) {
+
+						return false;
+
+					}
 
 				}
 
-			}
+				return true;
 
-			return true;
+			};
 
-		},
+		}(),
 
 		containsPoint: function ( point ) {
 
@@ -14294,6 +14341,367 @@ var Spacekit = (function (exports) {
 
 	} );
 
+	var alphamap_fragment = "#ifdef USE_ALPHAMAP\n\tdiffuseColor.a *= texture2D( alphaMap, vUv ).g;\n#endif";
+
+	var alphamap_pars_fragment = "#ifdef USE_ALPHAMAP\n\tuniform sampler2D alphaMap;\n#endif";
+
+	var alphatest_fragment = "#ifdef ALPHATEST\n\tif ( diffuseColor.a < ALPHATEST ) discard;\n#endif";
+
+	var aomap_fragment = "#ifdef USE_AOMAP\n\tfloat ambientOcclusion = ( texture2D( aoMap, vUv2 ).r - 1.0 ) * aoMapIntensity + 1.0;\n\treflectedLight.indirectDiffuse *= ambientOcclusion;\n\t#if defined( USE_ENVMAP ) && defined( PHYSICAL )\n\t\tfloat dotNV = saturate( dot( geometry.normal, geometry.viewDir ) );\n\t\treflectedLight.indirectSpecular *= computeSpecularOcclusion( dotNV, ambientOcclusion, material.specularRoughness );\n\t#endif\n#endif";
+
+	var aomap_pars_fragment = "#ifdef USE_AOMAP\n\tuniform sampler2D aoMap;\n\tuniform float aoMapIntensity;\n#endif";
+
+	var begin_vertex = "vec3 transformed = vec3( position );";
+
+	var beginnormal_vertex = "vec3 objectNormal = vec3( normal );\n#ifdef USE_TANGENT\n\tvec3 objectTangent = vec3( tangent.xyz );\n#endif";
+
+	var bsdfs = "vec2 integrateSpecularBRDF( const in float dotNV, const in float roughness ) {\n\tconst vec4 c0 = vec4( - 1, - 0.0275, - 0.572, 0.022 );\n\tconst vec4 c1 = vec4( 1, 0.0425, 1.04, - 0.04 );\n\tvec4 r = roughness * c0 + c1;\n\tfloat a004 = min( r.x * r.x, exp2( - 9.28 * dotNV ) ) * r.x + r.y;\n\treturn vec2( -1.04, 1.04 ) * a004 + r.zw;\n}\nfloat punctualLightIntensityToIrradianceFactor( const in float lightDistance, const in float cutoffDistance, const in float decayExponent ) {\n#if defined ( PHYSICALLY_CORRECT_LIGHTS )\n\tfloat distanceFalloff = 1.0 / max( pow( lightDistance, decayExponent ), 0.01 );\n\tif( cutoffDistance > 0.0 ) {\n\t\tdistanceFalloff *= pow2( saturate( 1.0 - pow4( lightDistance / cutoffDistance ) ) );\n\t}\n\treturn distanceFalloff;\n#else\n\tif( cutoffDistance > 0.0 && decayExponent > 0.0 ) {\n\t\treturn pow( saturate( -lightDistance / cutoffDistance + 1.0 ), decayExponent );\n\t}\n\treturn 1.0;\n#endif\n}\nvec3 BRDF_Diffuse_Lambert( const in vec3 diffuseColor ) {\n\treturn RECIPROCAL_PI * diffuseColor;\n}\nvec3 F_Schlick( const in vec3 specularColor, const in float dotLH ) {\n\tfloat fresnel = exp2( ( -5.55473 * dotLH - 6.98316 ) * dotLH );\n\treturn ( 1.0 - specularColor ) * fresnel + specularColor;\n}\nvec3 F_Schlick_RoughnessDependent( const in vec3 F0, const in float dotNV, const in float roughness ) {\n\tfloat fresnel = exp2( ( -5.55473 * dotNV - 6.98316 ) * dotNV );\n\tvec3 Fr = max( vec3( 1.0 - roughness ), F0 ) - F0;\n\treturn Fr * fresnel + F0;\n}\nfloat G_GGX_Smith( const in float alpha, const in float dotNL, const in float dotNV ) {\n\tfloat a2 = pow2( alpha );\n\tfloat gl = dotNL + sqrt( a2 + ( 1.0 - a2 ) * pow2( dotNL ) );\n\tfloat gv = dotNV + sqrt( a2 + ( 1.0 - a2 ) * pow2( dotNV ) );\n\treturn 1.0 / ( gl * gv );\n}\nfloat G_GGX_SmithCorrelated( const in float alpha, const in float dotNL, const in float dotNV ) {\n\tfloat a2 = pow2( alpha );\n\tfloat gv = dotNL * sqrt( a2 + ( 1.0 - a2 ) * pow2( dotNV ) );\n\tfloat gl = dotNV * sqrt( a2 + ( 1.0 - a2 ) * pow2( dotNL ) );\n\treturn 0.5 / max( gv + gl, EPSILON );\n}\nfloat D_GGX( const in float alpha, const in float dotNH ) {\n\tfloat a2 = pow2( alpha );\n\tfloat denom = pow2( dotNH ) * ( a2 - 1.0 ) + 1.0;\n\treturn RECIPROCAL_PI * a2 / pow2( denom );\n}\nvec3 BRDF_Specular_GGX( const in IncidentLight incidentLight, const in GeometricContext geometry, const in vec3 specularColor, const in float roughness ) {\n\tfloat alpha = pow2( roughness );\n\tvec3 halfDir = normalize( incidentLight.direction + geometry.viewDir );\n\tfloat dotNL = saturate( dot( geometry.normal, incidentLight.direction ) );\n\tfloat dotNV = saturate( dot( geometry.normal, geometry.viewDir ) );\n\tfloat dotNH = saturate( dot( geometry.normal, halfDir ) );\n\tfloat dotLH = saturate( dot( incidentLight.direction, halfDir ) );\n\tvec3 F = F_Schlick( specularColor, dotLH );\n\tfloat G = G_GGX_SmithCorrelated( alpha, dotNL, dotNV );\n\tfloat D = D_GGX( alpha, dotNH );\n\treturn F * ( G * D );\n}\nvec2 LTC_Uv( const in vec3 N, const in vec3 V, const in float roughness ) {\n\tconst float LUT_SIZE  = 64.0;\n\tconst float LUT_SCALE = ( LUT_SIZE - 1.0 ) / LUT_SIZE;\n\tconst float LUT_BIAS  = 0.5 / LUT_SIZE;\n\tfloat dotNV = saturate( dot( N, V ) );\n\tvec2 uv = vec2( roughness, sqrt( 1.0 - dotNV ) );\n\tuv = uv * LUT_SCALE + LUT_BIAS;\n\treturn uv;\n}\nfloat LTC_ClippedSphereFormFactor( const in vec3 f ) {\n\tfloat l = length( f );\n\treturn max( ( l * l + f.z ) / ( l + 1.0 ), 0.0 );\n}\nvec3 LTC_EdgeVectorFormFactor( const in vec3 v1, const in vec3 v2 ) {\n\tfloat x = dot( v1, v2 );\n\tfloat y = abs( x );\n\tfloat a = 0.8543985 + ( 0.4965155 + 0.0145206 * y ) * y;\n\tfloat b = 3.4175940 + ( 4.1616724 + y ) * y;\n\tfloat v = a / b;\n\tfloat theta_sintheta = ( x > 0.0 ) ? v : 0.5 * inversesqrt( max( 1.0 - x * x, 1e-7 ) ) - v;\n\treturn cross( v1, v2 ) * theta_sintheta;\n}\nvec3 LTC_Evaluate( const in vec3 N, const in vec3 V, const in vec3 P, const in mat3 mInv, const in vec3 rectCoords[ 4 ] ) {\n\tvec3 v1 = rectCoords[ 1 ] - rectCoords[ 0 ];\n\tvec3 v2 = rectCoords[ 3 ] - rectCoords[ 0 ];\n\tvec3 lightNormal = cross( v1, v2 );\n\tif( dot( lightNormal, P - rectCoords[ 0 ] ) < 0.0 ) return vec3( 0.0 );\n\tvec3 T1, T2;\n\tT1 = normalize( V - N * dot( V, N ) );\n\tT2 = - cross( N, T1 );\n\tmat3 mat = mInv * transposeMat3( mat3( T1, T2, N ) );\n\tvec3 coords[ 4 ];\n\tcoords[ 0 ] = mat * ( rectCoords[ 0 ] - P );\n\tcoords[ 1 ] = mat * ( rectCoords[ 1 ] - P );\n\tcoords[ 2 ] = mat * ( rectCoords[ 2 ] - P );\n\tcoords[ 3 ] = mat * ( rectCoords[ 3 ] - P );\n\tcoords[ 0 ] = normalize( coords[ 0 ] );\n\tcoords[ 1 ] = normalize( coords[ 1 ] );\n\tcoords[ 2 ] = normalize( coords[ 2 ] );\n\tcoords[ 3 ] = normalize( coords[ 3 ] );\n\tvec3 vectorFormFactor = vec3( 0.0 );\n\tvectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 0 ], coords[ 1 ] );\n\tvectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 1 ], coords[ 2 ] );\n\tvectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 2 ], coords[ 3 ] );\n\tvectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 3 ], coords[ 0 ] );\n\tfloat result = LTC_ClippedSphereFormFactor( vectorFormFactor );\n\treturn vec3( result );\n}\nvec3 BRDF_Specular_GGX_Environment( const in GeometricContext geometry, const in vec3 specularColor, const in float roughness ) {\n\tfloat dotNV = saturate( dot( geometry.normal, geometry.viewDir ) );\n\tvec2 brdf = integrateSpecularBRDF( dotNV, roughness );\n\treturn specularColor * brdf.x + brdf.y;\n}\nvoid BRDF_Specular_Multiscattering_Environment( const in GeometricContext geometry, const in vec3 specularColor, const in float roughness, inout vec3 singleScatter, inout vec3 multiScatter ) {\n\tfloat dotNV = saturate( dot( geometry.normal, geometry.viewDir ) );\n\tvec3 F = F_Schlick_RoughnessDependent( specularColor, dotNV, roughness );\n\tvec2 brdf = integrateSpecularBRDF( dotNV, roughness );\n\tvec3 FssEss = F * brdf.x + brdf.y;\n\tfloat Ess = brdf.x + brdf.y;\n\tfloat Ems = 1.0 - Ess;\n\tvec3 Favg = specularColor + ( 1.0 - specularColor ) * 0.047619;\tvec3 Fms = FssEss * Favg / ( 1.0 - Ems * Favg );\n\tsingleScatter += FssEss;\n\tmultiScatter += Fms * Ems;\n}\nfloat G_BlinnPhong_Implicit( ) {\n\treturn 0.25;\n}\nfloat D_BlinnPhong( const in float shininess, const in float dotNH ) {\n\treturn RECIPROCAL_PI * ( shininess * 0.5 + 1.0 ) * pow( dotNH, shininess );\n}\nvec3 BRDF_Specular_BlinnPhong( const in IncidentLight incidentLight, const in GeometricContext geometry, const in vec3 specularColor, const in float shininess ) {\n\tvec3 halfDir = normalize( incidentLight.direction + geometry.viewDir );\n\tfloat dotNH = saturate( dot( geometry.normal, halfDir ) );\n\tfloat dotLH = saturate( dot( incidentLight.direction, halfDir ) );\n\tvec3 F = F_Schlick( specularColor, dotLH );\n\tfloat G = G_BlinnPhong_Implicit( );\n\tfloat D = D_BlinnPhong( shininess, dotNH );\n\treturn F * ( G * D );\n}\nfloat GGXRoughnessToBlinnExponent( const in float ggxRoughness ) {\n\treturn ( 2.0 / pow2( ggxRoughness + 0.0001 ) - 2.0 );\n}\nfloat BlinnExponentToGGXRoughness( const in float blinnExponent ) {\n\treturn sqrt( 2.0 / ( blinnExponent + 2.0 ) );\n}";
+
+	var bumpmap_pars_fragment = "#ifdef USE_BUMPMAP\n\tuniform sampler2D bumpMap;\n\tuniform float bumpScale;\n\tvec2 dHdxy_fwd() {\n\t\tvec2 dSTdx = dFdx( vUv );\n\t\tvec2 dSTdy = dFdy( vUv );\n\t\tfloat Hll = bumpScale * texture2D( bumpMap, vUv ).x;\n\t\tfloat dBx = bumpScale * texture2D( bumpMap, vUv + dSTdx ).x - Hll;\n\t\tfloat dBy = bumpScale * texture2D( bumpMap, vUv + dSTdy ).x - Hll;\n\t\treturn vec2( dBx, dBy );\n\t}\n\tvec3 perturbNormalArb( vec3 surf_pos, vec3 surf_norm, vec2 dHdxy ) {\n\t\tvec3 vSigmaX = vec3( dFdx( surf_pos.x ), dFdx( surf_pos.y ), dFdx( surf_pos.z ) );\n\t\tvec3 vSigmaY = vec3( dFdy( surf_pos.x ), dFdy( surf_pos.y ), dFdy( surf_pos.z ) );\n\t\tvec3 vN = surf_norm;\n\t\tvec3 R1 = cross( vSigmaY, vN );\n\t\tvec3 R2 = cross( vN, vSigmaX );\n\t\tfloat fDet = dot( vSigmaX, R1 );\n\t\tfDet *= ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t\tvec3 vGrad = sign( fDet ) * ( dHdxy.x * R1 + dHdxy.y * R2 );\n\t\treturn normalize( abs( fDet ) * surf_norm - vGrad );\n\t}\n#endif";
+
+	var clipping_planes_fragment = "#if NUM_CLIPPING_PLANES > 0\n\tvec4 plane;\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < UNION_CLIPPING_PLANES; i ++ ) {\n\t\tplane = clippingPlanes[ i ];\n\t\tif ( dot( vViewPosition, plane.xyz ) > plane.w ) discard;\n\t}\n\t#if UNION_CLIPPING_PLANES < NUM_CLIPPING_PLANES\n\t\tbool clipped = true;\n\t\t#pragma unroll_loop\n\t\tfor ( int i = UNION_CLIPPING_PLANES; i < NUM_CLIPPING_PLANES; i ++ ) {\n\t\t\tplane = clippingPlanes[ i ];\n\t\t\tclipped = ( dot( vViewPosition, plane.xyz ) > plane.w ) && clipped;\n\t\t}\n\t\tif ( clipped ) discard;\n\t#endif\n#endif";
+
+	var clipping_planes_pars_fragment = "#if NUM_CLIPPING_PLANES > 0\n\t#if ! defined( PHYSICAL ) && ! defined( PHONG ) && ! defined( MATCAP )\n\t\tvarying vec3 vViewPosition;\n\t#endif\n\tuniform vec4 clippingPlanes[ NUM_CLIPPING_PLANES ];\n#endif";
+
+	var clipping_planes_pars_vertex = "#if NUM_CLIPPING_PLANES > 0 && ! defined( PHYSICAL ) && ! defined( PHONG ) && ! defined( MATCAP )\n\tvarying vec3 vViewPosition;\n#endif";
+
+	var clipping_planes_vertex = "#if NUM_CLIPPING_PLANES > 0 && ! defined( PHYSICAL ) && ! defined( PHONG ) && ! defined( MATCAP )\n\tvViewPosition = - mvPosition.xyz;\n#endif";
+
+	var color_fragment = "#ifdef USE_COLOR\n\tdiffuseColor.rgb *= vColor;\n#endif";
+
+	var color_pars_fragment = "#ifdef USE_COLOR\n\tvarying vec3 vColor;\n#endif";
+
+	var color_pars_vertex = "#ifdef USE_COLOR\n\tvarying vec3 vColor;\n#endif";
+
+	var color_vertex = "#ifdef USE_COLOR\n\tvColor.xyz = color.xyz;\n#endif";
+
+	var common = "#define PI 3.14159265359\n#define PI2 6.28318530718\n#define PI_HALF 1.5707963267949\n#define RECIPROCAL_PI 0.31830988618\n#define RECIPROCAL_PI2 0.15915494\n#define LOG2 1.442695\n#define EPSILON 1e-6\n#define saturate(a) clamp( a, 0.0, 1.0 )\n#define whiteCompliment(a) ( 1.0 - saturate( a ) )\nfloat pow2( const in float x ) { return x*x; }\nfloat pow3( const in float x ) { return x*x*x; }\nfloat pow4( const in float x ) { float x2 = x*x; return x2*x2; }\nfloat average( const in vec3 color ) { return dot( color, vec3( 0.3333 ) ); }\nhighp float rand( const in vec2 uv ) {\n\tconst highp float a = 12.9898, b = 78.233, c = 43758.5453;\n\thighp float dt = dot( uv.xy, vec2( a,b ) ), sn = mod( dt, PI );\n\treturn fract(sin(sn) * c);\n}\nstruct IncidentLight {\n\tvec3 color;\n\tvec3 direction;\n\tbool visible;\n};\nstruct ReflectedLight {\n\tvec3 directDiffuse;\n\tvec3 directSpecular;\n\tvec3 indirectDiffuse;\n\tvec3 indirectSpecular;\n};\nstruct GeometricContext {\n\tvec3 position;\n\tvec3 normal;\n\tvec3 viewDir;\n};\nvec3 transformDirection( in vec3 dir, in mat4 matrix ) {\n\treturn normalize( ( matrix * vec4( dir, 0.0 ) ).xyz );\n}\nvec3 inverseTransformDirection( in vec3 dir, in mat4 matrix ) {\n\treturn normalize( ( vec4( dir, 0.0 ) * matrix ).xyz );\n}\nvec3 projectOnPlane(in vec3 point, in vec3 pointOnPlane, in vec3 planeNormal ) {\n\tfloat distance = dot( planeNormal, point - pointOnPlane );\n\treturn - distance * planeNormal + point;\n}\nfloat sideOfPlane( in vec3 point, in vec3 pointOnPlane, in vec3 planeNormal ) {\n\treturn sign( dot( point - pointOnPlane, planeNormal ) );\n}\nvec3 linePlaneIntersect( in vec3 pointOnLine, in vec3 lineDirection, in vec3 pointOnPlane, in vec3 planeNormal ) {\n\treturn lineDirection * ( dot( planeNormal, pointOnPlane - pointOnLine ) / dot( planeNormal, lineDirection ) ) + pointOnLine;\n}\nmat3 transposeMat3( const in mat3 m ) {\n\tmat3 tmp;\n\ttmp[ 0 ] = vec3( m[ 0 ].x, m[ 1 ].x, m[ 2 ].x );\n\ttmp[ 1 ] = vec3( m[ 0 ].y, m[ 1 ].y, m[ 2 ].y );\n\ttmp[ 2 ] = vec3( m[ 0 ].z, m[ 1 ].z, m[ 2 ].z );\n\treturn tmp;\n}\nfloat linearToRelativeLuminance( const in vec3 color ) {\n\tvec3 weights = vec3( 0.2126, 0.7152, 0.0722 );\n\treturn dot( weights, color.rgb );\n}";
+
+	var cube_uv_reflection_fragment = "#ifdef ENVMAP_TYPE_CUBE_UV\n#define cubeUV_textureSize (1024.0)\nint getFaceFromDirection(vec3 direction) {\n\tvec3 absDirection = abs(direction);\n\tint face = -1;\n\tif( absDirection.x > absDirection.z ) {\n\t\tif(absDirection.x > absDirection.y )\n\t\t\tface = direction.x > 0.0 ? 0 : 3;\n\t\telse\n\t\t\tface = direction.y > 0.0 ? 1 : 4;\n\t}\n\telse {\n\t\tif(absDirection.z > absDirection.y )\n\t\t\tface = direction.z > 0.0 ? 2 : 5;\n\t\telse\n\t\t\tface = direction.y > 0.0 ? 1 : 4;\n\t}\n\treturn face;\n}\n#define cubeUV_maxLods1  (log2(cubeUV_textureSize*0.25) - 1.0)\n#define cubeUV_rangeClamp (exp2((6.0 - 1.0) * 2.0))\nvec2 MipLevelInfo( vec3 vec, float roughnessLevel, float roughness ) {\n\tfloat scale = exp2(cubeUV_maxLods1 - roughnessLevel);\n\tfloat dxRoughness = dFdx(roughness);\n\tfloat dyRoughness = dFdy(roughness);\n\tvec3 dx = dFdx( vec * scale * dxRoughness );\n\tvec3 dy = dFdy( vec * scale * dyRoughness );\n\tfloat d = max( dot( dx, dx ), dot( dy, dy ) );\n\td = clamp(d, 1.0, cubeUV_rangeClamp);\n\tfloat mipLevel = 0.5 * log2(d);\n\treturn vec2(floor(mipLevel), fract(mipLevel));\n}\n#define cubeUV_maxLods2 (log2(cubeUV_textureSize*0.25) - 2.0)\n#define cubeUV_rcpTextureSize (1.0 / cubeUV_textureSize)\nvec2 getCubeUV(vec3 direction, float roughnessLevel, float mipLevel) {\n\tmipLevel = roughnessLevel > cubeUV_maxLods2 - 3.0 ? 0.0 : mipLevel;\n\tfloat a = 16.0 * cubeUV_rcpTextureSize;\n\tvec2 exp2_packed = exp2( vec2( roughnessLevel, mipLevel ) );\n\tvec2 rcp_exp2_packed = vec2( 1.0 ) / exp2_packed;\n\tfloat powScale = exp2_packed.x * exp2_packed.y;\n\tfloat scale = rcp_exp2_packed.x * rcp_exp2_packed.y * 0.25;\n\tfloat mipOffset = 0.75*(1.0 - rcp_exp2_packed.y) * rcp_exp2_packed.x;\n\tbool bRes = mipLevel == 0.0;\n\tscale =  bRes && (scale < a) ? a : scale;\n\tvec3 r;\n\tvec2 offset;\n\tint face = getFaceFromDirection(direction);\n\tfloat rcpPowScale = 1.0 / powScale;\n\tif( face == 0) {\n\t\tr = vec3(direction.x, -direction.z, direction.y);\n\t\toffset = vec2(0.0+mipOffset,0.75 * rcpPowScale);\n\t\toffset.y = bRes && (offset.y < 2.0*a) ? a : offset.y;\n\t}\n\telse if( face == 1) {\n\t\tr = vec3(direction.y, direction.x, direction.z);\n\t\toffset = vec2(scale+mipOffset, 0.75 * rcpPowScale);\n\t\toffset.y = bRes && (offset.y < 2.0*a) ? a : offset.y;\n\t}\n\telse if( face == 2) {\n\t\tr = vec3(direction.z, direction.x, direction.y);\n\t\toffset = vec2(2.0*scale+mipOffset, 0.75 * rcpPowScale);\n\t\toffset.y = bRes && (offset.y < 2.0*a) ? a : offset.y;\n\t}\n\telse if( face == 3) {\n\t\tr = vec3(direction.x, direction.z, direction.y);\n\t\toffset = vec2(0.0+mipOffset,0.5 * rcpPowScale);\n\t\toffset.y = bRes && (offset.y < 2.0*a) ? 0.0 : offset.y;\n\t}\n\telse if( face == 4) {\n\t\tr = vec3(direction.y, direction.x, -direction.z);\n\t\toffset = vec2(scale+mipOffset, 0.5 * rcpPowScale);\n\t\toffset.y = bRes && (offset.y < 2.0*a) ? 0.0 : offset.y;\n\t}\n\telse {\n\t\tr = vec3(direction.z, -direction.x, direction.y);\n\t\toffset = vec2(2.0*scale+mipOffset, 0.5 * rcpPowScale);\n\t\toffset.y = bRes && (offset.y < 2.0*a) ? 0.0 : offset.y;\n\t}\n\tr = normalize(r);\n\tfloat texelOffset = 0.5 * cubeUV_rcpTextureSize;\n\tvec2 s = ( r.yz / abs( r.x ) + vec2( 1.0 ) ) * 0.5;\n\tvec2 base = offset + vec2( texelOffset );\n\treturn base + s * ( scale - 2.0 * texelOffset );\n}\n#define cubeUV_maxLods3 (log2(cubeUV_textureSize*0.25) - 3.0)\nvec4 textureCubeUV( sampler2D envMap, vec3 reflectedDirection, float roughness ) {\n\tfloat roughnessVal = roughness* cubeUV_maxLods3;\n\tfloat r1 = floor(roughnessVal);\n\tfloat r2 = r1 + 1.0;\n\tfloat t = fract(roughnessVal);\n\tvec2 mipInfo = MipLevelInfo(reflectedDirection, r1, roughness);\n\tfloat s = mipInfo.y;\n\tfloat level0 = mipInfo.x;\n\tfloat level1 = level0 + 1.0;\n\tlevel1 = level1 > 5.0 ? 5.0 : level1;\n\tlevel0 += min( floor( s + 0.5 ), 5.0 );\n\tvec2 uv_10 = getCubeUV(reflectedDirection, r1, level0);\n\tvec4 color10 = envMapTexelToLinear(texture2D(envMap, uv_10));\n\tvec2 uv_20 = getCubeUV(reflectedDirection, r2, level0);\n\tvec4 color20 = envMapTexelToLinear(texture2D(envMap, uv_20));\n\tvec4 result = mix(color10, color20, t);\n\treturn vec4(result.rgb, 1.0);\n}\n#endif";
+
+	var defaultnormal_vertex = "vec3 transformedNormal = normalMatrix * objectNormal;\n#ifdef FLIP_SIDED\n\ttransformedNormal = - transformedNormal;\n#endif\n#ifdef USE_TANGENT\n\tvec3 transformedTangent = normalMatrix * objectTangent;\n\t#ifdef FLIP_SIDED\n\t\ttransformedTangent = - transformedTangent;\n\t#endif\n#endif";
+
+	var displacementmap_pars_vertex = "#ifdef USE_DISPLACEMENTMAP\n\tuniform sampler2D displacementMap;\n\tuniform float displacementScale;\n\tuniform float displacementBias;\n#endif";
+
+	var displacementmap_vertex = "#ifdef USE_DISPLACEMENTMAP\n\ttransformed += normalize( objectNormal ) * ( texture2D( displacementMap, uv ).x * displacementScale + displacementBias );\n#endif";
+
+	var emissivemap_fragment = "#ifdef USE_EMISSIVEMAP\n\tvec4 emissiveColor = texture2D( emissiveMap, vUv );\n\temissiveColor.rgb = emissiveMapTexelToLinear( emissiveColor ).rgb;\n\ttotalEmissiveRadiance *= emissiveColor.rgb;\n#endif";
+
+	var emissivemap_pars_fragment = "#ifdef USE_EMISSIVEMAP\n\tuniform sampler2D emissiveMap;\n#endif";
+
+	var encodings_fragment = "gl_FragColor = linearToOutputTexel( gl_FragColor );";
+
+	var encodings_pars_fragment = "\nvec4 LinearToLinear( in vec4 value ) {\n\treturn value;\n}\nvec4 GammaToLinear( in vec4 value, in float gammaFactor ) {\n\treturn vec4( pow( value.rgb, vec3( gammaFactor ) ), value.a );\n}\nvec4 LinearToGamma( in vec4 value, in float gammaFactor ) {\n\treturn vec4( pow( value.rgb, vec3( 1.0 / gammaFactor ) ), value.a );\n}\nvec4 sRGBToLinear( in vec4 value ) {\n\treturn vec4( mix( pow( value.rgb * 0.9478672986 + vec3( 0.0521327014 ), vec3( 2.4 ) ), value.rgb * 0.0773993808, vec3( lessThanEqual( value.rgb, vec3( 0.04045 ) ) ) ), value.a );\n}\nvec4 LinearTosRGB( in vec4 value ) {\n\treturn vec4( mix( pow( value.rgb, vec3( 0.41666 ) ) * 1.055 - vec3( 0.055 ), value.rgb * 12.92, vec3( lessThanEqual( value.rgb, vec3( 0.0031308 ) ) ) ), value.a );\n}\nvec4 RGBEToLinear( in vec4 value ) {\n\treturn vec4( value.rgb * exp2( value.a * 255.0 - 128.0 ), 1.0 );\n}\nvec4 LinearToRGBE( in vec4 value ) {\n\tfloat maxComponent = max( max( value.r, value.g ), value.b );\n\tfloat fExp = clamp( ceil( log2( maxComponent ) ), -128.0, 127.0 );\n\treturn vec4( value.rgb / exp2( fExp ), ( fExp + 128.0 ) / 255.0 );\n}\nvec4 RGBMToLinear( in vec4 value, in float maxRange ) {\n\treturn vec4( value.rgb * value.a * maxRange, 1.0 );\n}\nvec4 LinearToRGBM( in vec4 value, in float maxRange ) {\n\tfloat maxRGB = max( value.r, max( value.g, value.b ) );\n\tfloat M = clamp( maxRGB / maxRange, 0.0, 1.0 );\n\tM = ceil( M * 255.0 ) / 255.0;\n\treturn vec4( value.rgb / ( M * maxRange ), M );\n}\nvec4 RGBDToLinear( in vec4 value, in float maxRange ) {\n\treturn vec4( value.rgb * ( ( maxRange / 255.0 ) / value.a ), 1.0 );\n}\nvec4 LinearToRGBD( in vec4 value, in float maxRange ) {\n\tfloat maxRGB = max( value.r, max( value.g, value.b ) );\n\tfloat D = max( maxRange / maxRGB, 1.0 );\n\tD = min( floor( D ) / 255.0, 1.0 );\n\treturn vec4( value.rgb * ( D * ( 255.0 / maxRange ) ), D );\n}\nconst mat3 cLogLuvM = mat3( 0.2209, 0.3390, 0.4184, 0.1138, 0.6780, 0.7319, 0.0102, 0.1130, 0.2969 );\nvec4 LinearToLogLuv( in vec4 value )  {\n\tvec3 Xp_Y_XYZp = cLogLuvM * value.rgb;\n\tXp_Y_XYZp = max( Xp_Y_XYZp, vec3( 1e-6, 1e-6, 1e-6 ) );\n\tvec4 vResult;\n\tvResult.xy = Xp_Y_XYZp.xy / Xp_Y_XYZp.z;\n\tfloat Le = 2.0 * log2(Xp_Y_XYZp.y) + 127.0;\n\tvResult.w = fract( Le );\n\tvResult.z = ( Le - ( floor( vResult.w * 255.0 ) ) / 255.0 ) / 255.0;\n\treturn vResult;\n}\nconst mat3 cLogLuvInverseM = mat3( 6.0014, -2.7008, -1.7996, -1.3320, 3.1029, -5.7721, 0.3008, -1.0882, 5.6268 );\nvec4 LogLuvToLinear( in vec4 value ) {\n\tfloat Le = value.z * 255.0 + value.w;\n\tvec3 Xp_Y_XYZp;\n\tXp_Y_XYZp.y = exp2( ( Le - 127.0 ) / 2.0 );\n\tXp_Y_XYZp.z = Xp_Y_XYZp.y / value.y;\n\tXp_Y_XYZp.x = value.x * Xp_Y_XYZp.z;\n\tvec3 vRGB = cLogLuvInverseM * Xp_Y_XYZp.rgb;\n\treturn vec4( max( vRGB, 0.0 ), 1.0 );\n}";
+
+	var envmap_fragment = "#ifdef USE_ENVMAP\n\t#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG )\n\t\tvec3 cameraToVertex = normalize( vWorldPosition - cameraPosition );\n\t\tvec3 worldNormal = inverseTransformDirection( normal, viewMatrix );\n\t\t#ifdef ENVMAP_MODE_REFLECTION\n\t\t\tvec3 reflectVec = reflect( cameraToVertex, worldNormal );\n\t\t#else\n\t\t\tvec3 reflectVec = refract( cameraToVertex, worldNormal, refractionRatio );\n\t\t#endif\n\t#else\n\t\tvec3 reflectVec = vReflect;\n\t#endif\n\t#ifdef ENVMAP_TYPE_CUBE\n\t\tvec4 envColor = textureCube( envMap, vec3( flipEnvMap * reflectVec.x, reflectVec.yz ) );\n\t#elif defined( ENVMAP_TYPE_EQUIREC )\n\t\tvec2 sampleUV;\n\t\treflectVec = normalize( reflectVec );\n\t\tsampleUV.y = asin( clamp( reflectVec.y, - 1.0, 1.0 ) ) * RECIPROCAL_PI + 0.5;\n\t\tsampleUV.x = atan( reflectVec.z, reflectVec.x ) * RECIPROCAL_PI2 + 0.5;\n\t\tvec4 envColor = texture2D( envMap, sampleUV );\n\t#elif defined( ENVMAP_TYPE_SPHERE )\n\t\treflectVec = normalize( reflectVec );\n\t\tvec3 reflectView = normalize( ( viewMatrix * vec4( reflectVec, 0.0 ) ).xyz + vec3( 0.0, 0.0, 1.0 ) );\n\t\tvec4 envColor = texture2D( envMap, reflectView.xy * 0.5 + 0.5 );\n\t#else\n\t\tvec4 envColor = vec4( 0.0 );\n\t#endif\n\tenvColor = envMapTexelToLinear( envColor );\n\t#ifdef ENVMAP_BLENDING_MULTIPLY\n\t\toutgoingLight = mix( outgoingLight, outgoingLight * envColor.xyz, specularStrength * reflectivity );\n\t#elif defined( ENVMAP_BLENDING_MIX )\n\t\toutgoingLight = mix( outgoingLight, envColor.xyz, specularStrength * reflectivity );\n\t#elif defined( ENVMAP_BLENDING_ADD )\n\t\toutgoingLight += envColor.xyz * specularStrength * reflectivity;\n\t#endif\n#endif";
+
+	var envmap_pars_fragment = "#if defined( USE_ENVMAP ) || defined( PHYSICAL )\n\tuniform float reflectivity;\n\tuniform float envMapIntensity;\n#endif\n#ifdef USE_ENVMAP\n\t#if ! defined( PHYSICAL ) && ( defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG ) )\n\t\tvarying vec3 vWorldPosition;\n\t#endif\n\t#ifdef ENVMAP_TYPE_CUBE\n\t\tuniform samplerCube envMap;\n\t#else\n\t\tuniform sampler2D envMap;\n\t#endif\n\tuniform float flipEnvMap;\n\tuniform int maxMipLevel;\n\t#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG ) || defined( PHYSICAL )\n\t\tuniform float refractionRatio;\n\t#else\n\t\tvarying vec3 vReflect;\n\t#endif\n#endif";
+
+	var envmap_pars_vertex = "#ifdef USE_ENVMAP\n\t#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG )\n\t\tvarying vec3 vWorldPosition;\n\t#else\n\t\tvarying vec3 vReflect;\n\t\tuniform float refractionRatio;\n\t#endif\n#endif";
+
+	var envmap_vertex = "#ifdef USE_ENVMAP\n\t#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG )\n\t\tvWorldPosition = worldPosition.xyz;\n\t#else\n\t\tvec3 cameraToVertex = normalize( worldPosition.xyz - cameraPosition );\n\t\tvec3 worldNormal = inverseTransformDirection( transformedNormal, viewMatrix );\n\t\t#ifdef ENVMAP_MODE_REFLECTION\n\t\t\tvReflect = reflect( cameraToVertex, worldNormal );\n\t\t#else\n\t\t\tvReflect = refract( cameraToVertex, worldNormal, refractionRatio );\n\t\t#endif\n\t#endif\n#endif";
+
+	var fog_vertex = "#ifdef USE_FOG\n\tfogDepth = -mvPosition.z;\n#endif";
+
+	var fog_pars_vertex = "#ifdef USE_FOG\n\tvarying float fogDepth;\n#endif";
+
+	var fog_fragment = "#ifdef USE_FOG\n\t#ifdef FOG_EXP2\n\t\tfloat fogFactor = whiteCompliment( exp2( - fogDensity * fogDensity * fogDepth * fogDepth * LOG2 ) );\n\t#else\n\t\tfloat fogFactor = smoothstep( fogNear, fogFar, fogDepth );\n\t#endif\n\tgl_FragColor.rgb = mix( gl_FragColor.rgb, fogColor, fogFactor );\n#endif";
+
+	var fog_pars_fragment = "#ifdef USE_FOG\n\tuniform vec3 fogColor;\n\tvarying float fogDepth;\n\t#ifdef FOG_EXP2\n\t\tuniform float fogDensity;\n\t#else\n\t\tuniform float fogNear;\n\t\tuniform float fogFar;\n\t#endif\n#endif";
+
+	var gradientmap_pars_fragment = "#ifdef TOON\n\tuniform sampler2D gradientMap;\n\tvec3 getGradientIrradiance( vec3 normal, vec3 lightDirection ) {\n\t\tfloat dotNL = dot( normal, lightDirection );\n\t\tvec2 coord = vec2( dotNL * 0.5 + 0.5, 0.0 );\n\t\t#ifdef USE_GRADIENTMAP\n\t\t\treturn texture2D( gradientMap, coord ).rgb;\n\t\t#else\n\t\t\treturn ( coord.x < 0.7 ) ? vec3( 0.7 ) : vec3( 1.0 );\n\t\t#endif\n\t}\n#endif";
+
+	var lightmap_fragment = "#ifdef USE_LIGHTMAP\n\treflectedLight.indirectDiffuse += PI * texture2D( lightMap, vUv2 ).xyz * lightMapIntensity;\n#endif";
+
+	var lightmap_pars_fragment = "#ifdef USE_LIGHTMAP\n\tuniform sampler2D lightMap;\n\tuniform float lightMapIntensity;\n#endif";
+
+	var lights_lambert_vertex = "vec3 diffuse = vec3( 1.0 );\nGeometricContext geometry;\ngeometry.position = mvPosition.xyz;\ngeometry.normal = normalize( transformedNormal );\ngeometry.viewDir = normalize( -mvPosition.xyz );\nGeometricContext backGeometry;\nbackGeometry.position = geometry.position;\nbackGeometry.normal = -geometry.normal;\nbackGeometry.viewDir = geometry.viewDir;\nvLightFront = vec3( 0.0 );\nvIndirectFront = vec3( 0.0 );\n#ifdef DOUBLE_SIDED\n\tvLightBack = vec3( 0.0 );\n\tvIndirectBack = vec3( 0.0 );\n#endif\nIncidentLight directLight;\nfloat dotNL;\nvec3 directLightColor_Diffuse;\n#if NUM_POINT_LIGHTS > 0\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {\n\t\tgetPointDirectLightIrradiance( pointLights[ i ], geometry, directLight );\n\t\tdotNL = dot( geometry.normal, directLight.direction );\n\t\tdirectLightColor_Diffuse = PI * directLight.color;\n\t\tvLightFront += saturate( dotNL ) * directLightColor_Diffuse;\n\t\t#ifdef DOUBLE_SIDED\n\t\t\tvLightBack += saturate( -dotNL ) * directLightColor_Diffuse;\n\t\t#endif\n\t}\n#endif\n#if NUM_SPOT_LIGHTS > 0\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {\n\t\tgetSpotDirectLightIrradiance( spotLights[ i ], geometry, directLight );\n\t\tdotNL = dot( geometry.normal, directLight.direction );\n\t\tdirectLightColor_Diffuse = PI * directLight.color;\n\t\tvLightFront += saturate( dotNL ) * directLightColor_Diffuse;\n\t\t#ifdef DOUBLE_SIDED\n\t\t\tvLightBack += saturate( -dotNL ) * directLightColor_Diffuse;\n\t\t#endif\n\t}\n#endif\n#if NUM_DIR_LIGHTS > 0\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {\n\t\tgetDirectionalDirectLightIrradiance( directionalLights[ i ], geometry, directLight );\n\t\tdotNL = dot( geometry.normal, directLight.direction );\n\t\tdirectLightColor_Diffuse = PI * directLight.color;\n\t\tvLightFront += saturate( dotNL ) * directLightColor_Diffuse;\n\t\t#ifdef DOUBLE_SIDED\n\t\t\tvLightBack += saturate( -dotNL ) * directLightColor_Diffuse;\n\t\t#endif\n\t}\n#endif\n#if NUM_HEMI_LIGHTS > 0\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {\n\t\tvIndirectFront += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );\n\t\t#ifdef DOUBLE_SIDED\n\t\t\tvIndirectBack += getHemisphereLightIrradiance( hemisphereLights[ i ], backGeometry );\n\t\t#endif\n\t}\n#endif";
+
+	var lights_pars_begin = "uniform vec3 ambientLightColor;\nuniform vec3 lightProbe[ 9 ];\nvec3 shGetIrradianceAt( in vec3 normal, in vec3 shCoefficients[ 9 ] ) {\n\tfloat x = normal.x, y = normal.y, z = normal.z;\n\tvec3 result = shCoefficients[ 0 ] * 0.886227;\n\tresult += shCoefficients[ 1 ] * 2.0 * 0.511664 * y;\n\tresult += shCoefficients[ 2 ] * 2.0 * 0.511664 * z;\n\tresult += shCoefficients[ 3 ] * 2.0 * 0.511664 * x;\n\tresult += shCoefficients[ 4 ] * 2.0 * 0.429043 * x * y;\n\tresult += shCoefficients[ 5 ] * 2.0 * 0.429043 * y * z;\n\tresult += shCoefficients[ 6 ] * ( 0.743125 * z * z - 0.247708 );\n\tresult += shCoefficients[ 7 ] * 2.0 * 0.429043 * x * z;\n\tresult += shCoefficients[ 8 ] * 0.429043 * ( x * x - y * y );\n\treturn result;\n}\nvec3 getLightProbeIrradiance( const in vec3 lightProbe[ 9 ], const in GeometricContext geometry ) {\n\tvec3 worldNormal = inverseTransformDirection( geometry.normal, viewMatrix );\n\tvec3 irradiance = shGetIrradianceAt( worldNormal, lightProbe );\n\treturn irradiance;\n}\nvec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {\n\tvec3 irradiance = ambientLightColor;\n\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\tirradiance *= PI;\n\t#endif\n\treturn irradiance;\n}\n#if NUM_DIR_LIGHTS > 0\n\tstruct DirectionalLight {\n\t\tvec3 direction;\n\t\tvec3 color;\n\t\tint shadow;\n\t\tfloat shadowBias;\n\t\tfloat shadowRadius;\n\t\tvec2 shadowMapSize;\n\t};\n\tuniform DirectionalLight directionalLights[ NUM_DIR_LIGHTS ];\n\tvoid getDirectionalDirectLightIrradiance( const in DirectionalLight directionalLight, const in GeometricContext geometry, out IncidentLight directLight ) {\n\t\tdirectLight.color = directionalLight.color;\n\t\tdirectLight.direction = directionalLight.direction;\n\t\tdirectLight.visible = true;\n\t}\n#endif\n#if NUM_POINT_LIGHTS > 0\n\tstruct PointLight {\n\t\tvec3 position;\n\t\tvec3 color;\n\t\tfloat distance;\n\t\tfloat decay;\n\t\tint shadow;\n\t\tfloat shadowBias;\n\t\tfloat shadowRadius;\n\t\tvec2 shadowMapSize;\n\t\tfloat shadowCameraNear;\n\t\tfloat shadowCameraFar;\n\t};\n\tuniform PointLight pointLights[ NUM_POINT_LIGHTS ];\n\tvoid getPointDirectLightIrradiance( const in PointLight pointLight, const in GeometricContext geometry, out IncidentLight directLight ) {\n\t\tvec3 lVector = pointLight.position - geometry.position;\n\t\tdirectLight.direction = normalize( lVector );\n\t\tfloat lightDistance = length( lVector );\n\t\tdirectLight.color = pointLight.color;\n\t\tdirectLight.color *= punctualLightIntensityToIrradianceFactor( lightDistance, pointLight.distance, pointLight.decay );\n\t\tdirectLight.visible = ( directLight.color != vec3( 0.0 ) );\n\t}\n#endif\n#if NUM_SPOT_LIGHTS > 0\n\tstruct SpotLight {\n\t\tvec3 position;\n\t\tvec3 direction;\n\t\tvec3 color;\n\t\tfloat distance;\n\t\tfloat decay;\n\t\tfloat coneCos;\n\t\tfloat penumbraCos;\n\t\tint shadow;\n\t\tfloat shadowBias;\n\t\tfloat shadowRadius;\n\t\tvec2 shadowMapSize;\n\t};\n\tuniform SpotLight spotLights[ NUM_SPOT_LIGHTS ];\n\tvoid getSpotDirectLightIrradiance( const in SpotLight spotLight, const in GeometricContext geometry, out IncidentLight directLight  ) {\n\t\tvec3 lVector = spotLight.position - geometry.position;\n\t\tdirectLight.direction = normalize( lVector );\n\t\tfloat lightDistance = length( lVector );\n\t\tfloat angleCos = dot( directLight.direction, spotLight.direction );\n\t\tif ( angleCos > spotLight.coneCos ) {\n\t\t\tfloat spotEffect = smoothstep( spotLight.coneCos, spotLight.penumbraCos, angleCos );\n\t\t\tdirectLight.color = spotLight.color;\n\t\t\tdirectLight.color *= spotEffect * punctualLightIntensityToIrradianceFactor( lightDistance, spotLight.distance, spotLight.decay );\n\t\t\tdirectLight.visible = true;\n\t\t} else {\n\t\t\tdirectLight.color = vec3( 0.0 );\n\t\t\tdirectLight.visible = false;\n\t\t}\n\t}\n#endif\n#if NUM_RECT_AREA_LIGHTS > 0\n\tstruct RectAreaLight {\n\t\tvec3 color;\n\t\tvec3 position;\n\t\tvec3 halfWidth;\n\t\tvec3 halfHeight;\n\t};\n\tuniform sampler2D ltc_1;\tuniform sampler2D ltc_2;\n\tuniform RectAreaLight rectAreaLights[ NUM_RECT_AREA_LIGHTS ];\n#endif\n#if NUM_HEMI_LIGHTS > 0\n\tstruct HemisphereLight {\n\t\tvec3 direction;\n\t\tvec3 skyColor;\n\t\tvec3 groundColor;\n\t};\n\tuniform HemisphereLight hemisphereLights[ NUM_HEMI_LIGHTS ];\n\tvec3 getHemisphereLightIrradiance( const in HemisphereLight hemiLight, const in GeometricContext geometry ) {\n\t\tfloat dotNL = dot( geometry.normal, hemiLight.direction );\n\t\tfloat hemiDiffuseWeight = 0.5 * dotNL + 0.5;\n\t\tvec3 irradiance = mix( hemiLight.groundColor, hemiLight.skyColor, hemiDiffuseWeight );\n\t\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\t\tirradiance *= PI;\n\t\t#endif\n\t\treturn irradiance;\n\t}\n#endif";
+
+	var envmap_physical_pars_fragment = "#if defined( USE_ENVMAP ) && defined( PHYSICAL )\n\tvec3 getLightProbeIndirectIrradiance( const in GeometricContext geometry, const in int maxMIPLevel ) {\n\t\tvec3 worldNormal = inverseTransformDirection( geometry.normal, viewMatrix );\n\t\t#ifdef ENVMAP_TYPE_CUBE\n\t\t\tvec3 queryVec = vec3( flipEnvMap * worldNormal.x, worldNormal.yz );\n\t\t\t#ifdef TEXTURE_LOD_EXT\n\t\t\t\tvec4 envMapColor = textureCubeLodEXT( envMap, queryVec, float( maxMIPLevel ) );\n\t\t\t#else\n\t\t\t\tvec4 envMapColor = textureCube( envMap, queryVec, float( maxMIPLevel ) );\n\t\t\t#endif\n\t\t\tenvMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;\n\t\t#elif defined( ENVMAP_TYPE_CUBE_UV )\n\t\t\tvec3 queryVec = vec3( flipEnvMap * worldNormal.x, worldNormal.yz );\n\t\t\tvec4 envMapColor = textureCubeUV( envMap, queryVec, 1.0 );\n\t\t#else\n\t\t\tvec4 envMapColor = vec4( 0.0 );\n\t\t#endif\n\t\treturn PI * envMapColor.rgb * envMapIntensity;\n\t}\n\tfloat getSpecularMIPLevel( const in float blinnShininessExponent, const in int maxMIPLevel ) {\n\t\tfloat maxMIPLevelScalar = float( maxMIPLevel );\n\t\tfloat desiredMIPLevel = maxMIPLevelScalar + 0.79248 - 0.5 * log2( pow2( blinnShininessExponent ) + 1.0 );\n\t\treturn clamp( desiredMIPLevel, 0.0, maxMIPLevelScalar );\n\t}\n\tvec3 getLightProbeIndirectRadiance( const in GeometricContext geometry, const in float blinnShininessExponent, const in int maxMIPLevel ) {\n\t\t#ifdef ENVMAP_MODE_REFLECTION\n\t\t\tvec3 reflectVec = reflect( -geometry.viewDir, geometry.normal );\n\t\t#else\n\t\t\tvec3 reflectVec = refract( -geometry.viewDir, geometry.normal, refractionRatio );\n\t\t#endif\n\t\treflectVec = inverseTransformDirection( reflectVec, viewMatrix );\n\t\tfloat specularMIPLevel = getSpecularMIPLevel( blinnShininessExponent, maxMIPLevel );\n\t\t#ifdef ENVMAP_TYPE_CUBE\n\t\t\tvec3 queryReflectVec = vec3( flipEnvMap * reflectVec.x, reflectVec.yz );\n\t\t\t#ifdef TEXTURE_LOD_EXT\n\t\t\t\tvec4 envMapColor = textureCubeLodEXT( envMap, queryReflectVec, specularMIPLevel );\n\t\t\t#else\n\t\t\t\tvec4 envMapColor = textureCube( envMap, queryReflectVec, specularMIPLevel );\n\t\t\t#endif\n\t\t\tenvMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;\n\t\t#elif defined( ENVMAP_TYPE_CUBE_UV )\n\t\t\tvec3 queryReflectVec = vec3( flipEnvMap * reflectVec.x, reflectVec.yz );\n\t\t\tvec4 envMapColor = textureCubeUV( envMap, queryReflectVec, BlinnExponentToGGXRoughness(blinnShininessExponent ));\n\t\t#elif defined( ENVMAP_TYPE_EQUIREC )\n\t\t\tvec2 sampleUV;\n\t\t\tsampleUV.y = asin( clamp( reflectVec.y, - 1.0, 1.0 ) ) * RECIPROCAL_PI + 0.5;\n\t\t\tsampleUV.x = atan( reflectVec.z, reflectVec.x ) * RECIPROCAL_PI2 + 0.5;\n\t\t\t#ifdef TEXTURE_LOD_EXT\n\t\t\t\tvec4 envMapColor = texture2DLodEXT( envMap, sampleUV, specularMIPLevel );\n\t\t\t#else\n\t\t\t\tvec4 envMapColor = texture2D( envMap, sampleUV, specularMIPLevel );\n\t\t\t#endif\n\t\t\tenvMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;\n\t\t#elif defined( ENVMAP_TYPE_SPHERE )\n\t\t\tvec3 reflectView = normalize( ( viewMatrix * vec4( reflectVec, 0.0 ) ).xyz + vec3( 0.0,0.0,1.0 ) );\n\t\t\t#ifdef TEXTURE_LOD_EXT\n\t\t\t\tvec4 envMapColor = texture2DLodEXT( envMap, reflectView.xy * 0.5 + 0.5, specularMIPLevel );\n\t\t\t#else\n\t\t\t\tvec4 envMapColor = texture2D( envMap, reflectView.xy * 0.5 + 0.5, specularMIPLevel );\n\t\t\t#endif\n\t\t\tenvMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;\n\t\t#endif\n\t\treturn envMapColor.rgb * envMapIntensity;\n\t}\n#endif";
+
+	var lights_phong_fragment = "BlinnPhongMaterial material;\nmaterial.diffuseColor = diffuseColor.rgb;\nmaterial.specularColor = specular;\nmaterial.specularShininess = shininess;\nmaterial.specularStrength = specularStrength;";
+
+	var lights_phong_pars_fragment = "varying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\nstruct BlinnPhongMaterial {\n\tvec3\tdiffuseColor;\n\tvec3\tspecularColor;\n\tfloat\tspecularShininess;\n\tfloat\tspecularStrength;\n};\nvoid RE_Direct_BlinnPhong( const in IncidentLight directLight, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {\n\t#ifdef TOON\n\t\tvec3 irradiance = getGradientIrradiance( geometry.normal, directLight.direction ) * directLight.color;\n\t#else\n\t\tfloat dotNL = saturate( dot( geometry.normal, directLight.direction ) );\n\t\tvec3 irradiance = dotNL * directLight.color;\n\t#endif\n\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\tirradiance *= PI;\n\t#endif\n\treflectedLight.directDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );\n\treflectedLight.directSpecular += irradiance * BRDF_Specular_BlinnPhong( directLight, geometry, material.specularColor, material.specularShininess ) * material.specularStrength;\n}\nvoid RE_IndirectDiffuse_BlinnPhong( const in vec3 irradiance, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {\n\treflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );\n}\n#define RE_Direct\t\t\t\tRE_Direct_BlinnPhong\n#define RE_IndirectDiffuse\t\tRE_IndirectDiffuse_BlinnPhong\n#define Material_LightProbeLOD( material )\t(0)";
+
+	var lights_physical_fragment = "PhysicalMaterial material;\nmaterial.diffuseColor = diffuseColor.rgb * ( 1.0 - metalnessFactor );\nmaterial.specularRoughness = clamp( roughnessFactor, 0.04, 1.0 );\n#ifdef STANDARD\n\tmaterial.specularColor = mix( vec3( DEFAULT_SPECULAR_COEFFICIENT ), diffuseColor.rgb, metalnessFactor );\n#else\n\tmaterial.specularColor = mix( vec3( MAXIMUM_SPECULAR_COEFFICIENT * pow2( reflectivity ) ), diffuseColor.rgb, metalnessFactor );\n\tmaterial.clearCoat = saturate( clearCoat );\tmaterial.clearCoatRoughness = clamp( clearCoatRoughness, 0.04, 1.0 );\n#endif";
+
+	var lights_physical_pars_fragment = "struct PhysicalMaterial {\n\tvec3\tdiffuseColor;\n\tfloat\tspecularRoughness;\n\tvec3\tspecularColor;\n\t#ifndef STANDARD\n\t\tfloat clearCoat;\n\t\tfloat clearCoatRoughness;\n\t#endif\n};\n#define MAXIMUM_SPECULAR_COEFFICIENT 0.16\n#define DEFAULT_SPECULAR_COEFFICIENT 0.04\nfloat clearCoatDHRApprox( const in float roughness, const in float dotNL ) {\n\treturn DEFAULT_SPECULAR_COEFFICIENT + ( 1.0 - DEFAULT_SPECULAR_COEFFICIENT ) * ( pow( 1.0 - dotNL, 5.0 ) * pow( 1.0 - roughness, 2.0 ) );\n}\n#if NUM_RECT_AREA_LIGHTS > 0\n\tvoid RE_Direct_RectArea_Physical( const in RectAreaLight rectAreaLight, const in GeometricContext geometry, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {\n\t\tvec3 normal = geometry.normal;\n\t\tvec3 viewDir = geometry.viewDir;\n\t\tvec3 position = geometry.position;\n\t\tvec3 lightPos = rectAreaLight.position;\n\t\tvec3 halfWidth = rectAreaLight.halfWidth;\n\t\tvec3 halfHeight = rectAreaLight.halfHeight;\n\t\tvec3 lightColor = rectAreaLight.color;\n\t\tfloat roughness = material.specularRoughness;\n\t\tvec3 rectCoords[ 4 ];\n\t\trectCoords[ 0 ] = lightPos + halfWidth - halfHeight;\t\trectCoords[ 1 ] = lightPos - halfWidth - halfHeight;\n\t\trectCoords[ 2 ] = lightPos - halfWidth + halfHeight;\n\t\trectCoords[ 3 ] = lightPos + halfWidth + halfHeight;\n\t\tvec2 uv = LTC_Uv( normal, viewDir, roughness );\n\t\tvec4 t1 = texture2D( ltc_1, uv );\n\t\tvec4 t2 = texture2D( ltc_2, uv );\n\t\tmat3 mInv = mat3(\n\t\t\tvec3( t1.x, 0, t1.y ),\n\t\t\tvec3(    0, 1,    0 ),\n\t\t\tvec3( t1.z, 0, t1.w )\n\t\t);\n\t\tvec3 fresnel = ( material.specularColor * t2.x + ( vec3( 1.0 ) - material.specularColor ) * t2.y );\n\t\treflectedLight.directSpecular += lightColor * fresnel * LTC_Evaluate( normal, viewDir, position, mInv, rectCoords );\n\t\treflectedLight.directDiffuse += lightColor * material.diffuseColor * LTC_Evaluate( normal, viewDir, position, mat3( 1.0 ), rectCoords );\n\t}\n#endif\nvoid RE_Direct_Physical( const in IncidentLight directLight, const in GeometricContext geometry, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {\n\tfloat dotNL = saturate( dot( geometry.normal, directLight.direction ) );\n\tvec3 irradiance = dotNL * directLight.color;\n\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\tirradiance *= PI;\n\t#endif\n\t#ifndef STANDARD\n\t\tfloat clearCoatDHR = material.clearCoat * clearCoatDHRApprox( material.clearCoatRoughness, dotNL );\n\t#else\n\t\tfloat clearCoatDHR = 0.0;\n\t#endif\n\treflectedLight.directSpecular += ( 1.0 - clearCoatDHR ) * irradiance * BRDF_Specular_GGX( directLight, geometry, material.specularColor, material.specularRoughness );\n\treflectedLight.directDiffuse += ( 1.0 - clearCoatDHR ) * irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );\n\t#ifndef STANDARD\n\t\treflectedLight.directSpecular += irradiance * material.clearCoat * BRDF_Specular_GGX( directLight, geometry, vec3( DEFAULT_SPECULAR_COEFFICIENT ), material.clearCoatRoughness );\n\t#endif\n}\nvoid RE_IndirectDiffuse_Physical( const in vec3 irradiance, const in GeometricContext geometry, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {\n\t#ifndef ENVMAP_TYPE_CUBE_UV\n\t\treflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );\n\t#endif\n}\nvoid RE_IndirectSpecular_Physical( const in vec3 radiance, const in vec3 irradiance, const in vec3 clearCoatRadiance, const in GeometricContext geometry, const in PhysicalMaterial material, inout ReflectedLight reflectedLight) {\n\t#ifndef STANDARD\n\t\tfloat dotNV = saturate( dot( geometry.normal, geometry.viewDir ) );\n\t\tfloat dotNL = dotNV;\n\t\tfloat clearCoatDHR = material.clearCoat * clearCoatDHRApprox( material.clearCoatRoughness, dotNL );\n\t#else\n\t\tfloat clearCoatDHR = 0.0;\n\t#endif\n\tfloat clearCoatInv = 1.0 - clearCoatDHR;\n\t#if defined( ENVMAP_TYPE_CUBE_UV )\n\t\tvec3 singleScattering = vec3( 0.0 );\n\t\tvec3 multiScattering = vec3( 0.0 );\n\t\tvec3 cosineWeightedIrradiance = irradiance * RECIPROCAL_PI;\n\t\tBRDF_Specular_Multiscattering_Environment( geometry, material.specularColor, material.specularRoughness, singleScattering, multiScattering );\n\t\tvec3 diffuse = material.diffuseColor * ( 1.0 - ( singleScattering + multiScattering ) );\n\t\treflectedLight.indirectSpecular += clearCoatInv * radiance * singleScattering;\n\t\treflectedLight.indirectDiffuse += multiScattering * cosineWeightedIrradiance;\n\t\treflectedLight.indirectDiffuse += diffuse * cosineWeightedIrradiance;\n\t#else\n\t\treflectedLight.indirectSpecular += clearCoatInv * radiance * BRDF_Specular_GGX_Environment( geometry, material.specularColor, material.specularRoughness );\n\t#endif\n\t#ifndef STANDARD\n\t\treflectedLight.indirectSpecular += clearCoatRadiance * material.clearCoat * BRDF_Specular_GGX_Environment( geometry, vec3( DEFAULT_SPECULAR_COEFFICIENT ), material.clearCoatRoughness );\n\t#endif\n}\n#define RE_Direct\t\t\t\tRE_Direct_Physical\n#define RE_Direct_RectArea\t\tRE_Direct_RectArea_Physical\n#define RE_IndirectDiffuse\t\tRE_IndirectDiffuse_Physical\n#define RE_IndirectSpecular\t\tRE_IndirectSpecular_Physical\n#define Material_BlinnShininessExponent( material )   GGXRoughnessToBlinnExponent( material.specularRoughness )\n#define Material_ClearCoat_BlinnShininessExponent( material )   GGXRoughnessToBlinnExponent( material.clearCoatRoughness )\nfloat computeSpecularOcclusion( const in float dotNV, const in float ambientOcclusion, const in float roughness ) {\n\treturn saturate( pow( dotNV + ambientOcclusion, exp2( - 16.0 * roughness - 1.0 ) ) - 1.0 + ambientOcclusion );\n}";
+
+	var lights_fragment_begin = "\nGeometricContext geometry;\ngeometry.position = - vViewPosition;\ngeometry.normal = normal;\ngeometry.viewDir = normalize( vViewPosition );\nIncidentLight directLight;\n#if ( NUM_POINT_LIGHTS > 0 ) && defined( RE_Direct )\n\tPointLight pointLight;\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {\n\t\tpointLight = pointLights[ i ];\n\t\tgetPointDirectLightIrradiance( pointLight, geometry, directLight );\n\t\t#ifdef USE_SHADOWMAP\n\t\tdirectLight.color *= all( bvec2( pointLight.shadow, directLight.visible ) ) ? getPointShadow( pointShadowMap[ i ], pointLight.shadowMapSize, pointLight.shadowBias, pointLight.shadowRadius, vPointShadowCoord[ i ], pointLight.shadowCameraNear, pointLight.shadowCameraFar ) : 1.0;\n\t\t#endif\n\t\tRE_Direct( directLight, geometry, material, reflectedLight );\n\t}\n#endif\n#if ( NUM_SPOT_LIGHTS > 0 ) && defined( RE_Direct )\n\tSpotLight spotLight;\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {\n\t\tspotLight = spotLights[ i ];\n\t\tgetSpotDirectLightIrradiance( spotLight, geometry, directLight );\n\t\t#ifdef USE_SHADOWMAP\n\t\tdirectLight.color *= all( bvec2( spotLight.shadow, directLight.visible ) ) ? getShadow( spotShadowMap[ i ], spotLight.shadowMapSize, spotLight.shadowBias, spotLight.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;\n\t\t#endif\n\t\tRE_Direct( directLight, geometry, material, reflectedLight );\n\t}\n#endif\n#if ( NUM_DIR_LIGHTS > 0 ) && defined( RE_Direct )\n\tDirectionalLight directionalLight;\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {\n\t\tdirectionalLight = directionalLights[ i ];\n\t\tgetDirectionalDirectLightIrradiance( directionalLight, geometry, directLight );\n\t\t#ifdef USE_SHADOWMAP\n\t\tdirectLight.color *= all( bvec2( directionalLight.shadow, directLight.visible ) ) ? getShadow( directionalShadowMap[ i ], directionalLight.shadowMapSize, directionalLight.shadowBias, directionalLight.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;\n\t\t#endif\n\t\tRE_Direct( directLight, geometry, material, reflectedLight );\n\t}\n#endif\n#if ( NUM_RECT_AREA_LIGHTS > 0 ) && defined( RE_Direct_RectArea )\n\tRectAreaLight rectAreaLight;\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_RECT_AREA_LIGHTS; i ++ ) {\n\t\trectAreaLight = rectAreaLights[ i ];\n\t\tRE_Direct_RectArea( rectAreaLight, geometry, material, reflectedLight );\n\t}\n#endif\n#if defined( RE_IndirectDiffuse )\n\tvec3 irradiance = getAmbientLightIrradiance( ambientLightColor );\n\tirradiance += getLightProbeIrradiance( lightProbe, geometry );\n\t#if ( NUM_HEMI_LIGHTS > 0 )\n\t\t#pragma unroll_loop\n\t\tfor ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {\n\t\t\tirradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );\n\t\t}\n\t#endif\n#endif\n#if defined( RE_IndirectSpecular )\n\tvec3 radiance = vec3( 0.0 );\n\tvec3 clearCoatRadiance = vec3( 0.0 );\n#endif";
+
+	var lights_fragment_maps = "#if defined( RE_IndirectDiffuse )\n\t#ifdef USE_LIGHTMAP\n\t\tvec3 lightMapIrradiance = texture2D( lightMap, vUv2 ).xyz * lightMapIntensity;\n\t\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\t\tlightMapIrradiance *= PI;\n\t\t#endif\n\t\tirradiance += lightMapIrradiance;\n\t#endif\n\t#if defined( USE_ENVMAP ) && defined( PHYSICAL ) && defined( ENVMAP_TYPE_CUBE_UV )\n\t\tirradiance += getLightProbeIndirectIrradiance( geometry, maxMipLevel );\n\t#endif\n#endif\n#if defined( USE_ENVMAP ) && defined( RE_IndirectSpecular )\n\tradiance += getLightProbeIndirectRadiance( geometry, Material_BlinnShininessExponent( material ), maxMipLevel );\n\t#ifndef STANDARD\n\t\tclearCoatRadiance += getLightProbeIndirectRadiance( geometry, Material_ClearCoat_BlinnShininessExponent( material ), maxMipLevel );\n\t#endif\n#endif";
+
+	var lights_fragment_end = "#if defined( RE_IndirectDiffuse )\n\tRE_IndirectDiffuse( irradiance, geometry, material, reflectedLight );\n#endif\n#if defined( RE_IndirectSpecular )\n\tRE_IndirectSpecular( radiance, irradiance, clearCoatRadiance, geometry, material, reflectedLight );\n#endif";
+
+	var logdepthbuf_fragment = "#if defined( USE_LOGDEPTHBUF ) && defined( USE_LOGDEPTHBUF_EXT )\n\tgl_FragDepthEXT = log2( vFragDepth ) * logDepthBufFC * 0.5;\n#endif";
+
+	var logdepthbuf_pars_fragment = "#if defined( USE_LOGDEPTHBUF ) && defined( USE_LOGDEPTHBUF_EXT )\n\tuniform float logDepthBufFC;\n\tvarying float vFragDepth;\n#endif";
+
+	var logdepthbuf_pars_vertex = "#ifdef USE_LOGDEPTHBUF\n\t#ifdef USE_LOGDEPTHBUF_EXT\n\t\tvarying float vFragDepth;\n\t#else\n\t\tuniform float logDepthBufFC;\n\t#endif\n#endif";
+
+	var logdepthbuf_vertex = "#ifdef USE_LOGDEPTHBUF\n\t#ifdef USE_LOGDEPTHBUF_EXT\n\t\tvFragDepth = 1.0 + gl_Position.w;\n\t#else\n\t\tgl_Position.z = log2( max( EPSILON, gl_Position.w + 1.0 ) ) * logDepthBufFC - 1.0;\n\t\tgl_Position.z *= gl_Position.w;\n\t#endif\n#endif";
+
+	var map_fragment = "#ifdef USE_MAP\n\tvec4 texelColor = texture2D( map, vUv );\n\ttexelColor = mapTexelToLinear( texelColor );\n\tdiffuseColor *= texelColor;\n#endif";
+
+	var map_pars_fragment = "#ifdef USE_MAP\n\tuniform sampler2D map;\n#endif";
+
+	var map_particle_fragment = "#ifdef USE_MAP\n\tvec2 uv = ( uvTransform * vec3( gl_PointCoord.x, 1.0 - gl_PointCoord.y, 1 ) ).xy;\n\tvec4 mapTexel = texture2D( map, uv );\n\tdiffuseColor *= mapTexelToLinear( mapTexel );\n#endif";
+
+	var map_particle_pars_fragment = "#ifdef USE_MAP\n\tuniform mat3 uvTransform;\n\tuniform sampler2D map;\n#endif";
+
+	var metalnessmap_fragment = "float metalnessFactor = metalness;\n#ifdef USE_METALNESSMAP\n\tvec4 texelMetalness = texture2D( metalnessMap, vUv );\n\tmetalnessFactor *= texelMetalness.b;\n#endif";
+
+	var metalnessmap_pars_fragment = "#ifdef USE_METALNESSMAP\n\tuniform sampler2D metalnessMap;\n#endif";
+
+	var morphnormal_vertex = "#ifdef USE_MORPHNORMALS\n\tobjectNormal += ( morphNormal0 - normal ) * morphTargetInfluences[ 0 ];\n\tobjectNormal += ( morphNormal1 - normal ) * morphTargetInfluences[ 1 ];\n\tobjectNormal += ( morphNormal2 - normal ) * morphTargetInfluences[ 2 ];\n\tobjectNormal += ( morphNormal3 - normal ) * morphTargetInfluences[ 3 ];\n#endif";
+
+	var morphtarget_pars_vertex = "#ifdef USE_MORPHTARGETS\n\t#ifndef USE_MORPHNORMALS\n\tuniform float morphTargetInfluences[ 8 ];\n\t#else\n\tuniform float morphTargetInfluences[ 4 ];\n\t#endif\n#endif";
+
+	var morphtarget_vertex = "#ifdef USE_MORPHTARGETS\n\ttransformed += ( morphTarget0 - position ) * morphTargetInfluences[ 0 ];\n\ttransformed += ( morphTarget1 - position ) * morphTargetInfluences[ 1 ];\n\ttransformed += ( morphTarget2 - position ) * morphTargetInfluences[ 2 ];\n\ttransformed += ( morphTarget3 - position ) * morphTargetInfluences[ 3 ];\n\t#ifndef USE_MORPHNORMALS\n\ttransformed += ( morphTarget4 - position ) * morphTargetInfluences[ 4 ];\n\ttransformed += ( morphTarget5 - position ) * morphTargetInfluences[ 5 ];\n\ttransformed += ( morphTarget6 - position ) * morphTargetInfluences[ 6 ];\n\ttransformed += ( morphTarget7 - position ) * morphTargetInfluences[ 7 ];\n\t#endif\n#endif";
+
+	var normal_fragment_begin = "#ifdef FLAT_SHADED\n\tvec3 fdx = vec3( dFdx( vViewPosition.x ), dFdx( vViewPosition.y ), dFdx( vViewPosition.z ) );\n\tvec3 fdy = vec3( dFdy( vViewPosition.x ), dFdy( vViewPosition.y ), dFdy( vViewPosition.z ) );\n\tvec3 normal = normalize( cross( fdx, fdy ) );\n#else\n\tvec3 normal = normalize( vNormal );\n\t#ifdef DOUBLE_SIDED\n\t\tnormal = normal * ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t#endif\n\t#ifdef USE_TANGENT\n\t\tvec3 tangent = normalize( vTangent );\n\t\tvec3 bitangent = normalize( vBitangent );\n\t\t#ifdef DOUBLE_SIDED\n\t\t\ttangent = tangent * ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t\t\tbitangent = bitangent * ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t\t#endif\n\t#endif\n#endif";
+
+	var normal_fragment_maps = "#ifdef USE_NORMALMAP\n\t#ifdef OBJECTSPACE_NORMALMAP\n\t\tnormal = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0;\n\t\t#ifdef FLIP_SIDED\n\t\t\tnormal = - normal;\n\t\t#endif\n\t\t#ifdef DOUBLE_SIDED\n\t\t\tnormal = normal * ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t\t#endif\n\t\tnormal = normalize( normalMatrix * normal );\n\t#else\n\t\t#ifdef USE_TANGENT\n\t\t\tmat3 vTBN = mat3( tangent, bitangent, normal );\n\t\t\tvec3 mapN = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0;\n\t\t\tmapN.xy = normalScale * mapN.xy;\n\t\t\tnormal = normalize( vTBN * mapN );\n\t\t#else\n\t\t\tnormal = perturbNormal2Arb( -vViewPosition, normal );\n\t\t#endif\n\t#endif\n#elif defined( USE_BUMPMAP )\n\tnormal = perturbNormalArb( -vViewPosition, normal, dHdxy_fwd() );\n#endif";
+
+	var normalmap_pars_fragment = "#ifdef USE_NORMALMAP\n\tuniform sampler2D normalMap;\n\tuniform vec2 normalScale;\n\t#ifdef OBJECTSPACE_NORMALMAP\n\t\tuniform mat3 normalMatrix;\n\t#else\n\t\tvec3 perturbNormal2Arb( vec3 eye_pos, vec3 surf_norm ) {\n\t\t\tvec3 q0 = vec3( dFdx( eye_pos.x ), dFdx( eye_pos.y ), dFdx( eye_pos.z ) );\n\t\t\tvec3 q1 = vec3( dFdy( eye_pos.x ), dFdy( eye_pos.y ), dFdy( eye_pos.z ) );\n\t\t\tvec2 st0 = dFdx( vUv.st );\n\t\t\tvec2 st1 = dFdy( vUv.st );\n\t\t\tfloat scale = sign( st1.t * st0.s - st0.t * st1.s );\n\t\t\tvec3 S = normalize( ( q0 * st1.t - q1 * st0.t ) * scale );\n\t\t\tvec3 T = normalize( ( - q0 * st1.s + q1 * st0.s ) * scale );\n\t\t\tvec3 N = normalize( surf_norm );\n\t\t\tmat3 tsn = mat3( S, T, N );\n\t\t\tvec3 mapN = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0;\n\t\t\tmapN.xy *= normalScale;\n\t\t\tmapN.xy *= ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t\t\treturn normalize( tsn * mapN );\n\t\t}\n\t#endif\n#endif";
+
+	var packing = "vec3 packNormalToRGB( const in vec3 normal ) {\n\treturn normalize( normal ) * 0.5 + 0.5;\n}\nvec3 unpackRGBToNormal( const in vec3 rgb ) {\n\treturn 2.0 * rgb.xyz - 1.0;\n}\nconst float PackUpscale = 256. / 255.;const float UnpackDownscale = 255. / 256.;\nconst vec3 PackFactors = vec3( 256. * 256. * 256., 256. * 256.,  256. );\nconst vec4 UnpackFactors = UnpackDownscale / vec4( PackFactors, 1. );\nconst float ShiftRight8 = 1. / 256.;\nvec4 packDepthToRGBA( const in float v ) {\n\tvec4 r = vec4( fract( v * PackFactors ), v );\n\tr.yzw -= r.xyz * ShiftRight8;\treturn r * PackUpscale;\n}\nfloat unpackRGBAToDepth( const in vec4 v ) {\n\treturn dot( v, UnpackFactors );\n}\nfloat viewZToOrthographicDepth( const in float viewZ, const in float near, const in float far ) {\n\treturn ( viewZ + near ) / ( near - far );\n}\nfloat orthographicDepthToViewZ( const in float linearClipZ, const in float near, const in float far ) {\n\treturn linearClipZ * ( near - far ) - near;\n}\nfloat viewZToPerspectiveDepth( const in float viewZ, const in float near, const in float far ) {\n\treturn (( near + viewZ ) * far ) / (( far - near ) * viewZ );\n}\nfloat perspectiveDepthToViewZ( const in float invClipZ, const in float near, const in float far ) {\n\treturn ( near * far ) / ( ( far - near ) * invClipZ - far );\n}";
+
+	var premultiplied_alpha_fragment = "#ifdef PREMULTIPLIED_ALPHA\n\tgl_FragColor.rgb *= gl_FragColor.a;\n#endif";
+
+	var project_vertex = "vec4 mvPosition = modelViewMatrix * vec4( transformed, 1.0 );\ngl_Position = projectionMatrix * mvPosition;";
+
+	var dithering_fragment = "#if defined( DITHERING )\n\tgl_FragColor.rgb = dithering( gl_FragColor.rgb );\n#endif";
+
+	var dithering_pars_fragment = "#if defined( DITHERING )\n\tvec3 dithering( vec3 color ) {\n\t\tfloat grid_position = rand( gl_FragCoord.xy );\n\t\tvec3 dither_shift_RGB = vec3( 0.25 / 255.0, -0.25 / 255.0, 0.25 / 255.0 );\n\t\tdither_shift_RGB = mix( 2.0 * dither_shift_RGB, -2.0 * dither_shift_RGB, grid_position );\n\t\treturn color + dither_shift_RGB;\n\t}\n#endif";
+
+	var roughnessmap_fragment = "float roughnessFactor = roughness;\n#ifdef USE_ROUGHNESSMAP\n\tvec4 texelRoughness = texture2D( roughnessMap, vUv );\n\troughnessFactor *= texelRoughness.g;\n#endif";
+
+	var roughnessmap_pars_fragment = "#ifdef USE_ROUGHNESSMAP\n\tuniform sampler2D roughnessMap;\n#endif";
+
+	var shadowmap_pars_fragment = "#ifdef USE_SHADOWMAP\n\t#if NUM_DIR_LIGHTS > 0\n\t\tuniform sampler2D directionalShadowMap[ NUM_DIR_LIGHTS ];\n\t\tvarying vec4 vDirectionalShadowCoord[ NUM_DIR_LIGHTS ];\n\t#endif\n\t#if NUM_SPOT_LIGHTS > 0\n\t\tuniform sampler2D spotShadowMap[ NUM_SPOT_LIGHTS ];\n\t\tvarying vec4 vSpotShadowCoord[ NUM_SPOT_LIGHTS ];\n\t#endif\n\t#if NUM_POINT_LIGHTS > 0\n\t\tuniform sampler2D pointShadowMap[ NUM_POINT_LIGHTS ];\n\t\tvarying vec4 vPointShadowCoord[ NUM_POINT_LIGHTS ];\n\t#endif\n\tfloat texture2DCompare( sampler2D depths, vec2 uv, float compare ) {\n\t\treturn step( compare, unpackRGBAToDepth( texture2D( depths, uv ) ) );\n\t}\n\tfloat texture2DShadowLerp( sampler2D depths, vec2 size, vec2 uv, float compare ) {\n\t\tconst vec2 offset = vec2( 0.0, 1.0 );\n\t\tvec2 texelSize = vec2( 1.0 ) / size;\n\t\tvec2 centroidUV = floor( uv * size + 0.5 ) / size;\n\t\tfloat lb = texture2DCompare( depths, centroidUV + texelSize * offset.xx, compare );\n\t\tfloat lt = texture2DCompare( depths, centroidUV + texelSize * offset.xy, compare );\n\t\tfloat rb = texture2DCompare( depths, centroidUV + texelSize * offset.yx, compare );\n\t\tfloat rt = texture2DCompare( depths, centroidUV + texelSize * offset.yy, compare );\n\t\tvec2 f = fract( uv * size + 0.5 );\n\t\tfloat a = mix( lb, lt, f.y );\n\t\tfloat b = mix( rb, rt, f.y );\n\t\tfloat c = mix( a, b, f.x );\n\t\treturn c;\n\t}\n\tfloat getShadow( sampler2D shadowMap, vec2 shadowMapSize, float shadowBias, float shadowRadius, vec4 shadowCoord ) {\n\t\tfloat shadow = 1.0;\n\t\tshadowCoord.xyz /= shadowCoord.w;\n\t\tshadowCoord.z += shadowBias;\n\t\tbvec4 inFrustumVec = bvec4 ( shadowCoord.x >= 0.0, shadowCoord.x <= 1.0, shadowCoord.y >= 0.0, shadowCoord.y <= 1.0 );\n\t\tbool inFrustum = all( inFrustumVec );\n\t\tbvec2 frustumTestVec = bvec2( inFrustum, shadowCoord.z <= 1.0 );\n\t\tbool frustumTest = all( frustumTestVec );\n\t\tif ( frustumTest ) {\n\t\t#if defined( SHADOWMAP_TYPE_PCF )\n\t\t\tvec2 texelSize = vec2( 1.0 ) / shadowMapSize;\n\t\t\tfloat dx0 = - texelSize.x * shadowRadius;\n\t\t\tfloat dy0 = - texelSize.y * shadowRadius;\n\t\t\tfloat dx1 = + texelSize.x * shadowRadius;\n\t\t\tfloat dy1 = + texelSize.y * shadowRadius;\n\t\t\tfloat dx2 = dx0 / 2.0;\n\t\t\tfloat dy2 = dy0 / 2.0;\n\t\t\tfloat dx3 = dx1 / 2.0;\n\t\t\tfloat dy3 = dy1 / 2.0;\n\t\t\tshadow = (\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx0, dy0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( 0.0, dy0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx1, dy0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx2, dy2 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( 0.0, dy2 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx3, dy2 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx0, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx2, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy, shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx3, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx1, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx2, dy3 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( 0.0, dy3 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx3, dy3 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx0, dy1 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( 0.0, dy1 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx1, dy1 ), shadowCoord.z )\n\t\t\t) * ( 1.0 / 17.0 );\n\t\t#elif defined( SHADOWMAP_TYPE_PCF_SOFT )\n\t\t\tvec2 texelSize = vec2( 1.0 ) / shadowMapSize;\n\t\t\tfloat dx0 = - texelSize.x * shadowRadius;\n\t\t\tfloat dy0 = - texelSize.y * shadowRadius;\n\t\t\tfloat dx1 = + texelSize.x * shadowRadius;\n\t\t\tfloat dy1 = + texelSize.y * shadowRadius;\n\t\t\tshadow = (\n\t\t\t\ttexture2DShadowLerp( shadowMap, shadowMapSize, shadowCoord.xy + vec2( dx0, dy0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DShadowLerp( shadowMap, shadowMapSize, shadowCoord.xy + vec2( 0.0, dy0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DShadowLerp( shadowMap, shadowMapSize, shadowCoord.xy + vec2( dx1, dy0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DShadowLerp( shadowMap, shadowMapSize, shadowCoord.xy + vec2( dx0, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DShadowLerp( shadowMap, shadowMapSize, shadowCoord.xy, shadowCoord.z ) +\n\t\t\t\ttexture2DShadowLerp( shadowMap, shadowMapSize, shadowCoord.xy + vec2( dx1, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DShadowLerp( shadowMap, shadowMapSize, shadowCoord.xy + vec2( dx0, dy1 ), shadowCoord.z ) +\n\t\t\t\ttexture2DShadowLerp( shadowMap, shadowMapSize, shadowCoord.xy + vec2( 0.0, dy1 ), shadowCoord.z ) +\n\t\t\t\ttexture2DShadowLerp( shadowMap, shadowMapSize, shadowCoord.xy + vec2( dx1, dy1 ), shadowCoord.z )\n\t\t\t) * ( 1.0 / 9.0 );\n\t\t#else\n\t\t\tshadow = texture2DCompare( shadowMap, shadowCoord.xy, shadowCoord.z );\n\t\t#endif\n\t\t}\n\t\treturn shadow;\n\t}\n\tvec2 cubeToUV( vec3 v, float texelSizeY ) {\n\t\tvec3 absV = abs( v );\n\t\tfloat scaleToCube = 1.0 / max( absV.x, max( absV.y, absV.z ) );\n\t\tabsV *= scaleToCube;\n\t\tv *= scaleToCube * ( 1.0 - 2.0 * texelSizeY );\n\t\tvec2 planar = v.xy;\n\t\tfloat almostATexel = 1.5 * texelSizeY;\n\t\tfloat almostOne = 1.0 - almostATexel;\n\t\tif ( absV.z >= almostOne ) {\n\t\t\tif ( v.z > 0.0 )\n\t\t\t\tplanar.x = 4.0 - v.x;\n\t\t} else if ( absV.x >= almostOne ) {\n\t\t\tfloat signX = sign( v.x );\n\t\t\tplanar.x = v.z * signX + 2.0 * signX;\n\t\t} else if ( absV.y >= almostOne ) {\n\t\t\tfloat signY = sign( v.y );\n\t\t\tplanar.x = v.x + 2.0 * signY + 2.0;\n\t\t\tplanar.y = v.z * signY - 2.0;\n\t\t}\n\t\treturn vec2( 0.125, 0.25 ) * planar + vec2( 0.375, 0.75 );\n\t}\n\tfloat getPointShadow( sampler2D shadowMap, vec2 shadowMapSize, float shadowBias, float shadowRadius, vec4 shadowCoord, float shadowCameraNear, float shadowCameraFar ) {\n\t\tvec2 texelSize = vec2( 1.0 ) / ( shadowMapSize * vec2( 4.0, 2.0 ) );\n\t\tvec3 lightToPosition = shadowCoord.xyz;\n\t\tfloat dp = ( length( lightToPosition ) - shadowCameraNear ) / ( shadowCameraFar - shadowCameraNear );\t\tdp += shadowBias;\n\t\tvec3 bd3D = normalize( lightToPosition );\n\t\t#if defined( SHADOWMAP_TYPE_PCF ) || defined( SHADOWMAP_TYPE_PCF_SOFT )\n\t\t\tvec2 offset = vec2( - 1, 1 ) * shadowRadius * texelSize.y;\n\t\t\treturn (\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.xyy, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.yyy, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.xyx, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.yyx, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.xxy, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.yxy, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.xxx, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.yxx, texelSize.y ), dp )\n\t\t\t) * ( 1.0 / 9.0 );\n\t\t#else\n\t\t\treturn texture2DCompare( shadowMap, cubeToUV( bd3D, texelSize.y ), dp );\n\t\t#endif\n\t}\n#endif";
+
+	var shadowmap_pars_vertex = "#ifdef USE_SHADOWMAP\n\t#if NUM_DIR_LIGHTS > 0\n\t\tuniform mat4 directionalShadowMatrix[ NUM_DIR_LIGHTS ];\n\t\tvarying vec4 vDirectionalShadowCoord[ NUM_DIR_LIGHTS ];\n\t#endif\n\t#if NUM_SPOT_LIGHTS > 0\n\t\tuniform mat4 spotShadowMatrix[ NUM_SPOT_LIGHTS ];\n\t\tvarying vec4 vSpotShadowCoord[ NUM_SPOT_LIGHTS ];\n\t#endif\n\t#if NUM_POINT_LIGHTS > 0\n\t\tuniform mat4 pointShadowMatrix[ NUM_POINT_LIGHTS ];\n\t\tvarying vec4 vPointShadowCoord[ NUM_POINT_LIGHTS ];\n\t#endif\n#endif";
+
+	var shadowmap_vertex = "#ifdef USE_SHADOWMAP\n\t#if NUM_DIR_LIGHTS > 0\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {\n\t\tvDirectionalShadowCoord[ i ] = directionalShadowMatrix[ i ] * worldPosition;\n\t}\n\t#endif\n\t#if NUM_SPOT_LIGHTS > 0\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {\n\t\tvSpotShadowCoord[ i ] = spotShadowMatrix[ i ] * worldPosition;\n\t}\n\t#endif\n\t#if NUM_POINT_LIGHTS > 0\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {\n\t\tvPointShadowCoord[ i ] = pointShadowMatrix[ i ] * worldPosition;\n\t}\n\t#endif\n#endif";
+
+	var shadowmask_pars_fragment = "float getShadowMask() {\n\tfloat shadow = 1.0;\n\t#ifdef USE_SHADOWMAP\n\t#if NUM_DIR_LIGHTS > 0\n\tDirectionalLight directionalLight;\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {\n\t\tdirectionalLight = directionalLights[ i ];\n\t\tshadow *= bool( directionalLight.shadow ) ? getShadow( directionalShadowMap[ i ], directionalLight.shadowMapSize, directionalLight.shadowBias, directionalLight.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;\n\t}\n\t#endif\n\t#if NUM_SPOT_LIGHTS > 0\n\tSpotLight spotLight;\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {\n\t\tspotLight = spotLights[ i ];\n\t\tshadow *= bool( spotLight.shadow ) ? getShadow( spotShadowMap[ i ], spotLight.shadowMapSize, spotLight.shadowBias, spotLight.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;\n\t}\n\t#endif\n\t#if NUM_POINT_LIGHTS > 0\n\tPointLight pointLight;\n\t#pragma unroll_loop\n\tfor ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {\n\t\tpointLight = pointLights[ i ];\n\t\tshadow *= bool( pointLight.shadow ) ? getPointShadow( pointShadowMap[ i ], pointLight.shadowMapSize, pointLight.shadowBias, pointLight.shadowRadius, vPointShadowCoord[ i ], pointLight.shadowCameraNear, pointLight.shadowCameraFar ) : 1.0;\n\t}\n\t#endif\n\t#endif\n\treturn shadow;\n}";
+
+	var skinbase_vertex = "#ifdef USE_SKINNING\n\tmat4 boneMatX = getBoneMatrix( skinIndex.x );\n\tmat4 boneMatY = getBoneMatrix( skinIndex.y );\n\tmat4 boneMatZ = getBoneMatrix( skinIndex.z );\n\tmat4 boneMatW = getBoneMatrix( skinIndex.w );\n#endif";
+
+	var skinning_pars_vertex = "#ifdef USE_SKINNING\n\tuniform mat4 bindMatrix;\n\tuniform mat4 bindMatrixInverse;\n\t#ifdef BONE_TEXTURE\n\t\tuniform highp sampler2D boneTexture;\n\t\tuniform int boneTextureSize;\n\t\tmat4 getBoneMatrix( const in float i ) {\n\t\t\tfloat j = i * 4.0;\n\t\t\tfloat x = mod( j, float( boneTextureSize ) );\n\t\t\tfloat y = floor( j / float( boneTextureSize ) );\n\t\t\tfloat dx = 1.0 / float( boneTextureSize );\n\t\t\tfloat dy = 1.0 / float( boneTextureSize );\n\t\t\ty = dy * ( y + 0.5 );\n\t\t\tvec4 v1 = texture2D( boneTexture, vec2( dx * ( x + 0.5 ), y ) );\n\t\t\tvec4 v2 = texture2D( boneTexture, vec2( dx * ( x + 1.5 ), y ) );\n\t\t\tvec4 v3 = texture2D( boneTexture, vec2( dx * ( x + 2.5 ), y ) );\n\t\t\tvec4 v4 = texture2D( boneTexture, vec2( dx * ( x + 3.5 ), y ) );\n\t\t\tmat4 bone = mat4( v1, v2, v3, v4 );\n\t\t\treturn bone;\n\t\t}\n\t#else\n\t\tuniform mat4 boneMatrices[ MAX_BONES ];\n\t\tmat4 getBoneMatrix( const in float i ) {\n\t\t\tmat4 bone = boneMatrices[ int(i) ];\n\t\t\treturn bone;\n\t\t}\n\t#endif\n#endif";
+
+	var skinning_vertex = "#ifdef USE_SKINNING\n\tvec4 skinVertex = bindMatrix * vec4( transformed, 1.0 );\n\tvec4 skinned = vec4( 0.0 );\n\tskinned += boneMatX * skinVertex * skinWeight.x;\n\tskinned += boneMatY * skinVertex * skinWeight.y;\n\tskinned += boneMatZ * skinVertex * skinWeight.z;\n\tskinned += boneMatW * skinVertex * skinWeight.w;\n\ttransformed = ( bindMatrixInverse * skinned ).xyz;\n#endif";
+
+	var skinnormal_vertex = "#ifdef USE_SKINNING\n\tmat4 skinMatrix = mat4( 0.0 );\n\tskinMatrix += skinWeight.x * boneMatX;\n\tskinMatrix += skinWeight.y * boneMatY;\n\tskinMatrix += skinWeight.z * boneMatZ;\n\tskinMatrix += skinWeight.w * boneMatW;\n\tskinMatrix  = bindMatrixInverse * skinMatrix * bindMatrix;\n\tobjectNormal = vec4( skinMatrix * vec4( objectNormal, 0.0 ) ).xyz;\n\t#ifdef USE_TANGENT\n\t\tobjectTangent = vec4( skinMatrix * vec4( objectTangent, 0.0 ) ).xyz;\n\t#endif\n#endif";
+
+	var specularmap_fragment = "float specularStrength;\n#ifdef USE_SPECULARMAP\n\tvec4 texelSpecular = texture2D( specularMap, vUv );\n\tspecularStrength = texelSpecular.r;\n#else\n\tspecularStrength = 1.0;\n#endif";
+
+	var specularmap_pars_fragment = "#ifdef USE_SPECULARMAP\n\tuniform sampler2D specularMap;\n#endif";
+
+	var tonemapping_fragment = "#if defined( TONE_MAPPING )\n\tgl_FragColor.rgb = toneMapping( gl_FragColor.rgb );\n#endif";
+
+	var tonemapping_pars_fragment = "#ifndef saturate\n\t#define saturate(a) clamp( a, 0.0, 1.0 )\n#endif\nuniform float toneMappingExposure;\nuniform float toneMappingWhitePoint;\nvec3 LinearToneMapping( vec3 color ) {\n\treturn toneMappingExposure * color;\n}\nvec3 ReinhardToneMapping( vec3 color ) {\n\tcolor *= toneMappingExposure;\n\treturn saturate( color / ( vec3( 1.0 ) + color ) );\n}\n#define Uncharted2Helper( x ) max( ( ( x * ( 0.15 * x + 0.10 * 0.50 ) + 0.20 * 0.02 ) / ( x * ( 0.15 * x + 0.50 ) + 0.20 * 0.30 ) ) - 0.02 / 0.30, vec3( 0.0 ) )\nvec3 Uncharted2ToneMapping( vec3 color ) {\n\tcolor *= toneMappingExposure;\n\treturn saturate( Uncharted2Helper( color ) / Uncharted2Helper( vec3( toneMappingWhitePoint ) ) );\n}\nvec3 OptimizedCineonToneMapping( vec3 color ) {\n\tcolor *= toneMappingExposure;\n\tcolor = max( vec3( 0.0 ), color - 0.004 );\n\treturn pow( ( color * ( 6.2 * color + 0.5 ) ) / ( color * ( 6.2 * color + 1.7 ) + 0.06 ), vec3( 2.2 ) );\n}\nvec3 ACESFilmicToneMapping( vec3 color ) {\n\tcolor *= toneMappingExposure;\n\treturn saturate( ( color * ( 2.51 * color + 0.03 ) ) / ( color * ( 2.43 * color + 0.59 ) + 0.14 ) );\n}";
+
+	var uv_pars_fragment = "#if defined( USE_MAP ) || defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( USE_SPECULARMAP ) || defined( USE_ALPHAMAP ) || defined( USE_EMISSIVEMAP ) || defined( USE_ROUGHNESSMAP ) || defined( USE_METALNESSMAP )\n\tvarying vec2 vUv;\n#endif";
+
+	var uv_pars_vertex = "#if defined( USE_MAP ) || defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( USE_SPECULARMAP ) || defined( USE_ALPHAMAP ) || defined( USE_EMISSIVEMAP ) || defined( USE_ROUGHNESSMAP ) || defined( USE_METALNESSMAP )\n\tvarying vec2 vUv;\n\tuniform mat3 uvTransform;\n#endif";
+
+	var uv_vertex = "#if defined( USE_MAP ) || defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( USE_SPECULARMAP ) || defined( USE_ALPHAMAP ) || defined( USE_EMISSIVEMAP ) || defined( USE_ROUGHNESSMAP ) || defined( USE_METALNESSMAP )\n\tvUv = ( uvTransform * vec3( uv, 1 ) ).xy;\n#endif";
+
+	var uv2_pars_fragment = "#if defined( USE_LIGHTMAP ) || defined( USE_AOMAP )\n\tvarying vec2 vUv2;\n#endif";
+
+	var uv2_pars_vertex = "#if defined( USE_LIGHTMAP ) || defined( USE_AOMAP )\n\tattribute vec2 uv2;\n\tvarying vec2 vUv2;\n#endif";
+
+	var uv2_vertex = "#if defined( USE_LIGHTMAP ) || defined( USE_AOMAP )\n\tvUv2 = uv2;\n#endif";
+
+	var worldpos_vertex = "#if defined( USE_ENVMAP ) || defined( DISTANCE ) || defined ( USE_SHADOWMAP )\n\tvec4 worldPosition = modelMatrix * vec4( transformed, 1.0 );\n#endif";
+
+	var background_frag = "uniform sampler2D t2D;\nvarying vec2 vUv;\nvoid main() {\n\tvec4 texColor = texture2D( t2D, vUv );\n\tgl_FragColor = mapTexelToLinear( texColor );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n}";
+
+	var background_vert = "varying vec2 vUv;\nuniform mat3 uvTransform;\nvoid main() {\n\tvUv = ( uvTransform * vec3( uv, 1 ) ).xy;\n\tgl_Position = vec4( position.xy, 1.0, 1.0 );\n}";
+
+	var cube_frag = "uniform samplerCube tCube;\nuniform float tFlip;\nuniform float opacity;\nvarying vec3 vWorldDirection;\nvoid main() {\n\tvec4 texColor = textureCube( tCube, vec3( tFlip * vWorldDirection.x, vWorldDirection.yz ) );\n\tgl_FragColor = mapTexelToLinear( texColor );\n\tgl_FragColor.a *= opacity;\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n}";
+
+	var cube_vert = "varying vec3 vWorldDirection;\n#include <common>\nvoid main() {\n\tvWorldDirection = transformDirection( position, modelMatrix );\n\t#include <begin_vertex>\n\t#include <project_vertex>\n\tgl_Position.z = gl_Position.w;\n}";
+
+	var depth_frag = "#if DEPTH_PACKING == 3200\n\tuniform float opacity;\n#endif\n#include <common>\n#include <packing>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( 1.0 );\n\t#if DEPTH_PACKING == 3200\n\t\tdiffuseColor.a = opacity;\n\t#endif\n\t#include <map_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <logdepthbuf_fragment>\n\t#if DEPTH_PACKING == 3200\n\t\tgl_FragColor = vec4( vec3( 1.0 - gl_FragCoord.z ), opacity );\n\t#elif DEPTH_PACKING == 3201\n\t\tgl_FragColor = packDepthToRGBA( gl_FragCoord.z );\n\t#endif\n}";
+
+	var depth_vert = "#include <common>\n#include <uv_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <skinbase_vertex>\n\t#ifdef USE_DISPLACEMENTMAP\n\t\t#include <beginnormal_vertex>\n\t\t#include <morphnormal_vertex>\n\t\t#include <skinnormal_vertex>\n\t#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n}";
+
+	var distanceRGBA_frag = "#define DISTANCE\nuniform vec3 referencePosition;\nuniform float nearDistance;\nuniform float farDistance;\nvarying vec3 vWorldPosition;\n#include <common>\n#include <packing>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main () {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( 1.0 );\n\t#include <map_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\tfloat dist = length( vWorldPosition - referencePosition );\n\tdist = ( dist - nearDistance ) / ( farDistance - nearDistance );\n\tdist = saturate( dist );\n\tgl_FragColor = packDepthToRGBA( dist );\n}";
+
+	var distanceRGBA_vert = "#define DISTANCE\nvarying vec3 vWorldPosition;\n#include <common>\n#include <uv_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <skinbase_vertex>\n\t#ifdef USE_DISPLACEMENTMAP\n\t\t#include <beginnormal_vertex>\n\t\t#include <morphnormal_vertex>\n\t\t#include <skinnormal_vertex>\n\t#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <worldpos_vertex>\n\t#include <clipping_planes_vertex>\n\tvWorldPosition = worldPosition.xyz;\n}";
+
+	var equirect_frag = "uniform sampler2D tEquirect;\nvarying vec3 vWorldDirection;\n#include <common>\nvoid main() {\n\tvec3 direction = normalize( vWorldDirection );\n\tvec2 sampleUV;\n\tsampleUV.y = asin( clamp( direction.y, - 1.0, 1.0 ) ) * RECIPROCAL_PI + 0.5;\n\tsampleUV.x = atan( direction.z, direction.x ) * RECIPROCAL_PI2 + 0.5;\n\tvec4 texColor = texture2D( tEquirect, sampleUV );\n\tgl_FragColor = mapTexelToLinear( texColor );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n}";
+
+	var equirect_vert = "varying vec3 vWorldDirection;\n#include <common>\nvoid main() {\n\tvWorldDirection = transformDirection( position, modelMatrix );\n\t#include <begin_vertex>\n\t#include <project_vertex>\n}";
+
+	var linedashed_frag = "uniform vec3 diffuse;\nuniform float opacity;\nuniform float dashSize;\nuniform float totalSize;\nvarying float vLineDistance;\n#include <common>\n#include <color_pars_fragment>\n#include <fog_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tif ( mod( vLineDistance, totalSize ) > dashSize ) {\n\t\tdiscard;\n\t}\n\tvec3 outgoingLight = vec3( 0.0 );\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\t#include <logdepthbuf_fragment>\n\t#include <color_fragment>\n\toutgoingLight = diffuseColor.rgb;\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <premultiplied_alpha_fragment>\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n}";
+
+	var linedashed_vert = "uniform float scale;\nattribute float lineDistance;\nvarying float vLineDistance;\n#include <common>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <color_vertex>\n\tvLineDistance = scale * lineDistance;\n\tvec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );\n\tgl_Position = projectionMatrix * mvPosition;\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <fog_vertex>\n}";
+
+	var meshbasic_frag = "uniform vec3 diffuse;\nuniform float opacity;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\n#include <common>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <uv2_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <envmap_pars_fragment>\n#include <fog_pars_fragment>\n#include <specularmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <color_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <specularmap_fragment>\n\tReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n\t#ifdef USE_LIGHTMAP\n\t\treflectedLight.indirectDiffuse += texture2D( lightMap, vUv2 ).xyz * lightMapIntensity;\n\t#else\n\t\treflectedLight.indirectDiffuse += vec3( 1.0 );\n\t#endif\n\t#include <aomap_fragment>\n\treflectedLight.indirectDiffuse *= diffuseColor.rgb;\n\tvec3 outgoingLight = reflectedLight.indirectDiffuse;\n\t#include <envmap_fragment>\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <premultiplied_alpha_fragment>\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n}";
+
+	var meshbasic_vert = "#include <common>\n#include <uv_pars_vertex>\n#include <uv2_pars_vertex>\n#include <envmap_pars_vertex>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <uv2_vertex>\n\t#include <color_vertex>\n\t#include <skinbase_vertex>\n\t#ifdef USE_ENVMAP\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n\t#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <worldpos_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <envmap_vertex>\n\t#include <fog_vertex>\n}";
+
+	var meshlambert_frag = "uniform vec3 diffuse;\nuniform vec3 emissive;\nuniform float opacity;\nvarying vec3 vLightFront;\nvarying vec3 vIndirectFront;\n#ifdef DOUBLE_SIDED\n\tvarying vec3 vLightBack;\n\tvarying vec3 vIndirectBack;\n#endif\n#include <common>\n#include <packing>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <uv2_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <emissivemap_pars_fragment>\n#include <envmap_pars_fragment>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <fog_pars_fragment>\n#include <shadowmap_pars_fragment>\n#include <shadowmask_pars_fragment>\n#include <specularmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\tReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n\tvec3 totalEmissiveRadiance = emissive;\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <color_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <specularmap_fragment>\n\t#include <emissivemap_fragment>\n\treflectedLight.indirectDiffuse = getAmbientLightIrradiance( ambientLightColor );\n\t#ifdef DOUBLE_SIDED\n\t\treflectedLight.indirectDiffuse += ( gl_FrontFacing ) ? vIndirectFront : vIndirectBack;\n\t#else\n\t\treflectedLight.indirectDiffuse += vIndirectFront;\n\t#endif\n\t#include <lightmap_fragment>\n\treflectedLight.indirectDiffuse *= BRDF_Diffuse_Lambert( diffuseColor.rgb );\n\t#ifdef DOUBLE_SIDED\n\t\treflectedLight.directDiffuse = ( gl_FrontFacing ) ? vLightFront : vLightBack;\n\t#else\n\t\treflectedLight.directDiffuse = vLightFront;\n\t#endif\n\treflectedLight.directDiffuse *= BRDF_Diffuse_Lambert( diffuseColor.rgb ) * getShadowMask();\n\t#include <aomap_fragment>\n\tvec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + totalEmissiveRadiance;\n\t#include <envmap_fragment>\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n\t#include <dithering_fragment>\n}";
+
+	var meshlambert_vert = "#define LAMBERT\nvarying vec3 vLightFront;\nvarying vec3 vIndirectFront;\n#ifdef DOUBLE_SIDED\n\tvarying vec3 vLightBack;\n\tvarying vec3 vIndirectBack;\n#endif\n#include <common>\n#include <uv_pars_vertex>\n#include <uv2_pars_vertex>\n#include <envmap_pars_vertex>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <shadowmap_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <uv2_vertex>\n\t#include <color_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <worldpos_vertex>\n\t#include <envmap_vertex>\n\t#include <lights_lambert_vertex>\n\t#include <shadowmap_vertex>\n\t#include <fog_vertex>\n}";
+
+	var meshmatcap_frag = "#define MATCAP\nuniform vec3 diffuse;\nuniform float opacity;\nuniform sampler2D matcap;\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\n#include <common>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <fog_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <normal_fragment_begin>\n\t#include <normal_fragment_maps>\n\tvec3 viewDir = normalize( vViewPosition );\n\tvec3 x = normalize( vec3( viewDir.z, 0.0, - viewDir.x ) );\n\tvec3 y = cross( viewDir, x );\n\tvec2 uv = vec2( dot( x, normal ), dot( y, normal ) ) * 0.495 + 0.5;\n\t#ifdef USE_MATCAP\n\t\tvec4 matcapColor = texture2D( matcap, uv );\n\t\tmatcapColor = matcapTexelToLinear( matcapColor );\n\t#else\n\t\tvec4 matcapColor = vec4( 1.0 );\n\t#endif\n\tvec3 outgoingLight = diffuseColor.rgb * matcapColor.rgb;\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <premultiplied_alpha_fragment>\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n}";
+
+	var meshmatcap_vert = "#define MATCAP\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\n#include <common>\n#include <uv_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n\t#ifndef FLAT_SHADED\n\t\tvNormal = normalize( transformedNormal );\n\t#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <fog_vertex>\n\tvViewPosition = - mvPosition.xyz;\n}";
+
+	var meshphong_frag = "#define PHONG\nuniform vec3 diffuse;\nuniform vec3 emissive;\nuniform vec3 specular;\nuniform float shininess;\nuniform float opacity;\n#include <common>\n#include <packing>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <uv2_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <emissivemap_pars_fragment>\n#include <envmap_pars_fragment>\n#include <gradientmap_pars_fragment>\n#include <fog_pars_fragment>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <lights_phong_pars_fragment>\n#include <shadowmap_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <specularmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\tReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n\tvec3 totalEmissiveRadiance = emissive;\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <color_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <specularmap_fragment>\n\t#include <normal_fragment_begin>\n\t#include <normal_fragment_maps>\n\t#include <emissivemap_fragment>\n\t#include <lights_phong_fragment>\n\t#include <lights_fragment_begin>\n\t#include <lights_fragment_maps>\n\t#include <lights_fragment_end>\n\t#include <aomap_fragment>\n\tvec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;\n\t#include <envmap_fragment>\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n\t#include <dithering_fragment>\n}";
+
+	var meshphong_vert = "#define PHONG\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\n#include <common>\n#include <uv_pars_vertex>\n#include <uv2_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <envmap_pars_vertex>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <shadowmap_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <uv2_vertex>\n\t#include <color_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n#ifndef FLAT_SHADED\n\tvNormal = normalize( transformedNormal );\n#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\tvViewPosition = - mvPosition.xyz;\n\t#include <worldpos_vertex>\n\t#include <envmap_vertex>\n\t#include <shadowmap_vertex>\n\t#include <fog_vertex>\n}";
+
+	var meshphysical_frag = "#define PHYSICAL\nuniform vec3 diffuse;\nuniform vec3 emissive;\nuniform float roughness;\nuniform float metalness;\nuniform float opacity;\n#ifndef STANDARD\n\tuniform float clearCoat;\n\tuniform float clearCoatRoughness;\n#endif\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n\t#ifdef USE_TANGENT\n\t\tvarying vec3 vTangent;\n\t\tvarying vec3 vBitangent;\n\t#endif\n#endif\n#include <common>\n#include <packing>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <uv2_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <emissivemap_pars_fragment>\n#include <bsdfs>\n#include <cube_uv_reflection_fragment>\n#include <envmap_pars_fragment>\n#include <envmap_physical_pars_fragment>\n#include <fog_pars_fragment>\n#include <lights_pars_begin>\n#include <lights_physical_pars_fragment>\n#include <shadowmap_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <roughnessmap_pars_fragment>\n#include <metalnessmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\tReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n\tvec3 totalEmissiveRadiance = emissive;\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <color_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <roughnessmap_fragment>\n\t#include <metalnessmap_fragment>\n\t#include <normal_fragment_begin>\n\t#include <normal_fragment_maps>\n\t#include <emissivemap_fragment>\n\t#include <lights_physical_fragment>\n\t#include <lights_fragment_begin>\n\t#include <lights_fragment_maps>\n\t#include <lights_fragment_end>\n\t#include <aomap_fragment>\n\tvec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n\t#include <dithering_fragment>\n}";
+
+	var meshphysical_vert = "#define PHYSICAL\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n\t#ifdef USE_TANGENT\n\t\tvarying vec3 vTangent;\n\t\tvarying vec3 vBitangent;\n\t#endif\n#endif\n#include <common>\n#include <uv_pars_vertex>\n#include <uv2_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <shadowmap_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <uv2_vertex>\n\t#include <color_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n#ifndef FLAT_SHADED\n\tvNormal = normalize( transformedNormal );\n\t#ifdef USE_TANGENT\n\t\tvTangent = normalize( transformedTangent );\n\t\tvBitangent = normalize( cross( vNormal, vTangent ) * tangent.w );\n\t#endif\n#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\tvViewPosition = - mvPosition.xyz;\n\t#include <worldpos_vertex>\n\t#include <shadowmap_vertex>\n\t#include <fog_vertex>\n}";
+
+	var normal_frag = "#define NORMAL\nuniform float opacity;\n#if defined( FLAT_SHADED ) || defined( USE_BUMPMAP ) || ( defined( USE_NORMALMAP ) && ! defined( OBJECTSPACE_NORMALMAP ) )\n\tvarying vec3 vViewPosition;\n#endif\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n\t#ifdef USE_TANGENT\n\t\tvarying vec3 vTangent;\n\t\tvarying vec3 vBitangent;\n\t#endif\n#endif\n#include <packing>\n#include <uv_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\t#include <logdepthbuf_fragment>\n\t#include <normal_fragment_begin>\n\t#include <normal_fragment_maps>\n\tgl_FragColor = vec4( packNormalToRGB( normal ), opacity );\n}";
+
+	var normal_vert = "#define NORMAL\n#if defined( FLAT_SHADED ) || defined( USE_BUMPMAP ) || ( defined( USE_NORMALMAP ) && ! defined( OBJECTSPACE_NORMALMAP ) )\n\tvarying vec3 vViewPosition;\n#endif\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n\t#ifdef USE_TANGENT\n\t\tvarying vec3 vTangent;\n\t\tvarying vec3 vBitangent;\n\t#endif\n#endif\n#include <uv_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n#ifndef FLAT_SHADED\n\tvNormal = normalize( transformedNormal );\n\t#ifdef USE_TANGENT\n\t\tvTangent = normalize( transformedTangent );\n\t\tvBitangent = normalize( cross( vNormal, vTangent ) * tangent.w );\n\t#endif\n#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n#if defined( FLAT_SHADED ) || defined( USE_BUMPMAP ) || ( defined( USE_NORMALMAP ) && ! defined( OBJECTSPACE_NORMALMAP ) )\n\tvViewPosition = - mvPosition.xyz;\n#endif\n}";
+
+	var points_frag = "uniform vec3 diffuse;\nuniform float opacity;\n#include <common>\n#include <color_pars_fragment>\n#include <map_particle_pars_fragment>\n#include <fog_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec3 outgoingLight = vec3( 0.0 );\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\t#include <logdepthbuf_fragment>\n\t#include <map_particle_fragment>\n\t#include <color_fragment>\n\t#include <alphatest_fragment>\n\toutgoingLight = diffuseColor.rgb;\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <premultiplied_alpha_fragment>\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n}";
+
+	var points_vert = "uniform float size;\nuniform float scale;\n#include <common>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <color_vertex>\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <project_vertex>\n\tgl_PointSize = size;\n\t#ifdef USE_SIZEATTENUATION\n\t\tbool isPerspective = ( projectionMatrix[ 2 ][ 3 ] == - 1.0 );\n\t\tif ( isPerspective ) gl_PointSize *= ( scale / - mvPosition.z );\n\t#endif\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <worldpos_vertex>\n\t#include <fog_vertex>\n}";
+
+	var shadow_frag = "uniform vec3 color;\nuniform float opacity;\n#include <common>\n#include <packing>\n#include <fog_pars_fragment>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <shadowmap_pars_fragment>\n#include <shadowmask_pars_fragment>\nvoid main() {\n\tgl_FragColor = vec4( color, opacity * ( 1.0 - getShadowMask() ) );\n\t#include <fog_fragment>\n}";
+
+	var shadow_vert = "#include <fog_pars_vertex>\n#include <shadowmap_pars_vertex>\nvoid main() {\n\t#include <begin_vertex>\n\t#include <project_vertex>\n\t#include <worldpos_vertex>\n\t#include <shadowmap_vertex>\n\t#include <fog_vertex>\n}";
+
+	var sprite_frag = "uniform vec3 diffuse;\nuniform float opacity;\n#include <common>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <fog_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec3 outgoingLight = vec3( 0.0 );\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <alphatest_fragment>\n\toutgoingLight = diffuseColor.rgb;\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n}";
+
+	var sprite_vert = "uniform float rotation;\nuniform vec2 center;\n#include <common>\n#include <uv_pars_vertex>\n#include <fog_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\tvec4 mvPosition = modelViewMatrix * vec4( 0.0, 0.0, 0.0, 1.0 );\n\tvec2 scale;\n\tscale.x = length( vec3( modelMatrix[ 0 ].x, modelMatrix[ 0 ].y, modelMatrix[ 0 ].z ) );\n\tscale.y = length( vec3( modelMatrix[ 1 ].x, modelMatrix[ 1 ].y, modelMatrix[ 1 ].z ) );\n\t#ifndef USE_SIZEATTENUATION\n\t\tbool isPerspective = ( projectionMatrix[ 2 ][ 3 ] == - 1.0 );\n\t\tif ( isPerspective ) scale *= - mvPosition.z;\n\t#endif\n\tvec2 alignedPosition = ( position.xy - ( center - vec2( 0.5 ) ) ) * scale;\n\tvec2 rotatedPosition;\n\trotatedPosition.x = cos( rotation ) * alignedPosition.x - sin( rotation ) * alignedPosition.y;\n\trotatedPosition.y = sin( rotation ) * alignedPosition.x + cos( rotation ) * alignedPosition.y;\n\tmvPosition.xy += rotatedPosition;\n\tgl_Position = projectionMatrix * mvPosition;\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <fog_vertex>\n}";
+
+	var ShaderChunk = {
+		alphamap_fragment: alphamap_fragment,
+		alphamap_pars_fragment: alphamap_pars_fragment,
+		alphatest_fragment: alphatest_fragment,
+		aomap_fragment: aomap_fragment,
+		aomap_pars_fragment: aomap_pars_fragment,
+		begin_vertex: begin_vertex,
+		beginnormal_vertex: beginnormal_vertex,
+		bsdfs: bsdfs,
+		bumpmap_pars_fragment: bumpmap_pars_fragment,
+		clipping_planes_fragment: clipping_planes_fragment,
+		clipping_planes_pars_fragment: clipping_planes_pars_fragment,
+		clipping_planes_pars_vertex: clipping_planes_pars_vertex,
+		clipping_planes_vertex: clipping_planes_vertex,
+		color_fragment: color_fragment,
+		color_pars_fragment: color_pars_fragment,
+		color_pars_vertex: color_pars_vertex,
+		color_vertex: color_vertex,
+		common: common,
+		cube_uv_reflection_fragment: cube_uv_reflection_fragment,
+		defaultnormal_vertex: defaultnormal_vertex,
+		displacementmap_pars_vertex: displacementmap_pars_vertex,
+		displacementmap_vertex: displacementmap_vertex,
+		emissivemap_fragment: emissivemap_fragment,
+		emissivemap_pars_fragment: emissivemap_pars_fragment,
+		encodings_fragment: encodings_fragment,
+		encodings_pars_fragment: encodings_pars_fragment,
+		envmap_fragment: envmap_fragment,
+		envmap_pars_fragment: envmap_pars_fragment,
+		envmap_pars_vertex: envmap_pars_vertex,
+		envmap_physical_pars_fragment: envmap_physical_pars_fragment,
+		envmap_vertex: envmap_vertex,
+		fog_vertex: fog_vertex,
+		fog_pars_vertex: fog_pars_vertex,
+		fog_fragment: fog_fragment,
+		fog_pars_fragment: fog_pars_fragment,
+		gradientmap_pars_fragment: gradientmap_pars_fragment,
+		lightmap_fragment: lightmap_fragment,
+		lightmap_pars_fragment: lightmap_pars_fragment,
+		lights_lambert_vertex: lights_lambert_vertex,
+		lights_pars_begin: lights_pars_begin,
+		lights_phong_fragment: lights_phong_fragment,
+		lights_phong_pars_fragment: lights_phong_pars_fragment,
+		lights_physical_fragment: lights_physical_fragment,
+		lights_physical_pars_fragment: lights_physical_pars_fragment,
+		lights_fragment_begin: lights_fragment_begin,
+		lights_fragment_maps: lights_fragment_maps,
+		lights_fragment_end: lights_fragment_end,
+		logdepthbuf_fragment: logdepthbuf_fragment,
+		logdepthbuf_pars_fragment: logdepthbuf_pars_fragment,
+		logdepthbuf_pars_vertex: logdepthbuf_pars_vertex,
+		logdepthbuf_vertex: logdepthbuf_vertex,
+		map_fragment: map_fragment,
+		map_pars_fragment: map_pars_fragment,
+		map_particle_fragment: map_particle_fragment,
+		map_particle_pars_fragment: map_particle_pars_fragment,
+		metalnessmap_fragment: metalnessmap_fragment,
+		metalnessmap_pars_fragment: metalnessmap_pars_fragment,
+		morphnormal_vertex: morphnormal_vertex,
+		morphtarget_pars_vertex: morphtarget_pars_vertex,
+		morphtarget_vertex: morphtarget_vertex,
+		normal_fragment_begin: normal_fragment_begin,
+		normal_fragment_maps: normal_fragment_maps,
+		normalmap_pars_fragment: normalmap_pars_fragment,
+		packing: packing,
+		premultiplied_alpha_fragment: premultiplied_alpha_fragment,
+		project_vertex: project_vertex,
+		dithering_fragment: dithering_fragment,
+		dithering_pars_fragment: dithering_pars_fragment,
+		roughnessmap_fragment: roughnessmap_fragment,
+		roughnessmap_pars_fragment: roughnessmap_pars_fragment,
+		shadowmap_pars_fragment: shadowmap_pars_fragment,
+		shadowmap_pars_vertex: shadowmap_pars_vertex,
+		shadowmap_vertex: shadowmap_vertex,
+		shadowmask_pars_fragment: shadowmask_pars_fragment,
+		skinbase_vertex: skinbase_vertex,
+		skinning_pars_vertex: skinning_pars_vertex,
+		skinning_vertex: skinning_vertex,
+		skinnormal_vertex: skinnormal_vertex,
+		specularmap_fragment: specularmap_fragment,
+		specularmap_pars_fragment: specularmap_pars_fragment,
+		tonemapping_fragment: tonemapping_fragment,
+		tonemapping_pars_fragment: tonemapping_pars_fragment,
+		uv_pars_fragment: uv_pars_fragment,
+		uv_pars_vertex: uv_pars_vertex,
+		uv_vertex: uv_vertex,
+		uv2_pars_fragment: uv2_pars_fragment,
+		uv2_pars_vertex: uv2_pars_vertex,
+		uv2_vertex: uv2_vertex,
+		worldpos_vertex: worldpos_vertex,
+
+		background_frag: background_frag,
+		background_vert: background_vert,
+		cube_frag: cube_frag,
+		cube_vert: cube_vert,
+		depth_frag: depth_frag,
+		depth_vert: depth_vert,
+		distanceRGBA_frag: distanceRGBA_frag,
+		distanceRGBA_vert: distanceRGBA_vert,
+		equirect_frag: equirect_frag,
+		equirect_vert: equirect_vert,
+		linedashed_frag: linedashed_frag,
+		linedashed_vert: linedashed_vert,
+		meshbasic_frag: meshbasic_frag,
+		meshbasic_vert: meshbasic_vert,
+		meshlambert_frag: meshlambert_frag,
+		meshlambert_vert: meshlambert_vert,
+		meshmatcap_frag: meshmatcap_frag,
+		meshmatcap_vert: meshmatcap_vert,
+		meshphong_frag: meshphong_frag,
+		meshphong_vert: meshphong_vert,
+		meshphysical_frag: meshphysical_frag,
+		meshphysical_vert: meshphysical_vert,
+		normal_frag: normal_frag,
+		normal_vert: normal_vert,
+		points_frag: points_frag,
+		points_vert: points_vert,
+		shadow_frag: shadow_frag,
+		shadow_vert: shadow_vert,
+		sprite_frag: sprite_frag,
+		sprite_vert: sprite_vert
+	};
+
 	/**
 	 * Uniforms library for shared webgl shaders
 	 */
@@ -14307,7 +14715,6 @@ var Spacekit = (function (exports) {
 
 			map: { value: null },
 			uvTransform: { value: new Matrix3() },
-			uv2Transform: { value: new Matrix3() },
 
 			alphaMap: { value: null },
 
@@ -14406,10 +14813,9 @@ var Spacekit = (function (exports) {
 
 			directionalLights: { value: [], properties: {
 				direction: {},
-				color: {}
-			} },
+				color: {},
 
-			directionalLightShadows: { value: [], properties: {
+				shadow: {},
 				shadowBias: {},
 				shadowRadius: {},
 				shadowMapSize: {}
@@ -14425,10 +14831,9 @@ var Spacekit = (function (exports) {
 				distance: {},
 				coneCos: {},
 				penumbraCos: {},
-				decay: {}
-			} },
+				decay: {},
 
-			spotLightShadows: { value: [], properties: {
+				shadow: {},
 				shadowBias: {},
 				shadowRadius: {},
 				shadowMapSize: {}
@@ -14441,10 +14846,9 @@ var Spacekit = (function (exports) {
 				color: {},
 				position: {},
 				decay: {},
-				distance: {}
-			} },
+				distance: {},
 
-			pointLightShadows: { value: [], properties: {
+				shadow: {},
 				shadowBias: {},
 				shadowRadius: {},
 				shadowMapSize: {},
@@ -14478,7 +14882,6 @@ var Spacekit = (function (exports) {
 			size: { value: 1.0 },
 			scale: { value: 1.0 },
 			map: { value: null },
-			alphaMap: { value: null },
 			uvTransform: { value: new Matrix3() }
 
 		},
@@ -14490,10 +14893,286 @@ var Spacekit = (function (exports) {
 			center: { value: new Vector2( 0.5, 0.5 ) },
 			rotation: { value: 0.0 },
 			map: { value: null },
-			alphaMap: { value: null },
 			uvTransform: { value: new Matrix3() }
 
 		}
+
+	};
+
+	/**
+	 * @author alteredq / http://alteredqualia.com/
+	 * @author mrdoob / http://mrdoob.com/
+	 * @author mikael emtinger / http://gomo.se/
+	 */
+
+	var ShaderLib = {
+
+		basic: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.common,
+				UniformsLib.specularmap,
+				UniformsLib.envmap,
+				UniformsLib.aomap,
+				UniformsLib.lightmap,
+				UniformsLib.fog
+			] ),
+
+			vertexShader: ShaderChunk.meshbasic_vert,
+			fragmentShader: ShaderChunk.meshbasic_frag
+
+		},
+
+		lambert: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.common,
+				UniformsLib.specularmap,
+				UniformsLib.envmap,
+				UniformsLib.aomap,
+				UniformsLib.lightmap,
+				UniformsLib.emissivemap,
+				UniformsLib.fog,
+				UniformsLib.lights,
+				{
+					emissive: { value: new Color( 0x000000 ) }
+				}
+			] ),
+
+			vertexShader: ShaderChunk.meshlambert_vert,
+			fragmentShader: ShaderChunk.meshlambert_frag
+
+		},
+
+		phong: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.common,
+				UniformsLib.specularmap,
+				UniformsLib.envmap,
+				UniformsLib.aomap,
+				UniformsLib.lightmap,
+				UniformsLib.emissivemap,
+				UniformsLib.bumpmap,
+				UniformsLib.normalmap,
+				UniformsLib.displacementmap,
+				UniformsLib.gradientmap,
+				UniformsLib.fog,
+				UniformsLib.lights,
+				{
+					emissive: { value: new Color( 0x000000 ) },
+					specular: { value: new Color( 0x111111 ) },
+					shininess: { value: 30 }
+				}
+			] ),
+
+			vertexShader: ShaderChunk.meshphong_vert,
+			fragmentShader: ShaderChunk.meshphong_frag
+
+		},
+
+		standard: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.common,
+				UniformsLib.envmap,
+				UniformsLib.aomap,
+				UniformsLib.lightmap,
+				UniformsLib.emissivemap,
+				UniformsLib.bumpmap,
+				UniformsLib.normalmap,
+				UniformsLib.displacementmap,
+				UniformsLib.roughnessmap,
+				UniformsLib.metalnessmap,
+				UniformsLib.fog,
+				UniformsLib.lights,
+				{
+					emissive: { value: new Color( 0x000000 ) },
+					roughness: { value: 0.5 },
+					metalness: { value: 0.5 },
+					envMapIntensity: { value: 1 } // temporary
+				}
+			] ),
+
+			vertexShader: ShaderChunk.meshphysical_vert,
+			fragmentShader: ShaderChunk.meshphysical_frag
+
+		},
+
+		matcap: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.common,
+				UniformsLib.bumpmap,
+				UniformsLib.normalmap,
+				UniformsLib.displacementmap,
+				UniformsLib.fog,
+				{
+					matcap: { value: null }
+				}
+			] ),
+
+			vertexShader: ShaderChunk.meshmatcap_vert,
+			fragmentShader: ShaderChunk.meshmatcap_frag
+
+		},
+
+		points: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.points,
+				UniformsLib.fog
+			] ),
+
+			vertexShader: ShaderChunk.points_vert,
+			fragmentShader: ShaderChunk.points_frag
+
+		},
+
+		dashed: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.common,
+				UniformsLib.fog,
+				{
+					scale: { value: 1 },
+					dashSize: { value: 1 },
+					totalSize: { value: 2 }
+				}
+			] ),
+
+			vertexShader: ShaderChunk.linedashed_vert,
+			fragmentShader: ShaderChunk.linedashed_frag
+
+		},
+
+		depth: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.common,
+				UniformsLib.displacementmap
+			] ),
+
+			vertexShader: ShaderChunk.depth_vert,
+			fragmentShader: ShaderChunk.depth_frag
+
+		},
+
+		normal: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.common,
+				UniformsLib.bumpmap,
+				UniformsLib.normalmap,
+				UniformsLib.displacementmap,
+				{
+					opacity: { value: 1.0 }
+				}
+			] ),
+
+			vertexShader: ShaderChunk.normal_vert,
+			fragmentShader: ShaderChunk.normal_frag
+
+		},
+
+		sprite: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.sprite,
+				UniformsLib.fog
+			] ),
+
+			vertexShader: ShaderChunk.sprite_vert,
+			fragmentShader: ShaderChunk.sprite_frag
+
+		},
+
+		background: {
+
+			uniforms: {
+				uvTransform: { value: new Matrix3() },
+				t2D: { value: null },
+			},
+
+			vertexShader: ShaderChunk.background_vert,
+			fragmentShader: ShaderChunk.background_frag
+
+		},
+		/* -------------------------------------------------------------------------
+		//	Cube map shader
+		 ------------------------------------------------------------------------- */
+
+		cube: {
+
+			uniforms: {
+				tCube: { value: null },
+				tFlip: { value: - 1 },
+				opacity: { value: 1.0 }
+			},
+
+			vertexShader: ShaderChunk.cube_vert,
+			fragmentShader: ShaderChunk.cube_frag
+
+		},
+
+		equirect: {
+
+			uniforms: {
+				tEquirect: { value: null },
+			},
+
+			vertexShader: ShaderChunk.equirect_vert,
+			fragmentShader: ShaderChunk.equirect_frag
+
+		},
+
+		distanceRGBA: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.common,
+				UniformsLib.displacementmap,
+				{
+					referencePosition: { value: new Vector3() },
+					nearDistance: { value: 1 },
+					farDistance: { value: 1000 }
+				}
+			] ),
+
+			vertexShader: ShaderChunk.distanceRGBA_vert,
+			fragmentShader: ShaderChunk.distanceRGBA_frag
+
+		},
+
+		shadow: {
+
+			uniforms: mergeUniforms( [
+				UniformsLib.lights,
+				UniformsLib.fog,
+				{
+					color: { value: new Color( 0x00000 ) },
+					opacity: { value: 1.0 }
+				},
+			] ),
+
+			vertexShader: ShaderChunk.shadow_vert,
+			fragmentShader: ShaderChunk.shadow_frag
+
+		}
+
+	};
+
+	ShaderLib.physical = {
+
+		uniforms: mergeUniforms( [
+			ShaderLib.standard.uniforms,
+			{
+				clearCoat: { value: 0 },
+				clearCoatRoughness: { value: 0 }
+			}
+		] ),
+
+		vertexShader: ShaderChunk.meshphysical_vert,
+		fragmentShader: ShaderChunk.meshphysical_frag
 
 	};
 
@@ -14556,16 +15235,14 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-	function WebGLAttributes( gl, capabilities ) {
-
-		var isWebGL2 = capabilities.isWebGL2;
+	function WebGLAttributes( gl ) {
 
 		var buffers = new WeakMap();
 
 		function createBuffer( attribute, bufferType ) {
 
 			var array = attribute.array;
-			var usage = attribute.usage;
+			var usage = attribute.dynamic ? 35048 : 35044;
 
 			var buffer = gl.createBuffer();
 
@@ -14626,25 +15303,24 @@ var Spacekit = (function (exports) {
 
 			gl.bindBuffer( bufferType, buffer );
 
-			if ( updateRange.count === - 1 ) {
+			if ( attribute.dynamic === false ) {
+
+				gl.bufferData( bufferType, array, 35044 );
+
+			} else if ( updateRange.count === - 1 ) {
 
 				// Not using update ranges
 
 				gl.bufferSubData( bufferType, 0, array );
 
+			} else if ( updateRange.count === 0 ) {
+
+				console.error( 'THREE.WebGLObjects.updateBuffer: dynamic THREE.BufferAttribute marked as needsUpdate but updateRange.count is 0, ensure you are using set methods or updating manually.' );
+
 			} else {
 
-				if ( isWebGL2 ) {
-
-					gl.bufferSubData( bufferType, updateRange.offset * array.BYTES_PER_ELEMENT,
-						array, updateRange.offset, updateRange.count );
-
-				} else {
-
-					gl.bufferSubData( bufferType, updateRange.offset * array.BYTES_PER_ELEMENT,
-						array.subarray( updateRange.offset, updateRange.offset + updateRange.count ) );
-
-				}
+				gl.bufferSubData( bufferType, updateRange.offset * array.BYTES_PER_ELEMENT,
+					array.subarray( updateRange.offset, updateRange.offset + updateRange.count ) );
 
 				updateRange.count = - 1; // reset range
 
@@ -14819,708 +15495,14 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	}
 
 	PlaneBufferGeometry.prototype = Object.create( BufferGeometry.prototype );
 	PlaneBufferGeometry.prototype.constructor = PlaneBufferGeometry;
-
-	var alphamap_fragment = "#ifdef USE_ALPHAMAP\n\tdiffuseColor.a *= texture2D( alphaMap, vUv ).g;\n#endif";
-
-	var alphamap_pars_fragment = "#ifdef USE_ALPHAMAP\n\tuniform sampler2D alphaMap;\n#endif";
-
-	var alphatest_fragment = "#ifdef ALPHATEST\n\tif ( diffuseColor.a < ALPHATEST ) discard;\n#endif";
-
-	var aomap_fragment = "#ifdef USE_AOMAP\n\tfloat ambientOcclusion = ( texture2D( aoMap, vUv2 ).r - 1.0 ) * aoMapIntensity + 1.0;\n\treflectedLight.indirectDiffuse *= ambientOcclusion;\n\t#if defined( USE_ENVMAP ) && defined( STANDARD )\n\t\tfloat dotNV = saturate( dot( geometry.normal, geometry.viewDir ) );\n\t\treflectedLight.indirectSpecular *= computeSpecularOcclusion( dotNV, ambientOcclusion, material.specularRoughness );\n\t#endif\n#endif";
-
-	var aomap_pars_fragment = "#ifdef USE_AOMAP\n\tuniform sampler2D aoMap;\n\tuniform float aoMapIntensity;\n#endif";
-
-	var begin_vertex = "vec3 transformed = vec3( position );";
-
-	var beginnormal_vertex = "vec3 objectNormal = vec3( normal );\n#ifdef USE_TANGENT\n\tvec3 objectTangent = vec3( tangent.xyz );\n#endif";
-
-	var bsdfs = "vec2 integrateSpecularBRDF( const in float dotNV, const in float roughness ) {\n\tconst vec4 c0 = vec4( - 1, - 0.0275, - 0.572, 0.022 );\n\tconst vec4 c1 = vec4( 1, 0.0425, 1.04, - 0.04 );\n\tvec4 r = roughness * c0 + c1;\n\tfloat a004 = min( r.x * r.x, exp2( - 9.28 * dotNV ) ) * r.x + r.y;\n\treturn vec2( -1.04, 1.04 ) * a004 + r.zw;\n}\nfloat punctualLightIntensityToIrradianceFactor( const in float lightDistance, const in float cutoffDistance, const in float decayExponent ) {\n#if defined ( PHYSICALLY_CORRECT_LIGHTS )\n\tfloat distanceFalloff = 1.0 / max( pow( lightDistance, decayExponent ), 0.01 );\n\tif( cutoffDistance > 0.0 ) {\n\t\tdistanceFalloff *= pow2( saturate( 1.0 - pow4( lightDistance / cutoffDistance ) ) );\n\t}\n\treturn distanceFalloff;\n#else\n\tif( cutoffDistance > 0.0 && decayExponent > 0.0 ) {\n\t\treturn pow( saturate( -lightDistance / cutoffDistance + 1.0 ), decayExponent );\n\t}\n\treturn 1.0;\n#endif\n}\nvec3 BRDF_Diffuse_Lambert( const in vec3 diffuseColor ) {\n\treturn RECIPROCAL_PI * diffuseColor;\n}\nvec3 F_Schlick( const in vec3 specularColor, const in float dotLH ) {\n\tfloat fresnel = exp2( ( -5.55473 * dotLH - 6.98316 ) * dotLH );\n\treturn ( 1.0 - specularColor ) * fresnel + specularColor;\n}\nvec3 F_Schlick_RoughnessDependent( const in vec3 F0, const in float dotNV, const in float roughness ) {\n\tfloat fresnel = exp2( ( -5.55473 * dotNV - 6.98316 ) * dotNV );\n\tvec3 Fr = max( vec3( 1.0 - roughness ), F0 ) - F0;\n\treturn Fr * fresnel + F0;\n}\nfloat G_GGX_Smith( const in float alpha, const in float dotNL, const in float dotNV ) {\n\tfloat a2 = pow2( alpha );\n\tfloat gl = dotNL + sqrt( a2 + ( 1.0 - a2 ) * pow2( dotNL ) );\n\tfloat gv = dotNV + sqrt( a2 + ( 1.0 - a2 ) * pow2( dotNV ) );\n\treturn 1.0 / ( gl * gv );\n}\nfloat G_GGX_SmithCorrelated( const in float alpha, const in float dotNL, const in float dotNV ) {\n\tfloat a2 = pow2( alpha );\n\tfloat gv = dotNL * sqrt( a2 + ( 1.0 - a2 ) * pow2( dotNV ) );\n\tfloat gl = dotNV * sqrt( a2 + ( 1.0 - a2 ) * pow2( dotNL ) );\n\treturn 0.5 / max( gv + gl, EPSILON );\n}\nfloat D_GGX( const in float alpha, const in float dotNH ) {\n\tfloat a2 = pow2( alpha );\n\tfloat denom = pow2( dotNH ) * ( a2 - 1.0 ) + 1.0;\n\treturn RECIPROCAL_PI * a2 / pow2( denom );\n}\nvec3 BRDF_Specular_GGX( const in IncidentLight incidentLight, const in vec3 viewDir, const in vec3 normal, const in vec3 specularColor, const in float roughness ) {\n\tfloat alpha = pow2( roughness );\n\tvec3 halfDir = normalize( incidentLight.direction + viewDir );\n\tfloat dotNL = saturate( dot( normal, incidentLight.direction ) );\n\tfloat dotNV = saturate( dot( normal, viewDir ) );\n\tfloat dotNH = saturate( dot( normal, halfDir ) );\n\tfloat dotLH = saturate( dot( incidentLight.direction, halfDir ) );\n\tvec3 F = F_Schlick( specularColor, dotLH );\n\tfloat G = G_GGX_SmithCorrelated( alpha, dotNL, dotNV );\n\tfloat D = D_GGX( alpha, dotNH );\n\treturn F * ( G * D );\n}\nvec2 LTC_Uv( const in vec3 N, const in vec3 V, const in float roughness ) {\n\tconst float LUT_SIZE  = 64.0;\n\tconst float LUT_SCALE = ( LUT_SIZE - 1.0 ) / LUT_SIZE;\n\tconst float LUT_BIAS  = 0.5 / LUT_SIZE;\n\tfloat dotNV = saturate( dot( N, V ) );\n\tvec2 uv = vec2( roughness, sqrt( 1.0 - dotNV ) );\n\tuv = uv * LUT_SCALE + LUT_BIAS;\n\treturn uv;\n}\nfloat LTC_ClippedSphereFormFactor( const in vec3 f ) {\n\tfloat l = length( f );\n\treturn max( ( l * l + f.z ) / ( l + 1.0 ), 0.0 );\n}\nvec3 LTC_EdgeVectorFormFactor( const in vec3 v1, const in vec3 v2 ) {\n\tfloat x = dot( v1, v2 );\n\tfloat y = abs( x );\n\tfloat a = 0.8543985 + ( 0.4965155 + 0.0145206 * y ) * y;\n\tfloat b = 3.4175940 + ( 4.1616724 + y ) * y;\n\tfloat v = a / b;\n\tfloat theta_sintheta = ( x > 0.0 ) ? v : 0.5 * inversesqrt( max( 1.0 - x * x, 1e-7 ) ) - v;\n\treturn cross( v1, v2 ) * theta_sintheta;\n}\nvec3 LTC_Evaluate( const in vec3 N, const in vec3 V, const in vec3 P, const in mat3 mInv, const in vec3 rectCoords[ 4 ] ) {\n\tvec3 v1 = rectCoords[ 1 ] - rectCoords[ 0 ];\n\tvec3 v2 = rectCoords[ 3 ] - rectCoords[ 0 ];\n\tvec3 lightNormal = cross( v1, v2 );\n\tif( dot( lightNormal, P - rectCoords[ 0 ] ) < 0.0 ) return vec3( 0.0 );\n\tvec3 T1, T2;\n\tT1 = normalize( V - N * dot( V, N ) );\n\tT2 = - cross( N, T1 );\n\tmat3 mat = mInv * transposeMat3( mat3( T1, T2, N ) );\n\tvec3 coords[ 4 ];\n\tcoords[ 0 ] = mat * ( rectCoords[ 0 ] - P );\n\tcoords[ 1 ] = mat * ( rectCoords[ 1 ] - P );\n\tcoords[ 2 ] = mat * ( rectCoords[ 2 ] - P );\n\tcoords[ 3 ] = mat * ( rectCoords[ 3 ] - P );\n\tcoords[ 0 ] = normalize( coords[ 0 ] );\n\tcoords[ 1 ] = normalize( coords[ 1 ] );\n\tcoords[ 2 ] = normalize( coords[ 2 ] );\n\tcoords[ 3 ] = normalize( coords[ 3 ] );\n\tvec3 vectorFormFactor = vec3( 0.0 );\n\tvectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 0 ], coords[ 1 ] );\n\tvectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 1 ], coords[ 2 ] );\n\tvectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 2 ], coords[ 3 ] );\n\tvectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 3 ], coords[ 0 ] );\n\tfloat result = LTC_ClippedSphereFormFactor( vectorFormFactor );\n\treturn vec3( result );\n}\nvec3 BRDF_Specular_GGX_Environment( const in vec3 viewDir, const in vec3 normal, const in vec3 specularColor, const in float roughness ) {\n\tfloat dotNV = saturate( dot( normal, viewDir ) );\n\tvec2 brdf = integrateSpecularBRDF( dotNV, roughness );\n\treturn specularColor * brdf.x + brdf.y;\n}\nvoid BRDF_Specular_Multiscattering_Environment( const in GeometricContext geometry, const in vec3 specularColor, const in float roughness, inout vec3 singleScatter, inout vec3 multiScatter ) {\n\tfloat dotNV = saturate( dot( geometry.normal, geometry.viewDir ) );\n\tvec3 F = F_Schlick_RoughnessDependent( specularColor, dotNV, roughness );\n\tvec2 brdf = integrateSpecularBRDF( dotNV, roughness );\n\tvec3 FssEss = F * brdf.x + brdf.y;\n\tfloat Ess = brdf.x + brdf.y;\n\tfloat Ems = 1.0 - Ess;\n\tvec3 Favg = specularColor + ( 1.0 - specularColor ) * 0.047619;\tvec3 Fms = FssEss * Favg / ( 1.0 - Ems * Favg );\n\tsingleScatter += FssEss;\n\tmultiScatter += Fms * Ems;\n}\nfloat G_BlinnPhong_Implicit( ) {\n\treturn 0.25;\n}\nfloat D_BlinnPhong( const in float shininess, const in float dotNH ) {\n\treturn RECIPROCAL_PI * ( shininess * 0.5 + 1.0 ) * pow( dotNH, shininess );\n}\nvec3 BRDF_Specular_BlinnPhong( const in IncidentLight incidentLight, const in GeometricContext geometry, const in vec3 specularColor, const in float shininess ) {\n\tvec3 halfDir = normalize( incidentLight.direction + geometry.viewDir );\n\tfloat dotNH = saturate( dot( geometry.normal, halfDir ) );\n\tfloat dotLH = saturate( dot( incidentLight.direction, halfDir ) );\n\tvec3 F = F_Schlick( specularColor, dotLH );\n\tfloat G = G_BlinnPhong_Implicit( );\n\tfloat D = D_BlinnPhong( shininess, dotNH );\n\treturn F * ( G * D );\n}\nfloat GGXRoughnessToBlinnExponent( const in float ggxRoughness ) {\n\treturn ( 2.0 / pow2( ggxRoughness + 0.0001 ) - 2.0 );\n}\nfloat BlinnExponentToGGXRoughness( const in float blinnExponent ) {\n\treturn sqrt( 2.0 / ( blinnExponent + 2.0 ) );\n}\n#if defined( USE_SHEEN )\nfloat D_Charlie(float roughness, float NoH) {\n\tfloat invAlpha  = 1.0 / roughness;\n\tfloat cos2h = NoH * NoH;\n\tfloat sin2h = max(1.0 - cos2h, 0.0078125);\treturn (2.0 + invAlpha) * pow(sin2h, invAlpha * 0.5) / (2.0 * PI);\n}\nfloat V_Neubelt(float NoV, float NoL) {\n\treturn saturate(1.0 / (4.0 * (NoL + NoV - NoL * NoV)));\n}\nvec3 BRDF_Specular_Sheen( const in float roughness, const in vec3 L, const in GeometricContext geometry, vec3 specularColor ) {\n\tvec3 N = geometry.normal;\n\tvec3 V = geometry.viewDir;\n\tvec3 H = normalize( V + L );\n\tfloat dotNH = saturate( dot( N, H ) );\n\treturn specularColor * D_Charlie( roughness, dotNH ) * V_Neubelt( dot(N, V), dot(N, L) );\n}\n#endif";
-
-	var bumpmap_pars_fragment = "#ifdef USE_BUMPMAP\n\tuniform sampler2D bumpMap;\n\tuniform float bumpScale;\n\tvec2 dHdxy_fwd() {\n\t\tvec2 dSTdx = dFdx( vUv );\n\t\tvec2 dSTdy = dFdy( vUv );\n\t\tfloat Hll = bumpScale * texture2D( bumpMap, vUv ).x;\n\t\tfloat dBx = bumpScale * texture2D( bumpMap, vUv + dSTdx ).x - Hll;\n\t\tfloat dBy = bumpScale * texture2D( bumpMap, vUv + dSTdy ).x - Hll;\n\t\treturn vec2( dBx, dBy );\n\t}\n\tvec3 perturbNormalArb( vec3 surf_pos, vec3 surf_norm, vec2 dHdxy ) {\n\t\tvec3 vSigmaX = vec3( dFdx( surf_pos.x ), dFdx( surf_pos.y ), dFdx( surf_pos.z ) );\n\t\tvec3 vSigmaY = vec3( dFdy( surf_pos.x ), dFdy( surf_pos.y ), dFdy( surf_pos.z ) );\n\t\tvec3 vN = surf_norm;\n\t\tvec3 R1 = cross( vSigmaY, vN );\n\t\tvec3 R2 = cross( vN, vSigmaX );\n\t\tfloat fDet = dot( vSigmaX, R1 );\n\t\tfDet *= ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t\tvec3 vGrad = sign( fDet ) * ( dHdxy.x * R1 + dHdxy.y * R2 );\n\t\treturn normalize( abs( fDet ) * surf_norm - vGrad );\n\t}\n#endif";
-
-	var clipping_planes_fragment = "#if NUM_CLIPPING_PLANES > 0\n\tvec4 plane;\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < UNION_CLIPPING_PLANES; i ++ ) {\n\t\tplane = clippingPlanes[ i ];\n\t\tif ( dot( vClipPosition, plane.xyz ) > plane.w ) discard;\n\t}\n\t#pragma unroll_loop_end\n\t#if UNION_CLIPPING_PLANES < NUM_CLIPPING_PLANES\n\t\tbool clipped = true;\n\t\t#pragma unroll_loop_start\n\t\tfor ( int i = UNION_CLIPPING_PLANES; i < NUM_CLIPPING_PLANES; i ++ ) {\n\t\t\tplane = clippingPlanes[ i ];\n\t\t\tclipped = ( dot( vClipPosition, plane.xyz ) > plane.w ) && clipped;\n\t\t}\n\t\t#pragma unroll_loop_end\n\t\tif ( clipped ) discard;\n\t#endif\n#endif";
-
-	var clipping_planes_pars_fragment = "#if NUM_CLIPPING_PLANES > 0\n\tvarying vec3 vClipPosition;\n\tuniform vec4 clippingPlanes[ NUM_CLIPPING_PLANES ];\n#endif";
-
-	var clipping_planes_pars_vertex = "#if NUM_CLIPPING_PLANES > 0\n\tvarying vec3 vClipPosition;\n#endif";
-
-	var clipping_planes_vertex = "#if NUM_CLIPPING_PLANES > 0\n\tvClipPosition = - mvPosition.xyz;\n#endif";
-
-	var color_fragment = "#ifdef USE_COLOR\n\tdiffuseColor.rgb *= vColor;\n#endif";
-
-	var color_pars_fragment = "#ifdef USE_COLOR\n\tvarying vec3 vColor;\n#endif";
-
-	var color_pars_vertex = "#ifdef USE_COLOR\n\tvarying vec3 vColor;\n#endif";
-
-	var color_vertex = "#ifdef USE_COLOR\n\tvColor.xyz = color.xyz;\n#endif";
-
-	var common = "#define PI 3.14159265359\n#define PI2 6.28318530718\n#define PI_HALF 1.5707963267949\n#define RECIPROCAL_PI 0.31830988618\n#define RECIPROCAL_PI2 0.15915494\n#define LOG2 1.442695\n#define EPSILON 1e-6\n#ifndef saturate\n#define saturate(a) clamp( a, 0.0, 1.0 )\n#endif\n#define whiteComplement(a) ( 1.0 - saturate( a ) )\nfloat pow2( const in float x ) { return x*x; }\nfloat pow3( const in float x ) { return x*x*x; }\nfloat pow4( const in float x ) { float x2 = x*x; return x2*x2; }\nfloat average( const in vec3 color ) { return dot( color, vec3( 0.3333 ) ); }\nhighp float rand( const in vec2 uv ) {\n\tconst highp float a = 12.9898, b = 78.233, c = 43758.5453;\n\thighp float dt = dot( uv.xy, vec2( a,b ) ), sn = mod( dt, PI );\n\treturn fract(sin(sn) * c);\n}\n#ifdef HIGH_PRECISION\n\tfloat precisionSafeLength( vec3 v ) { return length( v ); }\n#else\n\tfloat max3( vec3 v ) { return max( max( v.x, v.y ), v.z ); }\n\tfloat precisionSafeLength( vec3 v ) {\n\t\tfloat maxComponent = max3( abs( v ) );\n\t\treturn length( v / maxComponent ) * maxComponent;\n\t}\n#endif\nstruct IncidentLight {\n\tvec3 color;\n\tvec3 direction;\n\tbool visible;\n};\nstruct ReflectedLight {\n\tvec3 directDiffuse;\n\tvec3 directSpecular;\n\tvec3 indirectDiffuse;\n\tvec3 indirectSpecular;\n};\nstruct GeometricContext {\n\tvec3 position;\n\tvec3 normal;\n\tvec3 viewDir;\n#ifdef CLEARCOAT\n\tvec3 clearcoatNormal;\n#endif\n};\nvec3 transformDirection( in vec3 dir, in mat4 matrix ) {\n\treturn normalize( ( matrix * vec4( dir, 0.0 ) ).xyz );\n}\nvec3 inverseTransformDirection( in vec3 dir, in mat4 matrix ) {\n\treturn normalize( ( vec4( dir, 0.0 ) * matrix ).xyz );\n}\nvec3 projectOnPlane(in vec3 point, in vec3 pointOnPlane, in vec3 planeNormal ) {\n\tfloat distance = dot( planeNormal, point - pointOnPlane );\n\treturn - distance * planeNormal + point;\n}\nfloat sideOfPlane( in vec3 point, in vec3 pointOnPlane, in vec3 planeNormal ) {\n\treturn sign( dot( point - pointOnPlane, planeNormal ) );\n}\nvec3 linePlaneIntersect( in vec3 pointOnLine, in vec3 lineDirection, in vec3 pointOnPlane, in vec3 planeNormal ) {\n\treturn lineDirection * ( dot( planeNormal, pointOnPlane - pointOnLine ) / dot( planeNormal, lineDirection ) ) + pointOnLine;\n}\nmat3 transposeMat3( const in mat3 m ) {\n\tmat3 tmp;\n\ttmp[ 0 ] = vec3( m[ 0 ].x, m[ 1 ].x, m[ 2 ].x );\n\ttmp[ 1 ] = vec3( m[ 0 ].y, m[ 1 ].y, m[ 2 ].y );\n\ttmp[ 2 ] = vec3( m[ 0 ].z, m[ 1 ].z, m[ 2 ].z );\n\treturn tmp;\n}\nfloat linearToRelativeLuminance( const in vec3 color ) {\n\tvec3 weights = vec3( 0.2126, 0.7152, 0.0722 );\n\treturn dot( weights, color.rgb );\n}\nbool isPerspectiveMatrix( mat4 m ) {\n  return m[ 2 ][ 3 ] == - 1.0;\n}";
-
-	var cube_uv_reflection_fragment = "#ifdef ENVMAP_TYPE_CUBE_UV\n#define cubeUV_maxMipLevel 8.0\n#define cubeUV_minMipLevel 4.0\n#define cubeUV_maxTileSize 256.0\n#define cubeUV_minTileSize 16.0\nfloat getFace(vec3 direction) {\n    vec3 absDirection = abs(direction);\n    float face = -1.0;\n    if (absDirection.x > absDirection.z) {\n      if (absDirection.x > absDirection.y)\n        face = direction.x > 0.0 ? 0.0 : 3.0;\n      else\n        face = direction.y > 0.0 ? 1.0 : 4.0;\n    } else {\n      if (absDirection.z > absDirection.y)\n        face = direction.z > 0.0 ? 2.0 : 5.0;\n      else\n        face = direction.y > 0.0 ? 1.0 : 4.0;\n    }\n    return face;\n}\nvec2 getUV(vec3 direction, float face) {\n    vec2 uv;\n    if (face == 0.0) {\n      uv = vec2(-direction.z, direction.y) / abs(direction.x);\n    } else if (face == 1.0) {\n      uv = vec2(direction.x, -direction.z) / abs(direction.y);\n    } else if (face == 2.0) {\n      uv = direction.xy / abs(direction.z);\n    } else if (face == 3.0) {\n      uv = vec2(direction.z, direction.y) / abs(direction.x);\n    } else if (face == 4.0) {\n      uv = direction.xz / abs(direction.y);\n    } else {\n      uv = vec2(-direction.x, direction.y) / abs(direction.z);\n    }\n    return 0.5 * (uv + 1.0);\n}\nvec3 bilinearCubeUV(sampler2D envMap, vec3 direction, float mipInt) {\n  float face = getFace(direction);\n  float filterInt = max(cubeUV_minMipLevel - mipInt, 0.0);\n  mipInt = max(mipInt, cubeUV_minMipLevel);\n  float faceSize = exp2(mipInt);\n  float texelSize = 1.0 / (3.0 * cubeUV_maxTileSize);\n  vec2 uv = getUV(direction, face) * (faceSize - 1.0);\n  vec2 f = fract(uv);\n  uv += 0.5 - f;\n  if (face > 2.0) {\n    uv.y += faceSize;\n    face -= 3.0;\n  }\n  uv.x += face * faceSize;\n  if(mipInt < cubeUV_maxMipLevel){\n    uv.y += 2.0 * cubeUV_maxTileSize;\n  }\n  uv.y += filterInt * 2.0 * cubeUV_minTileSize;\n  uv.x += 3.0 * max(0.0, cubeUV_maxTileSize - 2.0 * faceSize);\n  uv *= texelSize;\n  vec3 tl = envMapTexelToLinear(texture2D(envMap, uv)).rgb;\n  uv.x += texelSize;\n  vec3 tr = envMapTexelToLinear(texture2D(envMap, uv)).rgb;\n  uv.y += texelSize;\n  vec3 br = envMapTexelToLinear(texture2D(envMap, uv)).rgb;\n  uv.x -= texelSize;\n  vec3 bl = envMapTexelToLinear(texture2D(envMap, uv)).rgb;\n  vec3 tm = mix(tl, tr, f.x);\n  vec3 bm = mix(bl, br, f.x);\n  return mix(tm, bm, f.y);\n}\n#define r0 1.0\n#define v0 0.339\n#define m0 -2.0\n#define r1 0.8\n#define v1 0.276\n#define m1 -1.0\n#define r4 0.4\n#define v4 0.046\n#define m4 2.0\n#define r5 0.305\n#define v5 0.016\n#define m5 3.0\n#define r6 0.21\n#define v6 0.0038\n#define m6 4.0\nfloat roughnessToMip(float roughness) {\n  float mip = 0.0;\n  if (roughness >= r1) {\n    mip = (r0 - roughness) * (m1 - m0) / (r0 - r1) + m0;\n  } else if (roughness >= r4) {\n    mip = (r1 - roughness) * (m4 - m1) / (r1 - r4) + m1;\n  } else if (roughness >= r5) {\n    mip = (r4 - roughness) * (m5 - m4) / (r4 - r5) + m4;\n  } else if (roughness >= r6) {\n    mip = (r5 - roughness) * (m6 - m5) / (r5 - r6) + m5;\n  } else {\n    mip = -2.0 * log2(1.16 * roughness);  }\n  return mip;\n}\nvec4 textureCubeUV(sampler2D envMap, vec3 sampleDir, float roughness) {\n  float mip = clamp(roughnessToMip(roughness), m0, cubeUV_maxMipLevel);\n  float mipF = fract(mip);\n  float mipInt = floor(mip);\n  vec3 color0 = bilinearCubeUV(envMap, sampleDir, mipInt);\n  if (mipF == 0.0) {\n    return vec4(color0, 1.0);\n  } else {\n    vec3 color1 = bilinearCubeUV(envMap, sampleDir, mipInt + 1.0);\n    return vec4(mix(color0, color1, mipF), 1.0);\n  }\n}\n#endif";
-
-	var defaultnormal_vertex = "vec3 transformedNormal = objectNormal;\n#ifdef USE_INSTANCING\n\tmat3 m = mat3( instanceMatrix );\n\ttransformedNormal /= vec3( dot( m[ 0 ], m[ 0 ] ), dot( m[ 1 ], m[ 1 ] ), dot( m[ 2 ], m[ 2 ] ) );\n\ttransformedNormal = m * transformedNormal;\n#endif\ntransformedNormal = normalMatrix * transformedNormal;\n#ifdef FLIP_SIDED\n\ttransformedNormal = - transformedNormal;\n#endif\n#ifdef USE_TANGENT\n\tvec3 transformedTangent = ( modelViewMatrix * vec4( objectTangent, 0.0 ) ).xyz;\n\t#ifdef FLIP_SIDED\n\t\ttransformedTangent = - transformedTangent;\n\t#endif\n#endif";
-
-	var displacementmap_pars_vertex = "#ifdef USE_DISPLACEMENTMAP\n\tuniform sampler2D displacementMap;\n\tuniform float displacementScale;\n\tuniform float displacementBias;\n#endif";
-
-	var displacementmap_vertex = "#ifdef USE_DISPLACEMENTMAP\n\ttransformed += normalize( objectNormal ) * ( texture2D( displacementMap, vUv ).x * displacementScale + displacementBias );\n#endif";
-
-	var emissivemap_fragment = "#ifdef USE_EMISSIVEMAP\n\tvec4 emissiveColor = texture2D( emissiveMap, vUv );\n\temissiveColor.rgb = emissiveMapTexelToLinear( emissiveColor ).rgb;\n\ttotalEmissiveRadiance *= emissiveColor.rgb;\n#endif";
-
-	var emissivemap_pars_fragment = "#ifdef USE_EMISSIVEMAP\n\tuniform sampler2D emissiveMap;\n#endif";
-
-	var encodings_fragment = "gl_FragColor = linearToOutputTexel( gl_FragColor );";
-
-	var encodings_pars_fragment = "\nvec4 LinearToLinear( in vec4 value ) {\n\treturn value;\n}\nvec4 GammaToLinear( in vec4 value, in float gammaFactor ) {\n\treturn vec4( pow( value.rgb, vec3( gammaFactor ) ), value.a );\n}\nvec4 LinearToGamma( in vec4 value, in float gammaFactor ) {\n\treturn vec4( pow( value.rgb, vec3( 1.0 / gammaFactor ) ), value.a );\n}\nvec4 sRGBToLinear( in vec4 value ) {\n\treturn vec4( mix( pow( value.rgb * 0.9478672986 + vec3( 0.0521327014 ), vec3( 2.4 ) ), value.rgb * 0.0773993808, vec3( lessThanEqual( value.rgb, vec3( 0.04045 ) ) ) ), value.a );\n}\nvec4 LinearTosRGB( in vec4 value ) {\n\treturn vec4( mix( pow( value.rgb, vec3( 0.41666 ) ) * 1.055 - vec3( 0.055 ), value.rgb * 12.92, vec3( lessThanEqual( value.rgb, vec3( 0.0031308 ) ) ) ), value.a );\n}\nvec4 RGBEToLinear( in vec4 value ) {\n\treturn vec4( value.rgb * exp2( value.a * 255.0 - 128.0 ), 1.0 );\n}\nvec4 LinearToRGBE( in vec4 value ) {\n\tfloat maxComponent = max( max( value.r, value.g ), value.b );\n\tfloat fExp = clamp( ceil( log2( maxComponent ) ), -128.0, 127.0 );\n\treturn vec4( value.rgb / exp2( fExp ), ( fExp + 128.0 ) / 255.0 );\n}\nvec4 RGBMToLinear( in vec4 value, in float maxRange ) {\n\treturn vec4( value.rgb * value.a * maxRange, 1.0 );\n}\nvec4 LinearToRGBM( in vec4 value, in float maxRange ) {\n\tfloat maxRGB = max( value.r, max( value.g, value.b ) );\n\tfloat M = clamp( maxRGB / maxRange, 0.0, 1.0 );\n\tM = ceil( M * 255.0 ) / 255.0;\n\treturn vec4( value.rgb / ( M * maxRange ), M );\n}\nvec4 RGBDToLinear( in vec4 value, in float maxRange ) {\n\treturn vec4( value.rgb * ( ( maxRange / 255.0 ) / value.a ), 1.0 );\n}\nvec4 LinearToRGBD( in vec4 value, in float maxRange ) {\n\tfloat maxRGB = max( value.r, max( value.g, value.b ) );\n\tfloat D = max( maxRange / maxRGB, 1.0 );\n\tD = clamp( floor( D ) / 255.0, 0.0, 1.0 );\n\treturn vec4( value.rgb * ( D * ( 255.0 / maxRange ) ), D );\n}\nconst mat3 cLogLuvM = mat3( 0.2209, 0.3390, 0.4184, 0.1138, 0.6780, 0.7319, 0.0102, 0.1130, 0.2969 );\nvec4 LinearToLogLuv( in vec4 value )  {\n\tvec3 Xp_Y_XYZp = cLogLuvM * value.rgb;\n\tXp_Y_XYZp = max( Xp_Y_XYZp, vec3( 1e-6, 1e-6, 1e-6 ) );\n\tvec4 vResult;\n\tvResult.xy = Xp_Y_XYZp.xy / Xp_Y_XYZp.z;\n\tfloat Le = 2.0 * log2(Xp_Y_XYZp.y) + 127.0;\n\tvResult.w = fract( Le );\n\tvResult.z = ( Le - ( floor( vResult.w * 255.0 ) ) / 255.0 ) / 255.0;\n\treturn vResult;\n}\nconst mat3 cLogLuvInverseM = mat3( 6.0014, -2.7008, -1.7996, -1.3320, 3.1029, -5.7721, 0.3008, -1.0882, 5.6268 );\nvec4 LogLuvToLinear( in vec4 value ) {\n\tfloat Le = value.z * 255.0 + value.w;\n\tvec3 Xp_Y_XYZp;\n\tXp_Y_XYZp.y = exp2( ( Le - 127.0 ) / 2.0 );\n\tXp_Y_XYZp.z = Xp_Y_XYZp.y / value.y;\n\tXp_Y_XYZp.x = value.x * Xp_Y_XYZp.z;\n\tvec3 vRGB = cLogLuvInverseM * Xp_Y_XYZp.rgb;\n\treturn vec4( max( vRGB, 0.0 ), 1.0 );\n}";
-
-	var envmap_fragment = "#ifdef USE_ENVMAP\n\t#ifdef ENV_WORLDPOS\n\t\tvec3 cameraToFrag;\n\t\t\n\t\tif ( isOrthographic ) {\n\t\t\tcameraToFrag = normalize( vec3( - viewMatrix[ 0 ][ 2 ], - viewMatrix[ 1 ][ 2 ], - viewMatrix[ 2 ][ 2 ] ) );\n\t\t}  else {\n\t\t\tcameraToFrag = normalize( vWorldPosition - cameraPosition );\n\t\t}\n\t\tvec3 worldNormal = inverseTransformDirection( normal, viewMatrix );\n\t\t#ifdef ENVMAP_MODE_REFLECTION\n\t\t\tvec3 reflectVec = reflect( cameraToFrag, worldNormal );\n\t\t#else\n\t\t\tvec3 reflectVec = refract( cameraToFrag, worldNormal, refractionRatio );\n\t\t#endif\n\t#else\n\t\tvec3 reflectVec = vReflect;\n\t#endif\n\t#ifdef ENVMAP_TYPE_CUBE\n\t\tvec4 envColor = textureCube( envMap, vec3( flipEnvMap * reflectVec.x, reflectVec.yz ) );\n\t#elif defined( ENVMAP_TYPE_CUBE_UV )\n\t\tvec4 envColor = textureCubeUV( envMap, reflectVec, 0.0 );\n\t#elif defined( ENVMAP_TYPE_EQUIREC )\n\t\tvec2 sampleUV;\n\t\treflectVec = normalize( reflectVec );\n\t\tsampleUV.y = asin( clamp( reflectVec.y, - 1.0, 1.0 ) ) * RECIPROCAL_PI + 0.5;\n\t\tsampleUV.x = atan( reflectVec.z, reflectVec.x ) * RECIPROCAL_PI2 + 0.5;\n\t\tvec4 envColor = texture2D( envMap, sampleUV );\n\t#elif defined( ENVMAP_TYPE_SPHERE )\n\t\treflectVec = normalize( reflectVec );\n\t\tvec3 reflectView = normalize( ( viewMatrix * vec4( reflectVec, 0.0 ) ).xyz + vec3( 0.0, 0.0, 1.0 ) );\n\t\tvec4 envColor = texture2D( envMap, reflectView.xy * 0.5 + 0.5 );\n\t#else\n\t\tvec4 envColor = vec4( 0.0 );\n\t#endif\n\t#ifndef ENVMAP_TYPE_CUBE_UV\n\t\tenvColor = envMapTexelToLinear( envColor );\n\t#endif\n\t#ifdef ENVMAP_BLENDING_MULTIPLY\n\t\toutgoingLight = mix( outgoingLight, outgoingLight * envColor.xyz, specularStrength * reflectivity );\n\t#elif defined( ENVMAP_BLENDING_MIX )\n\t\toutgoingLight = mix( outgoingLight, envColor.xyz, specularStrength * reflectivity );\n\t#elif defined( ENVMAP_BLENDING_ADD )\n\t\toutgoingLight += envColor.xyz * specularStrength * reflectivity;\n\t#endif\n#endif";
-
-	var envmap_common_pars_fragment = "#ifdef USE_ENVMAP\n\tuniform float envMapIntensity;\n\tuniform float flipEnvMap;\n\tuniform int maxMipLevel;\n\t#ifdef ENVMAP_TYPE_CUBE\n\t\tuniform samplerCube envMap;\n\t#else\n\t\tuniform sampler2D envMap;\n\t#endif\n\t\n#endif";
-
-	var envmap_pars_fragment = "#ifdef USE_ENVMAP\n\tuniform float reflectivity;\n\t#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG )\n\t\t#define ENV_WORLDPOS\n\t#endif\n\t#ifdef ENV_WORLDPOS\n\t\tvarying vec3 vWorldPosition;\n\t\tuniform float refractionRatio;\n\t#else\n\t\tvarying vec3 vReflect;\n\t#endif\n#endif";
-
-	var envmap_pars_vertex = "#ifdef USE_ENVMAP\n\t#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) ||defined( PHONG )\n\t\t#define ENV_WORLDPOS\n\t#endif\n\t#ifdef ENV_WORLDPOS\n\t\t\n\t\tvarying vec3 vWorldPosition;\n\t#else\n\t\tvarying vec3 vReflect;\n\t\tuniform float refractionRatio;\n\t#endif\n#endif";
-
-	var envmap_vertex = "#ifdef USE_ENVMAP\n\t#ifdef ENV_WORLDPOS\n\t\tvWorldPosition = worldPosition.xyz;\n\t#else\n\t\tvec3 cameraToVertex;\n\t\tif ( isOrthographic ) { \n\t\t\tcameraToVertex = normalize( vec3( - viewMatrix[ 0 ][ 2 ], - viewMatrix[ 1 ][ 2 ], - viewMatrix[ 2 ][ 2 ] ) );\n\t\t} else {\n\t\t\tcameraToVertex = normalize( worldPosition.xyz - cameraPosition );\n\t\t}\n\t\tvec3 worldNormal = inverseTransformDirection( transformedNormal, viewMatrix );\n\t\t#ifdef ENVMAP_MODE_REFLECTION\n\t\t\tvReflect = reflect( cameraToVertex, worldNormal );\n\t\t#else\n\t\t\tvReflect = refract( cameraToVertex, worldNormal, refractionRatio );\n\t\t#endif\n\t#endif\n#endif";
-
-	var fog_vertex = "#ifdef USE_FOG\n\tfogDepth = -mvPosition.z;\n#endif";
-
-	var fog_pars_vertex = "#ifdef USE_FOG\n\tvarying float fogDepth;\n#endif";
-
-	var fog_fragment = "#ifdef USE_FOG\n\t#ifdef FOG_EXP2\n\t\tfloat fogFactor = 1.0 - exp( - fogDensity * fogDensity * fogDepth * fogDepth );\n\t#else\n\t\tfloat fogFactor = smoothstep( fogNear, fogFar, fogDepth );\n\t#endif\n\tgl_FragColor.rgb = mix( gl_FragColor.rgb, fogColor, fogFactor );\n#endif";
-
-	var fog_pars_fragment = "#ifdef USE_FOG\n\tuniform vec3 fogColor;\n\tvarying float fogDepth;\n\t#ifdef FOG_EXP2\n\t\tuniform float fogDensity;\n\t#else\n\t\tuniform float fogNear;\n\t\tuniform float fogFar;\n\t#endif\n#endif";
-
-	var gradientmap_pars_fragment = "#ifdef USE_GRADIENTMAP\n\tuniform sampler2D gradientMap;\n#endif\nvec3 getGradientIrradiance( vec3 normal, vec3 lightDirection ) {\n\tfloat dotNL = dot( normal, lightDirection );\n\tvec2 coord = vec2( dotNL * 0.5 + 0.5, 0.0 );\n\t#ifdef USE_GRADIENTMAP\n\t\treturn texture2D( gradientMap, coord ).rgb;\n\t#else\n\t\treturn ( coord.x < 0.7 ) ? vec3( 0.7 ) : vec3( 1.0 );\n\t#endif\n}";
-
-	var lightmap_fragment = "#ifdef USE_LIGHTMAP\n\tvec4 lightMapTexel= texture2D( lightMap, vUv2 );\n\treflectedLight.indirectDiffuse += PI * lightMapTexelToLinear( lightMapTexel ).rgb * lightMapIntensity;\n#endif";
-
-	var lightmap_pars_fragment = "#ifdef USE_LIGHTMAP\n\tuniform sampler2D lightMap;\n\tuniform float lightMapIntensity;\n#endif";
-
-	var lights_lambert_vertex = "vec3 diffuse = vec3( 1.0 );\nGeometricContext geometry;\ngeometry.position = mvPosition.xyz;\ngeometry.normal = normalize( transformedNormal );\ngeometry.viewDir = ( isOrthographic ) ? vec3( 0, 0, 1 ) : normalize( -mvPosition.xyz );\nGeometricContext backGeometry;\nbackGeometry.position = geometry.position;\nbackGeometry.normal = -geometry.normal;\nbackGeometry.viewDir = geometry.viewDir;\nvLightFront = vec3( 0.0 );\nvIndirectFront = vec3( 0.0 );\n#ifdef DOUBLE_SIDED\n\tvLightBack = vec3( 0.0 );\n\tvIndirectBack = vec3( 0.0 );\n#endif\nIncidentLight directLight;\nfloat dotNL;\nvec3 directLightColor_Diffuse;\nvIndirectFront += getAmbientLightIrradiance( ambientLightColor );\nvIndirectFront += getLightProbeIrradiance( lightProbe, geometry );\n#ifdef DOUBLE_SIDED\n\tvIndirectBack += getAmbientLightIrradiance( ambientLightColor );\n\tvIndirectBack += getLightProbeIrradiance( lightProbe, backGeometry );\n#endif\n#if NUM_POINT_LIGHTS > 0\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {\n\t\tgetPointDirectLightIrradiance( pointLights[ i ], geometry, directLight );\n\t\tdotNL = dot( geometry.normal, directLight.direction );\n\t\tdirectLightColor_Diffuse = PI * directLight.color;\n\t\tvLightFront += saturate( dotNL ) * directLightColor_Diffuse;\n\t\t#ifdef DOUBLE_SIDED\n\t\t\tvLightBack += saturate( -dotNL ) * directLightColor_Diffuse;\n\t\t#endif\n\t}\n\t#pragma unroll_loop_end\n#endif\n#if NUM_SPOT_LIGHTS > 0\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {\n\t\tgetSpotDirectLightIrradiance( spotLights[ i ], geometry, directLight );\n\t\tdotNL = dot( geometry.normal, directLight.direction );\n\t\tdirectLightColor_Diffuse = PI * directLight.color;\n\t\tvLightFront += saturate( dotNL ) * directLightColor_Diffuse;\n\t\t#ifdef DOUBLE_SIDED\n\t\t\tvLightBack += saturate( -dotNL ) * directLightColor_Diffuse;\n\t\t#endif\n\t}\n\t#pragma unroll_loop_end\n#endif\n#if NUM_DIR_LIGHTS > 0\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {\n\t\tgetDirectionalDirectLightIrradiance( directionalLights[ i ], geometry, directLight );\n\t\tdotNL = dot( geometry.normal, directLight.direction );\n\t\tdirectLightColor_Diffuse = PI * directLight.color;\n\t\tvLightFront += saturate( dotNL ) * directLightColor_Diffuse;\n\t\t#ifdef DOUBLE_SIDED\n\t\t\tvLightBack += saturate( -dotNL ) * directLightColor_Diffuse;\n\t\t#endif\n\t}\n\t#pragma unroll_loop_end\n#endif\n#if NUM_HEMI_LIGHTS > 0\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {\n\t\tvIndirectFront += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );\n\t\t#ifdef DOUBLE_SIDED\n\t\t\tvIndirectBack += getHemisphereLightIrradiance( hemisphereLights[ i ], backGeometry );\n\t\t#endif\n\t}\n\t#pragma unroll_loop_end\n#endif";
-
-	var lights_pars_begin = "uniform bool receiveShadow;\nuniform vec3 ambientLightColor;\nuniform vec3 lightProbe[ 9 ];\nvec3 shGetIrradianceAt( in vec3 normal, in vec3 shCoefficients[ 9 ] ) {\n\tfloat x = normal.x, y = normal.y, z = normal.z;\n\tvec3 result = shCoefficients[ 0 ] * 0.886227;\n\tresult += shCoefficients[ 1 ] * 2.0 * 0.511664 * y;\n\tresult += shCoefficients[ 2 ] * 2.0 * 0.511664 * z;\n\tresult += shCoefficients[ 3 ] * 2.0 * 0.511664 * x;\n\tresult += shCoefficients[ 4 ] * 2.0 * 0.429043 * x * y;\n\tresult += shCoefficients[ 5 ] * 2.0 * 0.429043 * y * z;\n\tresult += shCoefficients[ 6 ] * ( 0.743125 * z * z - 0.247708 );\n\tresult += shCoefficients[ 7 ] * 2.0 * 0.429043 * x * z;\n\tresult += shCoefficients[ 8 ] * 0.429043 * ( x * x - y * y );\n\treturn result;\n}\nvec3 getLightProbeIrradiance( const in vec3 lightProbe[ 9 ], const in GeometricContext geometry ) {\n\tvec3 worldNormal = inverseTransformDirection( geometry.normal, viewMatrix );\n\tvec3 irradiance = shGetIrradianceAt( worldNormal, lightProbe );\n\treturn irradiance;\n}\nvec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {\n\tvec3 irradiance = ambientLightColor;\n\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\tirradiance *= PI;\n\t#endif\n\treturn irradiance;\n}\n#if NUM_DIR_LIGHTS > 0\n\tstruct DirectionalLight {\n\t\tvec3 direction;\n\t\tvec3 color;\n\t};\n\tuniform DirectionalLight directionalLights[ NUM_DIR_LIGHTS ];\n\t#if defined( USE_SHADOWMAP ) && NUM_DIR_LIGHT_SHADOWS > 0\n\t\tstruct DirectionalLightShadow {\n\t\t\tfloat shadowBias;\n\t\t\tfloat shadowRadius;\n\t\t\tvec2 shadowMapSize;\n\t\t};\n\t\tuniform DirectionalLightShadow directionalLightShadows[ NUM_DIR_LIGHT_SHADOWS ];\n\t#endif\n\tvoid getDirectionalDirectLightIrradiance( const in DirectionalLight directionalLight, const in GeometricContext geometry, out IncidentLight directLight ) {\n\t\tdirectLight.color = directionalLight.color;\n\t\tdirectLight.direction = directionalLight.direction;\n\t\tdirectLight.visible = true;\n\t}\n#endif\n#if NUM_POINT_LIGHTS > 0\n\tstruct PointLight {\n\t\tvec3 position;\n\t\tvec3 color;\n\t\tfloat distance;\n\t\tfloat decay;\n\t};\n\tuniform PointLight pointLights[ NUM_POINT_LIGHTS ];\n\t#if defined( USE_SHADOWMAP ) && NUM_POINT_LIGHT_SHADOWS > 0\n\t\tstruct PointLightShadow {\n\t\t\tfloat shadowBias;\n\t\t\tfloat shadowRadius;\n\t\t\tvec2 shadowMapSize;\n\t\t\tfloat shadowCameraNear;\n\t\t\tfloat shadowCameraFar;\n\t\t};\n\t\tuniform PointLightShadow pointLightShadows[ NUM_POINT_LIGHT_SHADOWS ];\n\t#endif\n\tvoid getPointDirectLightIrradiance( const in PointLight pointLight, const in GeometricContext geometry, out IncidentLight directLight ) {\n\t\tvec3 lVector = pointLight.position - geometry.position;\n\t\tdirectLight.direction = normalize( lVector );\n\t\tfloat lightDistance = length( lVector );\n\t\tdirectLight.color = pointLight.color;\n\t\tdirectLight.color *= punctualLightIntensityToIrradianceFactor( lightDistance, pointLight.distance, pointLight.decay );\n\t\tdirectLight.visible = ( directLight.color != vec3( 0.0 ) );\n\t}\n#endif\n#if NUM_SPOT_LIGHTS > 0\n\tstruct SpotLight {\n\t\tvec3 position;\n\t\tvec3 direction;\n\t\tvec3 color;\n\t\tfloat distance;\n\t\tfloat decay;\n\t\tfloat coneCos;\n\t\tfloat penumbraCos;\n\t};\n\tuniform SpotLight spotLights[ NUM_SPOT_LIGHTS ];\n\t#if defined( USE_SHADOWMAP ) && NUM_SPOT_LIGHT_SHADOWS > 0\n\t\tstruct SpotLightShadow {\n\t\t\tfloat shadowBias;\n\t\t\tfloat shadowRadius;\n\t\t\tvec2 shadowMapSize;\n\t\t};\n\t\tuniform SpotLightShadow spotLightShadows[ NUM_SPOT_LIGHT_SHADOWS ];\n\t#endif\n\tvoid getSpotDirectLightIrradiance( const in SpotLight spotLight, const in GeometricContext geometry, out IncidentLight directLight  ) {\n\t\tvec3 lVector = spotLight.position - geometry.position;\n\t\tdirectLight.direction = normalize( lVector );\n\t\tfloat lightDistance = length( lVector );\n\t\tfloat angleCos = dot( directLight.direction, spotLight.direction );\n\t\tif ( angleCos > spotLight.coneCos ) {\n\t\t\tfloat spotEffect = smoothstep( spotLight.coneCos, spotLight.penumbraCos, angleCos );\n\t\t\tdirectLight.color = spotLight.color;\n\t\t\tdirectLight.color *= spotEffect * punctualLightIntensityToIrradianceFactor( lightDistance, spotLight.distance, spotLight.decay );\n\t\t\tdirectLight.visible = true;\n\t\t} else {\n\t\t\tdirectLight.color = vec3( 0.0 );\n\t\t\tdirectLight.visible = false;\n\t\t}\n\t}\n#endif\n#if NUM_RECT_AREA_LIGHTS > 0\n\tstruct RectAreaLight {\n\t\tvec3 color;\n\t\tvec3 position;\n\t\tvec3 halfWidth;\n\t\tvec3 halfHeight;\n\t};\n\tuniform sampler2D ltc_1;\tuniform sampler2D ltc_2;\n\tuniform RectAreaLight rectAreaLights[ NUM_RECT_AREA_LIGHTS ];\n#endif\n#if NUM_HEMI_LIGHTS > 0\n\tstruct HemisphereLight {\n\t\tvec3 direction;\n\t\tvec3 skyColor;\n\t\tvec3 groundColor;\n\t};\n\tuniform HemisphereLight hemisphereLights[ NUM_HEMI_LIGHTS ];\n\tvec3 getHemisphereLightIrradiance( const in HemisphereLight hemiLight, const in GeometricContext geometry ) {\n\t\tfloat dotNL = dot( geometry.normal, hemiLight.direction );\n\t\tfloat hemiDiffuseWeight = 0.5 * dotNL + 0.5;\n\t\tvec3 irradiance = mix( hemiLight.groundColor, hemiLight.skyColor, hemiDiffuseWeight );\n\t\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\t\tirradiance *= PI;\n\t\t#endif\n\t\treturn irradiance;\n\t}\n#endif";
-
-	var envmap_physical_pars_fragment = "#if defined( USE_ENVMAP )\n\t#ifdef ENVMAP_MODE_REFRACTION\n\t\tuniform float refractionRatio;\n\t#endif\n\tvec3 getLightProbeIndirectIrradiance( const in GeometricContext geometry, const in int maxMIPLevel ) {\n\t\tvec3 worldNormal = inverseTransformDirection( geometry.normal, viewMatrix );\n\t\t#ifdef ENVMAP_TYPE_CUBE\n\t\t\tvec3 queryVec = vec3( flipEnvMap * worldNormal.x, worldNormal.yz );\n\t\t\t#ifdef TEXTURE_LOD_EXT\n\t\t\t\tvec4 envMapColor = textureCubeLodEXT( envMap, queryVec, float( maxMIPLevel ) );\n\t\t\t#else\n\t\t\t\tvec4 envMapColor = textureCube( envMap, queryVec, float( maxMIPLevel ) );\n\t\t\t#endif\n\t\t\tenvMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;\n\t\t#elif defined( ENVMAP_TYPE_CUBE_UV )\n\t\t\tvec4 envMapColor = textureCubeUV( envMap, worldNormal, 1.0 );\n\t\t#else\n\t\t\tvec4 envMapColor = vec4( 0.0 );\n\t\t#endif\n\t\treturn PI * envMapColor.rgb * envMapIntensity;\n\t}\n\tfloat getSpecularMIPLevel( const in float roughness, const in int maxMIPLevel ) {\n\t\tfloat maxMIPLevelScalar = float( maxMIPLevel );\n\t\tfloat sigma = PI * roughness * roughness / ( 1.0 + roughness );\n\t\tfloat desiredMIPLevel = maxMIPLevelScalar + log2( sigma );\n\t\treturn clamp( desiredMIPLevel, 0.0, maxMIPLevelScalar );\n\t}\n\tvec3 getLightProbeIndirectRadiance( const in vec3 viewDir, const in vec3 normal, const in float roughness, const in int maxMIPLevel ) {\n\t\t#ifdef ENVMAP_MODE_REFLECTION\n\t\t  vec3 reflectVec = reflect( -viewDir, normal );\n\t\t  reflectVec = normalize( mix( reflectVec, normal, roughness * roughness) );\n\t\t#else\n\t\t  vec3 reflectVec = refract( -viewDir, normal, refractionRatio );\n\t\t#endif\n\t\treflectVec = inverseTransformDirection( reflectVec, viewMatrix );\n\t\tfloat specularMIPLevel = getSpecularMIPLevel( roughness, maxMIPLevel );\n\t\t#ifdef ENVMAP_TYPE_CUBE\n\t\t\tvec3 queryReflectVec = vec3( flipEnvMap * reflectVec.x, reflectVec.yz );\n\t\t\t#ifdef TEXTURE_LOD_EXT\n\t\t\t\tvec4 envMapColor = textureCubeLodEXT( envMap, queryReflectVec, specularMIPLevel );\n\t\t\t#else\n\t\t\t\tvec4 envMapColor = textureCube( envMap, queryReflectVec, specularMIPLevel );\n\t\t\t#endif\n\t\t\tenvMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;\n\t\t#elif defined( ENVMAP_TYPE_CUBE_UV )\n\t\t\tvec4 envMapColor = textureCubeUV( envMap, reflectVec, roughness );\n\t\t#elif defined( ENVMAP_TYPE_EQUIREC )\n\t\t\tvec2 sampleUV;\n\t\t\tsampleUV.y = asin( clamp( reflectVec.y, - 1.0, 1.0 ) ) * RECIPROCAL_PI + 0.5;\n\t\t\tsampleUV.x = atan( reflectVec.z, reflectVec.x ) * RECIPROCAL_PI2 + 0.5;\n\t\t\t#ifdef TEXTURE_LOD_EXT\n\t\t\t\tvec4 envMapColor = texture2DLodEXT( envMap, sampleUV, specularMIPLevel );\n\t\t\t#else\n\t\t\t\tvec4 envMapColor = texture2D( envMap, sampleUV, specularMIPLevel );\n\t\t\t#endif\n\t\t\tenvMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;\n\t\t#elif defined( ENVMAP_TYPE_SPHERE )\n\t\t\tvec3 reflectView = normalize( ( viewMatrix * vec4( reflectVec, 0.0 ) ).xyz + vec3( 0.0,0.0,1.0 ) );\n\t\t\t#ifdef TEXTURE_LOD_EXT\n\t\t\t\tvec4 envMapColor = texture2DLodEXT( envMap, reflectView.xy * 0.5 + 0.5, specularMIPLevel );\n\t\t\t#else\n\t\t\t\tvec4 envMapColor = texture2D( envMap, reflectView.xy * 0.5 + 0.5, specularMIPLevel );\n\t\t\t#endif\n\t\t\tenvMapColor.rgb = envMapTexelToLinear( envMapColor ).rgb;\n\t\t#endif\n\t\treturn envMapColor.rgb * envMapIntensity;\n\t}\n#endif";
-
-	var lights_toon_fragment = "ToonMaterial material;\nmaterial.diffuseColor = diffuseColor.rgb;\nmaterial.specularColor = specular;\nmaterial.specularShininess = shininess;\nmaterial.specularStrength = specularStrength;";
-
-	var lights_toon_pars_fragment = "varying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\nstruct ToonMaterial {\n\tvec3\tdiffuseColor;\n\tvec3\tspecularColor;\n\tfloat\tspecularShininess;\n\tfloat\tspecularStrength;\n};\nvoid RE_Direct_Toon( const in IncidentLight directLight, const in GeometricContext geometry, const in ToonMaterial material, inout ReflectedLight reflectedLight ) {\n\tvec3 irradiance = getGradientIrradiance( geometry.normal, directLight.direction ) * directLight.color;\n\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\tirradiance *= PI;\n\t#endif\n\treflectedLight.directDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );\n\treflectedLight.directSpecular += irradiance * BRDF_Specular_BlinnPhong( directLight, geometry, material.specularColor, material.specularShininess ) * material.specularStrength;\n}\nvoid RE_IndirectDiffuse_Toon( const in vec3 irradiance, const in GeometricContext geometry, const in ToonMaterial material, inout ReflectedLight reflectedLight ) {\n\treflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );\n}\n#define RE_Direct\t\t\t\tRE_Direct_Toon\n#define RE_IndirectDiffuse\t\tRE_IndirectDiffuse_Toon\n#define Material_LightProbeLOD( material )\t(0)";
-
-	var lights_phong_fragment = "BlinnPhongMaterial material;\nmaterial.diffuseColor = diffuseColor.rgb;\nmaterial.specularColor = specular;\nmaterial.specularShininess = shininess;\nmaterial.specularStrength = specularStrength;";
-
-	var lights_phong_pars_fragment = "varying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\nstruct BlinnPhongMaterial {\n\tvec3\tdiffuseColor;\n\tvec3\tspecularColor;\n\tfloat\tspecularShininess;\n\tfloat\tspecularStrength;\n};\nvoid RE_Direct_BlinnPhong( const in IncidentLight directLight, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {\n\tfloat dotNL = saturate( dot( geometry.normal, directLight.direction ) );\n\tvec3 irradiance = dotNL * directLight.color;\n\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\tirradiance *= PI;\n\t#endif\n\treflectedLight.directDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );\n\treflectedLight.directSpecular += irradiance * BRDF_Specular_BlinnPhong( directLight, geometry, material.specularColor, material.specularShininess ) * material.specularStrength;\n}\nvoid RE_IndirectDiffuse_BlinnPhong( const in vec3 irradiance, const in GeometricContext geometry, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {\n\treflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );\n}\n#define RE_Direct\t\t\t\tRE_Direct_BlinnPhong\n#define RE_IndirectDiffuse\t\tRE_IndirectDiffuse_BlinnPhong\n#define Material_LightProbeLOD( material )\t(0)";
-
-	var lights_physical_fragment = "PhysicalMaterial material;\nmaterial.diffuseColor = diffuseColor.rgb * ( 1.0 - metalnessFactor );\nvec3 dxy = max( abs( dFdx( geometryNormal ) ), abs( dFdy( geometryNormal ) ) );\nfloat geometryRoughness = max( max( dxy.x, dxy.y ), dxy.z );\nmaterial.specularRoughness = max( roughnessFactor, 0.0525 );material.specularRoughness += geometryRoughness;\nmaterial.specularRoughness = min( material.specularRoughness, 1.0 );\n#ifdef REFLECTIVITY\n\tmaterial.specularColor = mix( vec3( MAXIMUM_SPECULAR_COEFFICIENT * pow2( reflectivity ) ), diffuseColor.rgb, metalnessFactor );\n#else\n\tmaterial.specularColor = mix( vec3( DEFAULT_SPECULAR_COEFFICIENT ), diffuseColor.rgb, metalnessFactor );\n#endif\n#ifdef CLEARCOAT\n\tmaterial.clearcoat = clearcoat;\n\tmaterial.clearcoatRoughness = clearcoatRoughness;\n\t#ifdef USE_CLEARCOATMAP\n\t\tmaterial.clearcoat *= texture2D( clearcoatMap, vUv ).x;\n\t#endif\n\t#ifdef USE_CLEARCOAT_ROUGHNESSMAP\n\t\tmaterial.clearcoatRoughness *= texture2D( clearcoatRoughnessMap, vUv ).y;\n\t#endif\n\tmaterial.clearcoat = saturate( material.clearcoat );\tmaterial.clearcoatRoughness = max( material.clearcoatRoughness, 0.0525 );\n\tmaterial.clearcoatRoughness += geometryRoughness;\n\tmaterial.clearcoatRoughness = min( material.clearcoatRoughness, 1.0 );\n#endif\n#ifdef USE_SHEEN\n\tmaterial.sheenColor = sheen;\n#endif";
-
-	var lights_physical_pars_fragment = "struct PhysicalMaterial {\n\tvec3\tdiffuseColor;\n\tfloat\tspecularRoughness;\n\tvec3\tspecularColor;\n#ifdef CLEARCOAT\n\tfloat clearcoat;\n\tfloat clearcoatRoughness;\n#endif\n#ifdef USE_SHEEN\n\tvec3 sheenColor;\n#endif\n};\n#define MAXIMUM_SPECULAR_COEFFICIENT 0.16\n#define DEFAULT_SPECULAR_COEFFICIENT 0.04\nfloat clearcoatDHRApprox( const in float roughness, const in float dotNL ) {\n\treturn DEFAULT_SPECULAR_COEFFICIENT + ( 1.0 - DEFAULT_SPECULAR_COEFFICIENT ) * ( pow( 1.0 - dotNL, 5.0 ) * pow( 1.0 - roughness, 2.0 ) );\n}\n#if NUM_RECT_AREA_LIGHTS > 0\n\tvoid RE_Direct_RectArea_Physical( const in RectAreaLight rectAreaLight, const in GeometricContext geometry, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {\n\t\tvec3 normal = geometry.normal;\n\t\tvec3 viewDir = geometry.viewDir;\n\t\tvec3 position = geometry.position;\n\t\tvec3 lightPos = rectAreaLight.position;\n\t\tvec3 halfWidth = rectAreaLight.halfWidth;\n\t\tvec3 halfHeight = rectAreaLight.halfHeight;\n\t\tvec3 lightColor = rectAreaLight.color;\n\t\tfloat roughness = material.specularRoughness;\n\t\tvec3 rectCoords[ 4 ];\n\t\trectCoords[ 0 ] = lightPos + halfWidth - halfHeight;\t\trectCoords[ 1 ] = lightPos - halfWidth - halfHeight;\n\t\trectCoords[ 2 ] = lightPos - halfWidth + halfHeight;\n\t\trectCoords[ 3 ] = lightPos + halfWidth + halfHeight;\n\t\tvec2 uv = LTC_Uv( normal, viewDir, roughness );\n\t\tvec4 t1 = texture2D( ltc_1, uv );\n\t\tvec4 t2 = texture2D( ltc_2, uv );\n\t\tmat3 mInv = mat3(\n\t\t\tvec3( t1.x, 0, t1.y ),\n\t\t\tvec3(    0, 1,    0 ),\n\t\t\tvec3( t1.z, 0, t1.w )\n\t\t);\n\t\tvec3 fresnel = ( material.specularColor * t2.x + ( vec3( 1.0 ) - material.specularColor ) * t2.y );\n\t\treflectedLight.directSpecular += lightColor * fresnel * LTC_Evaluate( normal, viewDir, position, mInv, rectCoords );\n\t\treflectedLight.directDiffuse += lightColor * material.diffuseColor * LTC_Evaluate( normal, viewDir, position, mat3( 1.0 ), rectCoords );\n\t}\n#endif\nvoid RE_Direct_Physical( const in IncidentLight directLight, const in GeometricContext geometry, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {\n\tfloat dotNL = saturate( dot( geometry.normal, directLight.direction ) );\n\tvec3 irradiance = dotNL * directLight.color;\n\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\tirradiance *= PI;\n\t#endif\n\t#ifdef CLEARCOAT\n\t\tfloat ccDotNL = saturate( dot( geometry.clearcoatNormal, directLight.direction ) );\n\t\tvec3 ccIrradiance = ccDotNL * directLight.color;\n\t\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\t\tccIrradiance *= PI;\n\t\t#endif\n\t\tfloat clearcoatDHR = material.clearcoat * clearcoatDHRApprox( material.clearcoatRoughness, ccDotNL );\n\t\treflectedLight.directSpecular += ccIrradiance * material.clearcoat * BRDF_Specular_GGX( directLight, geometry.viewDir, geometry.clearcoatNormal, vec3( DEFAULT_SPECULAR_COEFFICIENT ), material.clearcoatRoughness );\n\t#else\n\t\tfloat clearcoatDHR = 0.0;\n\t#endif\n\t#ifdef USE_SHEEN\n\t\treflectedLight.directSpecular += ( 1.0 - clearcoatDHR ) * irradiance * BRDF_Specular_Sheen(\n\t\t\tmaterial.specularRoughness,\n\t\t\tdirectLight.direction,\n\t\t\tgeometry,\n\t\t\tmaterial.sheenColor\n\t\t);\n\t#else\n\t\treflectedLight.directSpecular += ( 1.0 - clearcoatDHR ) * irradiance * BRDF_Specular_GGX( directLight, geometry.viewDir, geometry.normal, material.specularColor, material.specularRoughness);\n\t#endif\n\treflectedLight.directDiffuse += ( 1.0 - clearcoatDHR ) * irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );\n}\nvoid RE_IndirectDiffuse_Physical( const in vec3 irradiance, const in GeometricContext geometry, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {\n\treflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );\n}\nvoid RE_IndirectSpecular_Physical( const in vec3 radiance, const in vec3 irradiance, const in vec3 clearcoatRadiance, const in GeometricContext geometry, const in PhysicalMaterial material, inout ReflectedLight reflectedLight) {\n\t#ifdef CLEARCOAT\n\t\tfloat ccDotNV = saturate( dot( geometry.clearcoatNormal, geometry.viewDir ) );\n\t\treflectedLight.indirectSpecular += clearcoatRadiance * material.clearcoat * BRDF_Specular_GGX_Environment( geometry.viewDir, geometry.clearcoatNormal, vec3( DEFAULT_SPECULAR_COEFFICIENT ), material.clearcoatRoughness );\n\t\tfloat ccDotNL = ccDotNV;\n\t\tfloat clearcoatDHR = material.clearcoat * clearcoatDHRApprox( material.clearcoatRoughness, ccDotNL );\n\t#else\n\t\tfloat clearcoatDHR = 0.0;\n\t#endif\n\tfloat clearcoatInv = 1.0 - clearcoatDHR;\n\tvec3 singleScattering = vec3( 0.0 );\n\tvec3 multiScattering = vec3( 0.0 );\n\tvec3 cosineWeightedIrradiance = irradiance * RECIPROCAL_PI;\n\tBRDF_Specular_Multiscattering_Environment( geometry, material.specularColor, material.specularRoughness, singleScattering, multiScattering );\n\tvec3 diffuse = material.diffuseColor * ( 1.0 - ( singleScattering + multiScattering ) );\n\treflectedLight.indirectSpecular += clearcoatInv * radiance * singleScattering;\n\treflectedLight.indirectSpecular += multiScattering * cosineWeightedIrradiance;\n\treflectedLight.indirectDiffuse += diffuse * cosineWeightedIrradiance;\n}\n#define RE_Direct\t\t\t\tRE_Direct_Physical\n#define RE_Direct_RectArea\t\tRE_Direct_RectArea_Physical\n#define RE_IndirectDiffuse\t\tRE_IndirectDiffuse_Physical\n#define RE_IndirectSpecular\t\tRE_IndirectSpecular_Physical\nfloat computeSpecularOcclusion( const in float dotNV, const in float ambientOcclusion, const in float roughness ) {\n\treturn saturate( pow( dotNV + ambientOcclusion, exp2( - 16.0 * roughness - 1.0 ) ) - 1.0 + ambientOcclusion );\n}";
-
-	var lights_fragment_begin = "\nGeometricContext geometry;\ngeometry.position = - vViewPosition;\ngeometry.normal = normal;\ngeometry.viewDir = ( isOrthographic ) ? vec3( 0, 0, 1 ) : normalize( vViewPosition );\n#ifdef CLEARCOAT\n\tgeometry.clearcoatNormal = clearcoatNormal;\n#endif\nIncidentLight directLight;\n#if ( NUM_POINT_LIGHTS > 0 ) && defined( RE_Direct )\n\tPointLight pointLight;\n\t#if defined( USE_SHADOWMAP ) && NUM_POINT_LIGHT_SHADOWS > 0\n\tPointLightShadow pointLightShadow;\n\t#endif\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {\n\t\tpointLight = pointLights[ i ];\n\t\tgetPointDirectLightIrradiance( pointLight, geometry, directLight );\n\t\t#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_POINT_LIGHT_SHADOWS )\n\t\tpointLightShadow = pointLightShadows[ i ];\n\t\tdirectLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getPointShadow( pointShadowMap[ i ], pointLightShadow.shadowMapSize, pointLightShadow.shadowBias, pointLightShadow.shadowRadius, vPointShadowCoord[ i ], pointLightShadow.shadowCameraNear, pointLightShadow.shadowCameraFar ) : 1.0;\n\t\t#endif\n\t\tRE_Direct( directLight, geometry, material, reflectedLight );\n\t}\n\t#pragma unroll_loop_end\n#endif\n#if ( NUM_SPOT_LIGHTS > 0 ) && defined( RE_Direct )\n\tSpotLight spotLight;\n\t#if defined( USE_SHADOWMAP ) && NUM_SPOT_LIGHT_SHADOWS > 0\n\tSpotLightShadow spotLightShadow;\n\t#endif\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {\n\t\tspotLight = spotLights[ i ];\n\t\tgetSpotDirectLightIrradiance( spotLight, geometry, directLight );\n\t\t#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_SPOT_LIGHT_SHADOWS )\n\t\tspotLightShadow = spotLightShadows[ i ];\n\t\tdirectLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;\n\t\t#endif\n\t\tRE_Direct( directLight, geometry, material, reflectedLight );\n\t}\n\t#pragma unroll_loop_end\n#endif\n#if ( NUM_DIR_LIGHTS > 0 ) && defined( RE_Direct )\n\tDirectionalLight directionalLight;\n\t#if defined( USE_SHADOWMAP ) && NUM_DIR_LIGHT_SHADOWS > 0\n\tDirectionalLightShadow directionalLightShadow;\n\t#endif\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {\n\t\tdirectionalLight = directionalLights[ i ];\n\t\tgetDirectionalDirectLightIrradiance( directionalLight, geometry, directLight );\n\t\t#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_DIR_LIGHT_SHADOWS )\n\t\tdirectionalLightShadow = directionalLightShadows[ i ];\n\t\tdirectLight.color *= all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;\n\t\t#endif\n\t\tRE_Direct( directLight, geometry, material, reflectedLight );\n\t}\n\t#pragma unroll_loop_end\n#endif\n#if ( NUM_RECT_AREA_LIGHTS > 0 ) && defined( RE_Direct_RectArea )\n\tRectAreaLight rectAreaLight;\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_RECT_AREA_LIGHTS; i ++ ) {\n\t\trectAreaLight = rectAreaLights[ i ];\n\t\tRE_Direct_RectArea( rectAreaLight, geometry, material, reflectedLight );\n\t}\n\t#pragma unroll_loop_end\n#endif\n#if defined( RE_IndirectDiffuse )\n\tvec3 iblIrradiance = vec3( 0.0 );\n\tvec3 irradiance = getAmbientLightIrradiance( ambientLightColor );\n\tirradiance += getLightProbeIrradiance( lightProbe, geometry );\n\t#if ( NUM_HEMI_LIGHTS > 0 )\n\t\t#pragma unroll_loop_start\n\t\tfor ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {\n\t\t\tirradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );\n\t\t}\n\t\t#pragma unroll_loop_end\n\t#endif\n#endif\n#if defined( RE_IndirectSpecular )\n\tvec3 radiance = vec3( 0.0 );\n\tvec3 clearcoatRadiance = vec3( 0.0 );\n#endif";
-
-	var lights_fragment_maps = "#if defined( RE_IndirectDiffuse )\n\t#ifdef USE_LIGHTMAP\n\t\tvec4 lightMapTexel= texture2D( lightMap, vUv2 );\n\t\tvec3 lightMapIrradiance = lightMapTexelToLinear( lightMapTexel ).rgb * lightMapIntensity;\n\t\t#ifndef PHYSICALLY_CORRECT_LIGHTS\n\t\t\tlightMapIrradiance *= PI;\n\t\t#endif\n\t\tirradiance += lightMapIrradiance;\n\t#endif\n\t#if defined( USE_ENVMAP ) && defined( STANDARD ) && defined( ENVMAP_TYPE_CUBE_UV )\n\t\tiblIrradiance += getLightProbeIndirectIrradiance( geometry, maxMipLevel );\n\t#endif\n#endif\n#if defined( USE_ENVMAP ) && defined( RE_IndirectSpecular )\n\tradiance += getLightProbeIndirectRadiance( geometry.viewDir, geometry.normal, material.specularRoughness, maxMipLevel );\n\t#ifdef CLEARCOAT\n\t\tclearcoatRadiance += getLightProbeIndirectRadiance( geometry.viewDir, geometry.clearcoatNormal, material.clearcoatRoughness, maxMipLevel );\n\t#endif\n#endif";
-
-	var lights_fragment_end = "#if defined( RE_IndirectDiffuse )\n\tRE_IndirectDiffuse( irradiance, geometry, material, reflectedLight );\n#endif\n#if defined( RE_IndirectSpecular )\n\tRE_IndirectSpecular( radiance, iblIrradiance, clearcoatRadiance, geometry, material, reflectedLight );\n#endif";
-
-	var logdepthbuf_fragment = "#if defined( USE_LOGDEPTHBUF ) && defined( USE_LOGDEPTHBUF_EXT )\n\tgl_FragDepthEXT = vIsPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;\n#endif";
-
-	var logdepthbuf_pars_fragment = "#if defined( USE_LOGDEPTHBUF ) && defined( USE_LOGDEPTHBUF_EXT )\n\tuniform float logDepthBufFC;\n\tvarying float vFragDepth;\n\tvarying float vIsPerspective;\n#endif";
-
-	var logdepthbuf_pars_vertex = "#ifdef USE_LOGDEPTHBUF\n\t#ifdef USE_LOGDEPTHBUF_EXT\n\t\tvarying float vFragDepth;\n\t\tvarying float vIsPerspective;\n\t#else\n\t\tuniform float logDepthBufFC;\n\t#endif\n#endif";
-
-	var logdepthbuf_vertex = "#ifdef USE_LOGDEPTHBUF\n\t#ifdef USE_LOGDEPTHBUF_EXT\n\t\tvFragDepth = 1.0 + gl_Position.w;\n\t\tvIsPerspective = float( isPerspectiveMatrix( projectionMatrix ) );\n\t#else\n\t\tif ( isPerspectiveMatrix( projectionMatrix ) ) {\n\t\t\tgl_Position.z = log2( max( EPSILON, gl_Position.w + 1.0 ) ) * logDepthBufFC - 1.0;\n\t\t\tgl_Position.z *= gl_Position.w;\n\t\t}\n\t#endif\n#endif";
-
-	var map_fragment = "#ifdef USE_MAP\n\tvec4 texelColor = texture2D( map, vUv );\n\ttexelColor = mapTexelToLinear( texelColor );\n\tdiffuseColor *= texelColor;\n#endif";
-
-	var map_pars_fragment = "#ifdef USE_MAP\n\tuniform sampler2D map;\n#endif";
-
-	var map_particle_fragment = "#if defined( USE_MAP ) || defined( USE_ALPHAMAP )\n\tvec2 uv = ( uvTransform * vec3( gl_PointCoord.x, 1.0 - gl_PointCoord.y, 1 ) ).xy;\n#endif\n#ifdef USE_MAP\n\tvec4 mapTexel = texture2D( map, uv );\n\tdiffuseColor *= mapTexelToLinear( mapTexel );\n#endif\n#ifdef USE_ALPHAMAP\n\tdiffuseColor.a *= texture2D( alphaMap, uv ).g;\n#endif";
-
-	var map_particle_pars_fragment = "#if defined( USE_MAP ) || defined( USE_ALPHAMAP )\n\tuniform mat3 uvTransform;\n#endif\n#ifdef USE_MAP\n\tuniform sampler2D map;\n#endif\n#ifdef USE_ALPHAMAP\n\tuniform sampler2D alphaMap;\n#endif";
-
-	var metalnessmap_fragment = "float metalnessFactor = metalness;\n#ifdef USE_METALNESSMAP\n\tvec4 texelMetalness = texture2D( metalnessMap, vUv );\n\tmetalnessFactor *= texelMetalness.b;\n#endif";
-
-	var metalnessmap_pars_fragment = "#ifdef USE_METALNESSMAP\n\tuniform sampler2D metalnessMap;\n#endif";
-
-	var morphnormal_vertex = "#ifdef USE_MORPHNORMALS\n\tobjectNormal *= morphTargetBaseInfluence;\n\tobjectNormal += morphNormal0 * morphTargetInfluences[ 0 ];\n\tobjectNormal += morphNormal1 * morphTargetInfluences[ 1 ];\n\tobjectNormal += morphNormal2 * morphTargetInfluences[ 2 ];\n\tobjectNormal += morphNormal3 * morphTargetInfluences[ 3 ];\n#endif";
-
-	var morphtarget_pars_vertex = "#ifdef USE_MORPHTARGETS\n\tuniform float morphTargetBaseInfluence;\n\t#ifndef USE_MORPHNORMALS\n\tuniform float morphTargetInfluences[ 8 ];\n\t#else\n\tuniform float morphTargetInfluences[ 4 ];\n\t#endif\n#endif";
-
-	var morphtarget_vertex = "#ifdef USE_MORPHTARGETS\n\ttransformed *= morphTargetBaseInfluence;\n\ttransformed += morphTarget0 * morphTargetInfluences[ 0 ];\n\ttransformed += morphTarget1 * morphTargetInfluences[ 1 ];\n\ttransformed += morphTarget2 * morphTargetInfluences[ 2 ];\n\ttransformed += morphTarget3 * morphTargetInfluences[ 3 ];\n\t#ifndef USE_MORPHNORMALS\n\ttransformed += morphTarget4 * morphTargetInfluences[ 4 ];\n\ttransformed += morphTarget5 * morphTargetInfluences[ 5 ];\n\ttransformed += morphTarget6 * morphTargetInfluences[ 6 ];\n\ttransformed += morphTarget7 * morphTargetInfluences[ 7 ];\n\t#endif\n#endif";
-
-	var normal_fragment_begin = "#ifdef FLAT_SHADED\n\tvec3 fdx = vec3( dFdx( vViewPosition.x ), dFdx( vViewPosition.y ), dFdx( vViewPosition.z ) );\n\tvec3 fdy = vec3( dFdy( vViewPosition.x ), dFdy( vViewPosition.y ), dFdy( vViewPosition.z ) );\n\tvec3 normal = normalize( cross( fdx, fdy ) );\n#else\n\tvec3 normal = normalize( vNormal );\n\t#ifdef DOUBLE_SIDED\n\t\tnormal = normal * ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t#endif\n\t#ifdef USE_TANGENT\n\t\tvec3 tangent = normalize( vTangent );\n\t\tvec3 bitangent = normalize( vBitangent );\n\t\t#ifdef DOUBLE_SIDED\n\t\t\ttangent = tangent * ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t\t\tbitangent = bitangent * ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t\t#endif\n\t\t#if defined( TANGENTSPACE_NORMALMAP ) || defined( USE_CLEARCOAT_NORMALMAP )\n\t\t\tmat3 vTBN = mat3( tangent, bitangent, normal );\n\t\t#endif\n\t#endif\n#endif\nvec3 geometryNormal = normal;";
-
-	var normal_fragment_maps = "#ifdef OBJECTSPACE_NORMALMAP\n\tnormal = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0;\n\t#ifdef FLIP_SIDED\n\t\tnormal = - normal;\n\t#endif\n\t#ifdef DOUBLE_SIDED\n\t\tnormal = normal * ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t#endif\n\tnormal = normalize( normalMatrix * normal );\n#elif defined( TANGENTSPACE_NORMALMAP )\n\tvec3 mapN = texture2D( normalMap, vUv ).xyz * 2.0 - 1.0;\n\tmapN.xy *= normalScale;\n\t#ifdef USE_TANGENT\n\t\tnormal = normalize( vTBN * mapN );\n\t#else\n\t\tnormal = perturbNormal2Arb( -vViewPosition, normal, mapN );\n\t#endif\n#elif defined( USE_BUMPMAP )\n\tnormal = perturbNormalArb( -vViewPosition, normal, dHdxy_fwd() );\n#endif";
-
-	var normalmap_pars_fragment = "#ifdef USE_NORMALMAP\n\tuniform sampler2D normalMap;\n\tuniform vec2 normalScale;\n#endif\n#ifdef OBJECTSPACE_NORMALMAP\n\tuniform mat3 normalMatrix;\n#endif\n#if ! defined ( USE_TANGENT ) && ( defined ( TANGENTSPACE_NORMALMAP ) || defined ( USE_CLEARCOAT_NORMALMAP ) )\n\tvec3 perturbNormal2Arb( vec3 eye_pos, vec3 surf_norm, vec3 mapN ) {\n\t\tvec3 q0 = vec3( dFdx( eye_pos.x ), dFdx( eye_pos.y ), dFdx( eye_pos.z ) );\n\t\tvec3 q1 = vec3( dFdy( eye_pos.x ), dFdy( eye_pos.y ), dFdy( eye_pos.z ) );\n\t\tvec2 st0 = dFdx( vUv.st );\n\t\tvec2 st1 = dFdy( vUv.st );\n\t\tfloat scale = sign( st1.t * st0.s - st0.t * st1.s );\n\t\tvec3 S = normalize( ( q0 * st1.t - q1 * st0.t ) * scale );\n\t\tvec3 T = normalize( ( - q0 * st1.s + q1 * st0.s ) * scale );\n\t\tvec3 N = normalize( surf_norm );\n\t\tmat3 tsn = mat3( S, T, N );\n\t\tmapN.xy *= ( float( gl_FrontFacing ) * 2.0 - 1.0 );\n\t\treturn normalize( tsn * mapN );\n\t}\n#endif";
-
-	var clearcoat_normal_fragment_begin = "#ifdef CLEARCOAT\n\tvec3 clearcoatNormal = geometryNormal;\n#endif";
-
-	var clearcoat_normal_fragment_maps = "#ifdef USE_CLEARCOAT_NORMALMAP\n\tvec3 clearcoatMapN = texture2D( clearcoatNormalMap, vUv ).xyz * 2.0 - 1.0;\n\tclearcoatMapN.xy *= clearcoatNormalScale;\n\t#ifdef USE_TANGENT\n\t\tclearcoatNormal = normalize( vTBN * clearcoatMapN );\n\t#else\n\t\tclearcoatNormal = perturbNormal2Arb( - vViewPosition, clearcoatNormal, clearcoatMapN );\n\t#endif\n#endif";
-
-	var clearcoat_pars_fragment = "#ifdef USE_CLEARCOATMAP\n\tuniform sampler2D clearcoatMap;\n#endif\n#ifdef USE_CLEARCOAT_ROUGHNESSMAP\n\tuniform sampler2D clearcoatRoughnessMap;\n#endif\n#ifdef USE_CLEARCOAT_NORMALMAP\n\tuniform sampler2D clearcoatNormalMap;\n\tuniform vec2 clearcoatNormalScale;\n#endif";
-
-	var packing = "vec3 packNormalToRGB( const in vec3 normal ) {\n\treturn normalize( normal ) * 0.5 + 0.5;\n}\nvec3 unpackRGBToNormal( const in vec3 rgb ) {\n\treturn 2.0 * rgb.xyz - 1.0;\n}\nconst float PackUpscale = 256. / 255.;const float UnpackDownscale = 255. / 256.;\nconst vec3 PackFactors = vec3( 256. * 256. * 256., 256. * 256.,  256. );\nconst vec4 UnpackFactors = UnpackDownscale / vec4( PackFactors, 1. );\nconst float ShiftRight8 = 1. / 256.;\nvec4 packDepthToRGBA( const in float v ) {\n\tvec4 r = vec4( fract( v * PackFactors ), v );\n\tr.yzw -= r.xyz * ShiftRight8;\treturn r * PackUpscale;\n}\nfloat unpackRGBAToDepth( const in vec4 v ) {\n\treturn dot( v, UnpackFactors );\n}\nvec4 pack2HalfToRGBA( vec2 v ) {\n\tvec4 r = vec4( v.x, fract( v.x * 255.0 ), v.y, fract( v.y * 255.0 ));\n\treturn vec4( r.x - r.y / 255.0, r.y, r.z - r.w / 255.0, r.w);\n}\nvec2 unpackRGBATo2Half( vec4 v ) {\n\treturn vec2( v.x + ( v.y / 255.0 ), v.z + ( v.w / 255.0 ) );\n}\nfloat viewZToOrthographicDepth( const in float viewZ, const in float near, const in float far ) {\n\treturn ( viewZ + near ) / ( near - far );\n}\nfloat orthographicDepthToViewZ( const in float linearClipZ, const in float near, const in float far ) {\n\treturn linearClipZ * ( near - far ) - near;\n}\nfloat viewZToPerspectiveDepth( const in float viewZ, const in float near, const in float far ) {\n\treturn (( near + viewZ ) * far ) / (( far - near ) * viewZ );\n}\nfloat perspectiveDepthToViewZ( const in float invClipZ, const in float near, const in float far ) {\n\treturn ( near * far ) / ( ( far - near ) * invClipZ - far );\n}";
-
-	var premultiplied_alpha_fragment = "#ifdef PREMULTIPLIED_ALPHA\n\tgl_FragColor.rgb *= gl_FragColor.a;\n#endif";
-
-	var project_vertex = "vec4 mvPosition = vec4( transformed, 1.0 );\n#ifdef USE_INSTANCING\n\tmvPosition = instanceMatrix * mvPosition;\n#endif\nmvPosition = modelViewMatrix * mvPosition;\ngl_Position = projectionMatrix * mvPosition;";
-
-	var dithering_fragment = "#ifdef DITHERING\n\tgl_FragColor.rgb = dithering( gl_FragColor.rgb );\n#endif";
-
-	var dithering_pars_fragment = "#ifdef DITHERING\n\tvec3 dithering( vec3 color ) {\n\t\tfloat grid_position = rand( gl_FragCoord.xy );\n\t\tvec3 dither_shift_RGB = vec3( 0.25 / 255.0, -0.25 / 255.0, 0.25 / 255.0 );\n\t\tdither_shift_RGB = mix( 2.0 * dither_shift_RGB, -2.0 * dither_shift_RGB, grid_position );\n\t\treturn color + dither_shift_RGB;\n\t}\n#endif";
-
-	var roughnessmap_fragment = "float roughnessFactor = roughness;\n#ifdef USE_ROUGHNESSMAP\n\tvec4 texelRoughness = texture2D( roughnessMap, vUv );\n\troughnessFactor *= texelRoughness.g;\n#endif";
-
-	var roughnessmap_pars_fragment = "#ifdef USE_ROUGHNESSMAP\n\tuniform sampler2D roughnessMap;\n#endif";
-
-	var shadowmap_pars_fragment = "#ifdef USE_SHADOWMAP\n\t#if NUM_DIR_LIGHT_SHADOWS > 0\n\t\tuniform sampler2D directionalShadowMap[ NUM_DIR_LIGHT_SHADOWS ];\n\t\tvarying vec4 vDirectionalShadowCoord[ NUM_DIR_LIGHT_SHADOWS ];\n\t#endif\n\t#if NUM_SPOT_LIGHT_SHADOWS > 0\n\t\tuniform sampler2D spotShadowMap[ NUM_SPOT_LIGHT_SHADOWS ];\n\t\tvarying vec4 vSpotShadowCoord[ NUM_SPOT_LIGHT_SHADOWS ];\n\t#endif\n\t#if NUM_POINT_LIGHT_SHADOWS > 0\n\t\tuniform sampler2D pointShadowMap[ NUM_POINT_LIGHT_SHADOWS ];\n\t\tvarying vec4 vPointShadowCoord[ NUM_POINT_LIGHT_SHADOWS ];\n\t#endif\n\tfloat texture2DCompare( sampler2D depths, vec2 uv, float compare ) {\n\t\treturn step( compare, unpackRGBAToDepth( texture2D( depths, uv ) ) );\n\t}\n\tvec2 texture2DDistribution( sampler2D shadow, vec2 uv ) {\n\t\treturn unpackRGBATo2Half( texture2D( shadow, uv ) );\n\t}\n\tfloat VSMShadow (sampler2D shadow, vec2 uv, float compare ){\n\t\tfloat occlusion = 1.0;\n\t\tvec2 distribution = texture2DDistribution( shadow, uv );\n\t\tfloat hard_shadow = step( compare , distribution.x );\n\t\tif (hard_shadow != 1.0 ) {\n\t\t\tfloat distance = compare - distribution.x ;\n\t\t\tfloat variance = max( 0.00000, distribution.y * distribution.y );\n\t\t\tfloat softness_probability = variance / (variance + distance * distance );\t\t\tsoftness_probability = clamp( ( softness_probability - 0.3 ) / ( 0.95 - 0.3 ), 0.0, 1.0 );\t\t\tocclusion = clamp( max( hard_shadow, softness_probability ), 0.0, 1.0 );\n\t\t}\n\t\treturn occlusion;\n\t}\n\tfloat getShadow( sampler2D shadowMap, vec2 shadowMapSize, float shadowBias, float shadowRadius, vec4 shadowCoord ) {\n\t\tfloat shadow = 1.0;\n\t\tshadowCoord.xyz /= shadowCoord.w;\n\t\tshadowCoord.z += shadowBias;\n\t\tbvec4 inFrustumVec = bvec4 ( shadowCoord.x >= 0.0, shadowCoord.x <= 1.0, shadowCoord.y >= 0.0, shadowCoord.y <= 1.0 );\n\t\tbool inFrustum = all( inFrustumVec );\n\t\tbvec2 frustumTestVec = bvec2( inFrustum, shadowCoord.z <= 1.0 );\n\t\tbool frustumTest = all( frustumTestVec );\n\t\tif ( frustumTest ) {\n\t\t#if defined( SHADOWMAP_TYPE_PCF )\n\t\t\tvec2 texelSize = vec2( 1.0 ) / shadowMapSize;\n\t\t\tfloat dx0 = - texelSize.x * shadowRadius;\n\t\t\tfloat dy0 = - texelSize.y * shadowRadius;\n\t\t\tfloat dx1 = + texelSize.x * shadowRadius;\n\t\t\tfloat dy1 = + texelSize.y * shadowRadius;\n\t\t\tfloat dx2 = dx0 / 2.0;\n\t\t\tfloat dy2 = dy0 / 2.0;\n\t\t\tfloat dx3 = dx1 / 2.0;\n\t\t\tfloat dy3 = dy1 / 2.0;\n\t\t\tshadow = (\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx0, dy0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( 0.0, dy0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx1, dy0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx2, dy2 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( 0.0, dy2 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx3, dy2 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx0, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx2, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy, shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx3, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx1, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx2, dy3 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( 0.0, dy3 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx3, dy3 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx0, dy1 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( 0.0, dy1 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, shadowCoord.xy + vec2( dx1, dy1 ), shadowCoord.z )\n\t\t\t) * ( 1.0 / 17.0 );\n\t\t#elif defined( SHADOWMAP_TYPE_PCF_SOFT )\n\t\t\tvec2 texelSize = vec2( 1.0 ) / shadowMapSize;\n\t\t\tfloat dx = texelSize.x;\n\t\t\tfloat dy = texelSize.y;\n\t\t\tvec2 uv = shadowCoord.xy;\n\t\t\tvec2 f = fract( uv * shadowMapSize + 0.5 );\n\t\t\tuv -= f * texelSize;\n\t\t\tshadow = (\n\t\t\t\ttexture2DCompare( shadowMap, uv, shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, uv + vec2( dx, 0.0 ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, uv + vec2( 0.0, dy ), shadowCoord.z ) +\n\t\t\t\ttexture2DCompare( shadowMap, uv + texelSize, shadowCoord.z ) +\n\t\t\t\tmix( texture2DCompare( shadowMap, uv + vec2( -dx, 0.0 ), shadowCoord.z ), \n\t\t\t\t\t texture2DCompare( shadowMap, uv + vec2( 2.0 * dx, 0.0 ), shadowCoord.z ),\n\t\t\t\t\t f.x ) +\n\t\t\t\tmix( texture2DCompare( shadowMap, uv + vec2( -dx, dy ), shadowCoord.z ), \n\t\t\t\t\t texture2DCompare( shadowMap, uv + vec2( 2.0 * dx, dy ), shadowCoord.z ),\n\t\t\t\t\t f.x ) +\n\t\t\t\tmix( texture2DCompare( shadowMap, uv + vec2( 0.0, -dy ), shadowCoord.z ), \n\t\t\t\t\t texture2DCompare( shadowMap, uv + vec2( 0.0, 2.0 * dy ), shadowCoord.z ),\n\t\t\t\t\t f.y ) +\n\t\t\t\tmix( texture2DCompare( shadowMap, uv + vec2( dx, -dy ), shadowCoord.z ), \n\t\t\t\t\t texture2DCompare( shadowMap, uv + vec2( dx, 2.0 * dy ), shadowCoord.z ),\n\t\t\t\t\t f.y ) +\n\t\t\t\tmix( mix( texture2DCompare( shadowMap, uv + vec2( -dx, -dy ), shadowCoord.z ), \n\t\t\t\t\t\t  texture2DCompare( shadowMap, uv + vec2( 2.0 * dx, -dy ), shadowCoord.z ),\n\t\t\t\t\t\t  f.x ),\n\t\t\t\t\t mix( texture2DCompare( shadowMap, uv + vec2( -dx, 2.0 * dy ), shadowCoord.z ), \n\t\t\t\t\t\t  texture2DCompare( shadowMap, uv + vec2( 2.0 * dx, 2.0 * dy ), shadowCoord.z ),\n\t\t\t\t\t\t  f.x ),\n\t\t\t\t\t f.y )\n\t\t\t) * ( 1.0 / 9.0 );\n\t\t#elif defined( SHADOWMAP_TYPE_VSM )\n\t\t\tshadow = VSMShadow( shadowMap, shadowCoord.xy, shadowCoord.z );\n\t\t#else\n\t\t\tshadow = texture2DCompare( shadowMap, shadowCoord.xy, shadowCoord.z );\n\t\t#endif\n\t\t}\n\t\treturn shadow;\n\t}\n\tvec2 cubeToUV( vec3 v, float texelSizeY ) {\n\t\tvec3 absV = abs( v );\n\t\tfloat scaleToCube = 1.0 / max( absV.x, max( absV.y, absV.z ) );\n\t\tabsV *= scaleToCube;\n\t\tv *= scaleToCube * ( 1.0 - 2.0 * texelSizeY );\n\t\tvec2 planar = v.xy;\n\t\tfloat almostATexel = 1.5 * texelSizeY;\n\t\tfloat almostOne = 1.0 - almostATexel;\n\t\tif ( absV.z >= almostOne ) {\n\t\t\tif ( v.z > 0.0 )\n\t\t\t\tplanar.x = 4.0 - v.x;\n\t\t} else if ( absV.x >= almostOne ) {\n\t\t\tfloat signX = sign( v.x );\n\t\t\tplanar.x = v.z * signX + 2.0 * signX;\n\t\t} else if ( absV.y >= almostOne ) {\n\t\t\tfloat signY = sign( v.y );\n\t\t\tplanar.x = v.x + 2.0 * signY + 2.0;\n\t\t\tplanar.y = v.z * signY - 2.0;\n\t\t}\n\t\treturn vec2( 0.125, 0.25 ) * planar + vec2( 0.375, 0.75 );\n\t}\n\tfloat getPointShadow( sampler2D shadowMap, vec2 shadowMapSize, float shadowBias, float shadowRadius, vec4 shadowCoord, float shadowCameraNear, float shadowCameraFar ) {\n\t\tvec2 texelSize = vec2( 1.0 ) / ( shadowMapSize * vec2( 4.0, 2.0 ) );\n\t\tvec3 lightToPosition = shadowCoord.xyz;\n\t\tfloat dp = ( length( lightToPosition ) - shadowCameraNear ) / ( shadowCameraFar - shadowCameraNear );\t\tdp += shadowBias;\n\t\tvec3 bd3D = normalize( lightToPosition );\n\t\t#if defined( SHADOWMAP_TYPE_PCF ) || defined( SHADOWMAP_TYPE_PCF_SOFT ) || defined( SHADOWMAP_TYPE_VSM )\n\t\t\tvec2 offset = vec2( - 1, 1 ) * shadowRadius * texelSize.y;\n\t\t\treturn (\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.xyy, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.yyy, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.xyx, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.yyx, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.xxy, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.yxy, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.xxx, texelSize.y ), dp ) +\n\t\t\t\ttexture2DCompare( shadowMap, cubeToUV( bd3D + offset.yxx, texelSize.y ), dp )\n\t\t\t) * ( 1.0 / 9.0 );\n\t\t#else\n\t\t\treturn texture2DCompare( shadowMap, cubeToUV( bd3D, texelSize.y ), dp );\n\t\t#endif\n\t}\n#endif";
-
-	var shadowmap_pars_vertex = "#ifdef USE_SHADOWMAP\n\t#if NUM_DIR_LIGHT_SHADOWS > 0\n\t\tuniform mat4 directionalShadowMatrix[ NUM_DIR_LIGHT_SHADOWS ];\n\t\tvarying vec4 vDirectionalShadowCoord[ NUM_DIR_LIGHT_SHADOWS ];\n\t#endif\n\t#if NUM_SPOT_LIGHT_SHADOWS > 0\n\t\tuniform mat4 spotShadowMatrix[ NUM_SPOT_LIGHT_SHADOWS ];\n\t\tvarying vec4 vSpotShadowCoord[ NUM_SPOT_LIGHT_SHADOWS ];\n\t#endif\n\t#if NUM_POINT_LIGHT_SHADOWS > 0\n\t\tuniform mat4 pointShadowMatrix[ NUM_POINT_LIGHT_SHADOWS ];\n\t\tvarying vec4 vPointShadowCoord[ NUM_POINT_LIGHT_SHADOWS ];\n\t#endif\n#endif";
-
-	var shadowmap_vertex = "#ifdef USE_SHADOWMAP\n\t#if NUM_DIR_LIGHT_SHADOWS > 0\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_DIR_LIGHT_SHADOWS; i ++ ) {\n\t\tvDirectionalShadowCoord[ i ] = directionalShadowMatrix[ i ] * worldPosition;\n\t}\n\t#pragma unroll_loop_end\n\t#endif\n\t#if NUM_SPOT_LIGHT_SHADOWS > 0\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_SPOT_LIGHT_SHADOWS; i ++ ) {\n\t\tvSpotShadowCoord[ i ] = spotShadowMatrix[ i ] * worldPosition;\n\t}\n\t#pragma unroll_loop_end\n\t#endif\n\t#if NUM_POINT_LIGHT_SHADOWS > 0\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_POINT_LIGHT_SHADOWS; i ++ ) {\n\t\tvPointShadowCoord[ i ] = pointShadowMatrix[ i ] * worldPosition;\n\t}\n\t#pragma unroll_loop_end\n\t#endif\n#endif";
-
-	var shadowmask_pars_fragment = "float getShadowMask() {\n\tfloat shadow = 1.0;\n\t#ifdef USE_SHADOWMAP\n\t#if NUM_DIR_LIGHT_SHADOWS > 0\n\tDirectionalLightShadow directionalLight;\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_DIR_LIGHT_SHADOWS; i ++ ) {\n\t\tdirectionalLight = directionalLightShadows[ i ];\n\t\tshadow *= receiveShadow ? getShadow( directionalShadowMap[ i ], directionalLight.shadowMapSize, directionalLight.shadowBias, directionalLight.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;\n\t}\n\t#pragma unroll_loop_end\n\t#endif\n\t#if NUM_SPOT_LIGHT_SHADOWS > 0\n\tSpotLightShadow spotLight;\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_SPOT_LIGHT_SHADOWS; i ++ ) {\n\t\tspotLight = spotLightShadows[ i ];\n\t\tshadow *= receiveShadow ? getShadow( spotShadowMap[ i ], spotLight.shadowMapSize, spotLight.shadowBias, spotLight.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;\n\t}\n\t#pragma unroll_loop_end\n\t#endif\n\t#if NUM_POINT_LIGHT_SHADOWS > 0\n\tPointLightShadow pointLight;\n\t#pragma unroll_loop_start\n\tfor ( int i = 0; i < NUM_POINT_LIGHT_SHADOWS; i ++ ) {\n\t\tpointLight = pointLightShadows[ i ];\n\t\tshadow *= receiveShadow ? getPointShadow( pointShadowMap[ i ], pointLight.shadowMapSize, pointLight.shadowBias, pointLight.shadowRadius, vPointShadowCoord[ i ], pointLight.shadowCameraNear, pointLight.shadowCameraFar ) : 1.0;\n\t}\n\t#pragma unroll_loop_end\n\t#endif\n\t#endif\n\treturn shadow;\n}";
-
-	var skinbase_vertex = "#ifdef USE_SKINNING\n\tmat4 boneMatX = getBoneMatrix( skinIndex.x );\n\tmat4 boneMatY = getBoneMatrix( skinIndex.y );\n\tmat4 boneMatZ = getBoneMatrix( skinIndex.z );\n\tmat4 boneMatW = getBoneMatrix( skinIndex.w );\n#endif";
-
-	var skinning_pars_vertex = "#ifdef USE_SKINNING\n\tuniform mat4 bindMatrix;\n\tuniform mat4 bindMatrixInverse;\n\t#ifdef BONE_TEXTURE\n\t\tuniform highp sampler2D boneTexture;\n\t\tuniform int boneTextureSize;\n\t\tmat4 getBoneMatrix( const in float i ) {\n\t\t\tfloat j = i * 4.0;\n\t\t\tfloat x = mod( j, float( boneTextureSize ) );\n\t\t\tfloat y = floor( j / float( boneTextureSize ) );\n\t\t\tfloat dx = 1.0 / float( boneTextureSize );\n\t\t\tfloat dy = 1.0 / float( boneTextureSize );\n\t\t\ty = dy * ( y + 0.5 );\n\t\t\tvec4 v1 = texture2D( boneTexture, vec2( dx * ( x + 0.5 ), y ) );\n\t\t\tvec4 v2 = texture2D( boneTexture, vec2( dx * ( x + 1.5 ), y ) );\n\t\t\tvec4 v3 = texture2D( boneTexture, vec2( dx * ( x + 2.5 ), y ) );\n\t\t\tvec4 v4 = texture2D( boneTexture, vec2( dx * ( x + 3.5 ), y ) );\n\t\t\tmat4 bone = mat4( v1, v2, v3, v4 );\n\t\t\treturn bone;\n\t\t}\n\t#else\n\t\tuniform mat4 boneMatrices[ MAX_BONES ];\n\t\tmat4 getBoneMatrix( const in float i ) {\n\t\t\tmat4 bone = boneMatrices[ int(i) ];\n\t\t\treturn bone;\n\t\t}\n\t#endif\n#endif";
-
-	var skinning_vertex = "#ifdef USE_SKINNING\n\tvec4 skinVertex = bindMatrix * vec4( transformed, 1.0 );\n\tvec4 skinned = vec4( 0.0 );\n\tskinned += boneMatX * skinVertex * skinWeight.x;\n\tskinned += boneMatY * skinVertex * skinWeight.y;\n\tskinned += boneMatZ * skinVertex * skinWeight.z;\n\tskinned += boneMatW * skinVertex * skinWeight.w;\n\ttransformed = ( bindMatrixInverse * skinned ).xyz;\n#endif";
-
-	var skinnormal_vertex = "#ifdef USE_SKINNING\n\tmat4 skinMatrix = mat4( 0.0 );\n\tskinMatrix += skinWeight.x * boneMatX;\n\tskinMatrix += skinWeight.y * boneMatY;\n\tskinMatrix += skinWeight.z * boneMatZ;\n\tskinMatrix += skinWeight.w * boneMatW;\n\tskinMatrix  = bindMatrixInverse * skinMatrix * bindMatrix;\n\tobjectNormal = vec4( skinMatrix * vec4( objectNormal, 0.0 ) ).xyz;\n\t#ifdef USE_TANGENT\n\t\tobjectTangent = vec4( skinMatrix * vec4( objectTangent, 0.0 ) ).xyz;\n\t#endif\n#endif";
-
-	var specularmap_fragment = "float specularStrength;\n#ifdef USE_SPECULARMAP\n\tvec4 texelSpecular = texture2D( specularMap, vUv );\n\tspecularStrength = texelSpecular.r;\n#else\n\tspecularStrength = 1.0;\n#endif";
-
-	var specularmap_pars_fragment = "#ifdef USE_SPECULARMAP\n\tuniform sampler2D specularMap;\n#endif";
-
-	var tonemapping_fragment = "#if defined( TONE_MAPPING )\n\tgl_FragColor.rgb = toneMapping( gl_FragColor.rgb );\n#endif";
-
-	var tonemapping_pars_fragment = "#ifndef saturate\n#define saturate(a) clamp( a, 0.0, 1.0 )\n#endif\nuniform float toneMappingExposure;\nuniform float toneMappingWhitePoint;\nvec3 LinearToneMapping( vec3 color ) {\n\treturn toneMappingExposure * color;\n}\nvec3 ReinhardToneMapping( vec3 color ) {\n\tcolor *= toneMappingExposure;\n\treturn saturate( color / ( vec3( 1.0 ) + color ) );\n}\n#define Uncharted2Helper( x ) max( ( ( x * ( 0.15 * x + 0.10 * 0.50 ) + 0.20 * 0.02 ) / ( x * ( 0.15 * x + 0.50 ) + 0.20 * 0.30 ) ) - 0.02 / 0.30, vec3( 0.0 ) )\nvec3 Uncharted2ToneMapping( vec3 color ) {\n\tcolor *= toneMappingExposure;\n\treturn saturate( Uncharted2Helper( color ) / Uncharted2Helper( vec3( toneMappingWhitePoint ) ) );\n}\nvec3 OptimizedCineonToneMapping( vec3 color ) {\n\tcolor *= toneMappingExposure;\n\tcolor = max( vec3( 0.0 ), color - 0.004 );\n\treturn pow( ( color * ( 6.2 * color + 0.5 ) ) / ( color * ( 6.2 * color + 1.7 ) + 0.06 ), vec3( 2.2 ) );\n}\nvec3 ACESFilmicToneMapping( vec3 color ) {\n\tcolor *= toneMappingExposure;\n\treturn saturate( ( color * ( 2.51 * color + 0.03 ) ) / ( color * ( 2.43 * color + 0.59 ) + 0.14 ) );\n}";
-
-	var uv_pars_fragment = "#if ( defined( USE_UV ) && ! defined( UVS_VERTEX_ONLY ) )\n\tvarying vec2 vUv;\n#endif";
-
-	var uv_pars_vertex = "#ifdef USE_UV\n\t#ifdef UVS_VERTEX_ONLY\n\t\tvec2 vUv;\n\t#else\n\t\tvarying vec2 vUv;\n\t#endif\n\tuniform mat3 uvTransform;\n#endif";
-
-	var uv_vertex = "#ifdef USE_UV\n\tvUv = ( uvTransform * vec3( uv, 1 ) ).xy;\n#endif";
-
-	var uv2_pars_fragment = "#if defined( USE_LIGHTMAP ) || defined( USE_AOMAP )\n\tvarying vec2 vUv2;\n#endif";
-
-	var uv2_pars_vertex = "#if defined( USE_LIGHTMAP ) || defined( USE_AOMAP )\n\tattribute vec2 uv2;\n\tvarying vec2 vUv2;\n\tuniform mat3 uv2Transform;\n#endif";
-
-	var uv2_vertex = "#if defined( USE_LIGHTMAP ) || defined( USE_AOMAP )\n\tvUv2 = ( uv2Transform * vec3( uv2, 1 ) ).xy;\n#endif";
-
-	var worldpos_vertex = "#if defined( USE_ENVMAP ) || defined( DISTANCE ) || defined ( USE_SHADOWMAP )\n\tvec4 worldPosition = vec4( transformed, 1.0 );\n\t#ifdef USE_INSTANCING\n\t\tworldPosition = instanceMatrix * worldPosition;\n\t#endif\n\tworldPosition = modelMatrix * worldPosition;\n#endif";
-
-	var background_frag = "uniform sampler2D t2D;\nvarying vec2 vUv;\nvoid main() {\n\tvec4 texColor = texture2D( t2D, vUv );\n\tgl_FragColor = mapTexelToLinear( texColor );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n}";
-
-	var background_vert = "varying vec2 vUv;\nuniform mat3 uvTransform;\nvoid main() {\n\tvUv = ( uvTransform * vec3( uv, 1 ) ).xy;\n\tgl_Position = vec4( position.xy, 1.0, 1.0 );\n}";
-
-	var cube_frag = "#include <envmap_common_pars_fragment>\nuniform float opacity;\nvarying vec3 vWorldDirection;\n#include <cube_uv_reflection_fragment>\nvoid main() {\n\tvec3 vReflect = vWorldDirection;\n\t#include <envmap_fragment>\n\tgl_FragColor = envColor;\n\tgl_FragColor.a *= opacity;\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n}";
-
-	var cube_vert = "varying vec3 vWorldDirection;\n#include <common>\nvoid main() {\n\tvWorldDirection = transformDirection( position, modelMatrix );\n\t#include <begin_vertex>\n\t#include <project_vertex>\n\tgl_Position.z = gl_Position.w;\n}";
-
-	var depth_frag = "#if DEPTH_PACKING == 3200\n\tuniform float opacity;\n#endif\n#include <common>\n#include <packing>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvarying vec2 vHighPrecisionZW;\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( 1.0 );\n\t#if DEPTH_PACKING == 3200\n\t\tdiffuseColor.a = opacity;\n\t#endif\n\t#include <map_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <logdepthbuf_fragment>\n\tfloat fragCoordZ = 0.5 * vHighPrecisionZW[0] / vHighPrecisionZW[1] + 0.5;\n\t#if DEPTH_PACKING == 3200\n\t\tgl_FragColor = vec4( vec3( 1.0 - fragCoordZ ), opacity );\n\t#elif DEPTH_PACKING == 3201\n\t\tgl_FragColor = packDepthToRGBA( fragCoordZ );\n\t#endif\n}";
-
-	var depth_vert = "#include <common>\n#include <uv_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvarying vec2 vHighPrecisionZW;\nvoid main() {\n\t#include <uv_vertex>\n\t#include <skinbase_vertex>\n\t#ifdef USE_DISPLACEMENTMAP\n\t\t#include <beginnormal_vertex>\n\t\t#include <morphnormal_vertex>\n\t\t#include <skinnormal_vertex>\n\t#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\tvHighPrecisionZW = gl_Position.zw;\n}";
-
-	var distanceRGBA_frag = "#define DISTANCE\nuniform vec3 referencePosition;\nuniform float nearDistance;\nuniform float farDistance;\nvarying vec3 vWorldPosition;\n#include <common>\n#include <packing>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main () {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( 1.0 );\n\t#include <map_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\tfloat dist = length( vWorldPosition - referencePosition );\n\tdist = ( dist - nearDistance ) / ( farDistance - nearDistance );\n\tdist = saturate( dist );\n\tgl_FragColor = packDepthToRGBA( dist );\n}";
-
-	var distanceRGBA_vert = "#define DISTANCE\nvarying vec3 vWorldPosition;\n#include <common>\n#include <uv_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <skinbase_vertex>\n\t#ifdef USE_DISPLACEMENTMAP\n\t\t#include <beginnormal_vertex>\n\t\t#include <morphnormal_vertex>\n\t\t#include <skinnormal_vertex>\n\t#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <worldpos_vertex>\n\t#include <clipping_planes_vertex>\n\tvWorldPosition = worldPosition.xyz;\n}";
-
-	var equirect_frag = "uniform sampler2D tEquirect;\nvarying vec3 vWorldDirection;\n#include <common>\nvoid main() {\n\tvec3 direction = normalize( vWorldDirection );\n\tvec2 sampleUV;\n\tsampleUV.y = asin( clamp( direction.y, - 1.0, 1.0 ) ) * RECIPROCAL_PI + 0.5;\n\tsampleUV.x = atan( direction.z, direction.x ) * RECIPROCAL_PI2 + 0.5;\n\tvec4 texColor = texture2D( tEquirect, sampleUV );\n\tgl_FragColor = mapTexelToLinear( texColor );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n}";
-
-	var equirect_vert = "varying vec3 vWorldDirection;\n#include <common>\nvoid main() {\n\tvWorldDirection = transformDirection( position, modelMatrix );\n\t#include <begin_vertex>\n\t#include <project_vertex>\n}";
-
-	var linedashed_frag = "uniform vec3 diffuse;\nuniform float opacity;\nuniform float dashSize;\nuniform float totalSize;\nvarying float vLineDistance;\n#include <common>\n#include <color_pars_fragment>\n#include <fog_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tif ( mod( vLineDistance, totalSize ) > dashSize ) {\n\t\tdiscard;\n\t}\n\tvec3 outgoingLight = vec3( 0.0 );\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\t#include <logdepthbuf_fragment>\n\t#include <color_fragment>\n\toutgoingLight = diffuseColor.rgb;\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n}";
-
-	var linedashed_vert = "uniform float scale;\nattribute float lineDistance;\nvarying float vLineDistance;\n#include <common>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\tvLineDistance = scale * lineDistance;\n\t#include <color_vertex>\n\t#include <begin_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <fog_vertex>\n}";
-
-	var meshbasic_frag = "uniform vec3 diffuse;\nuniform float opacity;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\n#include <common>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <uv2_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <envmap_common_pars_fragment>\n#include <envmap_pars_fragment>\n#include <cube_uv_reflection_fragment>\n#include <fog_pars_fragment>\n#include <specularmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <color_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <specularmap_fragment>\n\tReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n\t#ifdef USE_LIGHTMAP\n\t\n\t\tvec4 lightMapTexel= texture2D( lightMap, vUv2 );\n\t\treflectedLight.indirectDiffuse += lightMapTexelToLinear( lightMapTexel ).rgb * lightMapIntensity;\n\t#else\n\t\treflectedLight.indirectDiffuse += vec3( 1.0 );\n\t#endif\n\t#include <aomap_fragment>\n\treflectedLight.indirectDiffuse *= diffuseColor.rgb;\n\tvec3 outgoingLight = reflectedLight.indirectDiffuse;\n\t#include <envmap_fragment>\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n\t#include <dithering_fragment>\n}";
-
-	var meshbasic_vert = "#include <common>\n#include <uv_pars_vertex>\n#include <uv2_pars_vertex>\n#include <envmap_pars_vertex>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <uv2_vertex>\n\t#include <color_vertex>\n\t#include <skinbase_vertex>\n\t#ifdef USE_ENVMAP\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n\t#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <worldpos_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <envmap_vertex>\n\t#include <fog_vertex>\n}";
-
-	var meshlambert_frag = "uniform vec3 diffuse;\nuniform vec3 emissive;\nuniform float opacity;\nvarying vec3 vLightFront;\nvarying vec3 vIndirectFront;\n#ifdef DOUBLE_SIDED\n\tvarying vec3 vLightBack;\n\tvarying vec3 vIndirectBack;\n#endif\n#include <common>\n#include <packing>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <uv2_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <emissivemap_pars_fragment>\n#include <envmap_common_pars_fragment>\n#include <envmap_pars_fragment>\n#include <cube_uv_reflection_fragment>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <fog_pars_fragment>\n#include <shadowmap_pars_fragment>\n#include <shadowmask_pars_fragment>\n#include <specularmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\tReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n\tvec3 totalEmissiveRadiance = emissive;\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <color_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <specularmap_fragment>\n\t#include <emissivemap_fragment>\n\t#ifdef DOUBLE_SIDED\n\t\treflectedLight.indirectDiffuse += ( gl_FrontFacing ) ? vIndirectFront : vIndirectBack;\n\t#else\n\t\treflectedLight.indirectDiffuse += vIndirectFront;\n\t#endif\n\t#include <lightmap_fragment>\n\treflectedLight.indirectDiffuse *= BRDF_Diffuse_Lambert( diffuseColor.rgb );\n\t#ifdef DOUBLE_SIDED\n\t\treflectedLight.directDiffuse = ( gl_FrontFacing ) ? vLightFront : vLightBack;\n\t#else\n\t\treflectedLight.directDiffuse = vLightFront;\n\t#endif\n\treflectedLight.directDiffuse *= BRDF_Diffuse_Lambert( diffuseColor.rgb ) * getShadowMask();\n\t#include <aomap_fragment>\n\tvec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + totalEmissiveRadiance;\n\t#include <envmap_fragment>\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n\t#include <dithering_fragment>\n}";
-
-	var meshlambert_vert = "#define LAMBERT\nvarying vec3 vLightFront;\nvarying vec3 vIndirectFront;\n#ifdef DOUBLE_SIDED\n\tvarying vec3 vLightBack;\n\tvarying vec3 vIndirectBack;\n#endif\n#include <common>\n#include <uv_pars_vertex>\n#include <uv2_pars_vertex>\n#include <envmap_pars_vertex>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <shadowmap_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <uv2_vertex>\n\t#include <color_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <worldpos_vertex>\n\t#include <envmap_vertex>\n\t#include <lights_lambert_vertex>\n\t#include <shadowmap_vertex>\n\t#include <fog_vertex>\n}";
-
-	var meshmatcap_frag = "#define MATCAP\nuniform vec3 diffuse;\nuniform float opacity;\nuniform sampler2D matcap;\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\n#include <common>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <fog_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <color_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <normal_fragment_begin>\n\t#include <normal_fragment_maps>\n\tvec3 viewDir = normalize( vViewPosition );\n\tvec3 x = normalize( vec3( viewDir.z, 0.0, - viewDir.x ) );\n\tvec3 y = cross( viewDir, x );\n\tvec2 uv = vec2( dot( x, normal ), dot( y, normal ) ) * 0.495 + 0.5;\n\t#ifdef USE_MATCAP\n\t\tvec4 matcapColor = texture2D( matcap, uv );\n\t\tmatcapColor = matcapTexelToLinear( matcapColor );\n\t#else\n\t\tvec4 matcapColor = vec4( 1.0 );\n\t#endif\n\tvec3 outgoingLight = diffuseColor.rgb * matcapColor.rgb;\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n\t#include <dithering_fragment>\n}";
-
-	var meshmatcap_vert = "#define MATCAP\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\n#include <common>\n#include <uv_pars_vertex>\n#include <color_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <color_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n\t#ifndef FLAT_SHADED\n\t\tvNormal = normalize( transformedNormal );\n\t#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <fog_vertex>\n\tvViewPosition = - mvPosition.xyz;\n}";
-
-	var meshtoon_frag = "#define TOON\nuniform vec3 diffuse;\nuniform vec3 emissive;\nuniform vec3 specular;\nuniform float shininess;\nuniform float opacity;\n#include <common>\n#include <packing>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <uv2_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <emissivemap_pars_fragment>\n#include <gradientmap_pars_fragment>\n#include <fog_pars_fragment>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <lights_toon_pars_fragment>\n#include <shadowmap_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <specularmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\tReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n\tvec3 totalEmissiveRadiance = emissive;\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <color_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <specularmap_fragment>\n\t#include <normal_fragment_begin>\n\t#include <normal_fragment_maps>\n\t#include <emissivemap_fragment>\n\t#include <lights_toon_fragment>\n\t#include <lights_fragment_begin>\n\t#include <lights_fragment_maps>\n\t#include <lights_fragment_end>\n\t#include <aomap_fragment>\n\tvec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n\t#include <dithering_fragment>\n}";
-
-	var meshtoon_vert = "#define TOON\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\n#include <common>\n#include <uv_pars_vertex>\n#include <uv2_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <shadowmap_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <uv2_vertex>\n\t#include <color_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n#ifndef FLAT_SHADED\n\tvNormal = normalize( transformedNormal );\n#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\tvViewPosition = - mvPosition.xyz;\n\t#include <worldpos_vertex>\n\t#include <shadowmap_vertex>\n\t#include <fog_vertex>\n}";
-
-	var meshphong_frag = "#define PHONG\nuniform vec3 diffuse;\nuniform vec3 emissive;\nuniform vec3 specular;\nuniform float shininess;\nuniform float opacity;\n#include <common>\n#include <packing>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <uv2_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <emissivemap_pars_fragment>\n#include <envmap_common_pars_fragment>\n#include <envmap_pars_fragment>\n#include <cube_uv_reflection_fragment>\n#include <fog_pars_fragment>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <lights_phong_pars_fragment>\n#include <shadowmap_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <specularmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\tReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n\tvec3 totalEmissiveRadiance = emissive;\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <color_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <specularmap_fragment>\n\t#include <normal_fragment_begin>\n\t#include <normal_fragment_maps>\n\t#include <emissivemap_fragment>\n\t#include <lights_phong_fragment>\n\t#include <lights_fragment_begin>\n\t#include <lights_fragment_maps>\n\t#include <lights_fragment_end>\n\t#include <aomap_fragment>\n\tvec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;\n\t#include <envmap_fragment>\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n\t#include <dithering_fragment>\n}";
-
-	var meshphong_vert = "#define PHONG\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n#endif\n#include <common>\n#include <uv_pars_vertex>\n#include <uv2_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <envmap_pars_vertex>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <shadowmap_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <uv2_vertex>\n\t#include <color_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n#ifndef FLAT_SHADED\n\tvNormal = normalize( transformedNormal );\n#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\tvViewPosition = - mvPosition.xyz;\n\t#include <worldpos_vertex>\n\t#include <envmap_vertex>\n\t#include <shadowmap_vertex>\n\t#include <fog_vertex>\n}";
-
-	var meshphysical_frag = "#define STANDARD\n#ifdef PHYSICAL\n\t#define REFLECTIVITY\n\t#define CLEARCOAT\n\t#define TRANSPARENCY\n#endif\nuniform vec3 diffuse;\nuniform vec3 emissive;\nuniform float roughness;\nuniform float metalness;\nuniform float opacity;\n#ifdef TRANSPARENCY\n\tuniform float transparency;\n#endif\n#ifdef REFLECTIVITY\n\tuniform float reflectivity;\n#endif\n#ifdef CLEARCOAT\n\tuniform float clearcoat;\n\tuniform float clearcoatRoughness;\n#endif\n#ifdef USE_SHEEN\n\tuniform vec3 sheen;\n#endif\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n\t#ifdef USE_TANGENT\n\t\tvarying vec3 vTangent;\n\t\tvarying vec3 vBitangent;\n\t#endif\n#endif\n#include <common>\n#include <packing>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <uv2_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <emissivemap_pars_fragment>\n#include <bsdfs>\n#include <cube_uv_reflection_fragment>\n#include <envmap_common_pars_fragment>\n#include <envmap_physical_pars_fragment>\n#include <fog_pars_fragment>\n#include <lights_pars_begin>\n#include <lights_physical_pars_fragment>\n#include <shadowmap_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <clearcoat_pars_fragment>\n#include <roughnessmap_pars_fragment>\n#include <metalnessmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\tReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n\tvec3 totalEmissiveRadiance = emissive;\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <color_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\t#include <roughnessmap_fragment>\n\t#include <metalnessmap_fragment>\n\t#include <normal_fragment_begin>\n\t#include <normal_fragment_maps>\n\t#include <clearcoat_normal_fragment_begin>\n\t#include <clearcoat_normal_fragment_maps>\n\t#include <emissivemap_fragment>\n\t#include <lights_physical_fragment>\n\t#include <lights_fragment_begin>\n\t#include <lights_fragment_maps>\n\t#include <lights_fragment_end>\n\t#include <aomap_fragment>\n\tvec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;\n\t#ifdef TRANSPARENCY\n\t\tdiffuseColor.a *= saturate( 1. - transparency + linearToRelativeLuminance( reflectedLight.directSpecular + reflectedLight.indirectSpecular ) );\n\t#endif\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n\t#include <dithering_fragment>\n}";
-
-	var meshphysical_vert = "#define STANDARD\nvarying vec3 vViewPosition;\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n\t#ifdef USE_TANGENT\n\t\tvarying vec3 vTangent;\n\t\tvarying vec3 vBitangent;\n\t#endif\n#endif\n#include <common>\n#include <uv_pars_vertex>\n#include <uv2_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <shadowmap_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <uv2_vertex>\n\t#include <color_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n#ifndef FLAT_SHADED\n\tvNormal = normalize( transformedNormal );\n\t#ifdef USE_TANGENT\n\t\tvTangent = normalize( transformedTangent );\n\t\tvBitangent = normalize( cross( vNormal, vTangent ) * tangent.w );\n\t#endif\n#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\tvViewPosition = - mvPosition.xyz;\n\t#include <worldpos_vertex>\n\t#include <shadowmap_vertex>\n\t#include <fog_vertex>\n}";
-
-	var normal_frag = "#define NORMAL\nuniform float opacity;\n#if defined( FLAT_SHADED ) || defined( USE_BUMPMAP ) || defined( TANGENTSPACE_NORMALMAP )\n\tvarying vec3 vViewPosition;\n#endif\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n\t#ifdef USE_TANGENT\n\t\tvarying vec3 vTangent;\n\t\tvarying vec3 vBitangent;\n\t#endif\n#endif\n#include <packing>\n#include <uv_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\t#include <logdepthbuf_fragment>\n\t#include <normal_fragment_begin>\n\t#include <normal_fragment_maps>\n\tgl_FragColor = vec4( packNormalToRGB( normal ), opacity );\n}";
-
-	var normal_vert = "#define NORMAL\n#if defined( FLAT_SHADED ) || defined( USE_BUMPMAP ) || defined( TANGENTSPACE_NORMALMAP )\n\tvarying vec3 vViewPosition;\n#endif\n#ifndef FLAT_SHADED\n\tvarying vec3 vNormal;\n\t#ifdef USE_TANGENT\n\t\tvarying vec3 vTangent;\n\t\tvarying vec3 vBitangent;\n\t#endif\n#endif\n#include <common>\n#include <uv_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\t#include <beginnormal_vertex>\n\t#include <morphnormal_vertex>\n\t#include <skinbase_vertex>\n\t#include <skinnormal_vertex>\n\t#include <defaultnormal_vertex>\n#ifndef FLAT_SHADED\n\tvNormal = normalize( transformedNormal );\n\t#ifdef USE_TANGENT\n\t\tvTangent = normalize( transformedTangent );\n\t\tvBitangent = normalize( cross( vNormal, vTangent ) * tangent.w );\n\t#endif\n#endif\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <skinning_vertex>\n\t#include <displacementmap_vertex>\n\t#include <project_vertex>\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n#if defined( FLAT_SHADED ) || defined( USE_BUMPMAP ) || defined( TANGENTSPACE_NORMALMAP )\n\tvViewPosition = - mvPosition.xyz;\n#endif\n}";
-
-	var points_frag = "uniform vec3 diffuse;\nuniform float opacity;\n#include <common>\n#include <color_pars_fragment>\n#include <map_particle_pars_fragment>\n#include <fog_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec3 outgoingLight = vec3( 0.0 );\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\t#include <logdepthbuf_fragment>\n\t#include <map_particle_fragment>\n\t#include <color_fragment>\n\t#include <alphatest_fragment>\n\toutgoingLight = diffuseColor.rgb;\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n\t#include <premultiplied_alpha_fragment>\n}";
-
-	var points_vert = "uniform float size;\nuniform float scale;\n#include <common>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <color_vertex>\n\t#include <begin_vertex>\n\t#include <morphtarget_vertex>\n\t#include <project_vertex>\n\tgl_PointSize = size;\n\t#ifdef USE_SIZEATTENUATION\n\t\tbool isPerspective = isPerspectiveMatrix( projectionMatrix );\n\t\tif ( isPerspective ) gl_PointSize *= ( scale / - mvPosition.z );\n\t#endif\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <worldpos_vertex>\n\t#include <fog_vertex>\n}";
-
-	var shadow_frag = "uniform vec3 color;\nuniform float opacity;\n#include <common>\n#include <packing>\n#include <fog_pars_fragment>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <shadowmap_pars_fragment>\n#include <shadowmask_pars_fragment>\nvoid main() {\n\tgl_FragColor = vec4( color, opacity * ( 1.0 - getShadowMask() ) );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n}";
-
-	var shadow_vert = "#include <fog_pars_vertex>\n#include <shadowmap_pars_vertex>\nvoid main() {\n\t#include <begin_vertex>\n\t#include <project_vertex>\n\t#include <worldpos_vertex>\n\t#include <shadowmap_vertex>\n\t#include <fog_vertex>\n}";
-
-	var sprite_frag = "uniform vec3 diffuse;\nuniform float opacity;\n#include <common>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <fog_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n\t#include <clipping_planes_fragment>\n\tvec3 outgoingLight = vec3( 0.0 );\n\tvec4 diffuseColor = vec4( diffuse, opacity );\n\t#include <logdepthbuf_fragment>\n\t#include <map_fragment>\n\t#include <alphamap_fragment>\n\t#include <alphatest_fragment>\n\toutgoingLight = diffuseColor.rgb;\n\tgl_FragColor = vec4( outgoingLight, diffuseColor.a );\n\t#include <tonemapping_fragment>\n\t#include <encodings_fragment>\n\t#include <fog_fragment>\n}";
-
-	var sprite_vert = "uniform float rotation;\nuniform vec2 center;\n#include <common>\n#include <uv_pars_vertex>\n#include <fog_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n\t#include <uv_vertex>\n\tvec4 mvPosition = modelViewMatrix * vec4( 0.0, 0.0, 0.0, 1.0 );\n\tvec2 scale;\n\tscale.x = length( vec3( modelMatrix[ 0 ].x, modelMatrix[ 0 ].y, modelMatrix[ 0 ].z ) );\n\tscale.y = length( vec3( modelMatrix[ 1 ].x, modelMatrix[ 1 ].y, modelMatrix[ 1 ].z ) );\n\t#ifndef USE_SIZEATTENUATION\n\t\tbool isPerspective = isPerspectiveMatrix( projectionMatrix );\n\t\tif ( isPerspective ) scale *= - mvPosition.z;\n\t#endif\n\tvec2 alignedPosition = ( position.xy - ( center - vec2( 0.5 ) ) ) * scale;\n\tvec2 rotatedPosition;\n\trotatedPosition.x = cos( rotation ) * alignedPosition.x - sin( rotation ) * alignedPosition.y;\n\trotatedPosition.y = sin( rotation ) * alignedPosition.x + cos( rotation ) * alignedPosition.y;\n\tmvPosition.xy += rotatedPosition;\n\tgl_Position = projectionMatrix * mvPosition;\n\t#include <logdepthbuf_vertex>\n\t#include <clipping_planes_vertex>\n\t#include <fog_vertex>\n}";
-
-	var ShaderChunk = {
-		alphamap_fragment: alphamap_fragment,
-		alphamap_pars_fragment: alphamap_pars_fragment,
-		alphatest_fragment: alphatest_fragment,
-		aomap_fragment: aomap_fragment,
-		aomap_pars_fragment: aomap_pars_fragment,
-		begin_vertex: begin_vertex,
-		beginnormal_vertex: beginnormal_vertex,
-		bsdfs: bsdfs,
-		bumpmap_pars_fragment: bumpmap_pars_fragment,
-		clipping_planes_fragment: clipping_planes_fragment,
-		clipping_planes_pars_fragment: clipping_planes_pars_fragment,
-		clipping_planes_pars_vertex: clipping_planes_pars_vertex,
-		clipping_planes_vertex: clipping_planes_vertex,
-		color_fragment: color_fragment,
-		color_pars_fragment: color_pars_fragment,
-		color_pars_vertex: color_pars_vertex,
-		color_vertex: color_vertex,
-		common: common,
-		cube_uv_reflection_fragment: cube_uv_reflection_fragment,
-		defaultnormal_vertex: defaultnormal_vertex,
-		displacementmap_pars_vertex: displacementmap_pars_vertex,
-		displacementmap_vertex: displacementmap_vertex,
-		emissivemap_fragment: emissivemap_fragment,
-		emissivemap_pars_fragment: emissivemap_pars_fragment,
-		encodings_fragment: encodings_fragment,
-		encodings_pars_fragment: encodings_pars_fragment,
-		envmap_fragment: envmap_fragment,
-		envmap_common_pars_fragment: envmap_common_pars_fragment,
-		envmap_pars_fragment: envmap_pars_fragment,
-		envmap_pars_vertex: envmap_pars_vertex,
-		envmap_physical_pars_fragment: envmap_physical_pars_fragment,
-		envmap_vertex: envmap_vertex,
-		fog_vertex: fog_vertex,
-		fog_pars_vertex: fog_pars_vertex,
-		fog_fragment: fog_fragment,
-		fog_pars_fragment: fog_pars_fragment,
-		gradientmap_pars_fragment: gradientmap_pars_fragment,
-		lightmap_fragment: lightmap_fragment,
-		lightmap_pars_fragment: lightmap_pars_fragment,
-		lights_lambert_vertex: lights_lambert_vertex,
-		lights_pars_begin: lights_pars_begin,
-		lights_toon_fragment: lights_toon_fragment,
-		lights_toon_pars_fragment: lights_toon_pars_fragment,
-		lights_phong_fragment: lights_phong_fragment,
-		lights_phong_pars_fragment: lights_phong_pars_fragment,
-		lights_physical_fragment: lights_physical_fragment,
-		lights_physical_pars_fragment: lights_physical_pars_fragment,
-		lights_fragment_begin: lights_fragment_begin,
-		lights_fragment_maps: lights_fragment_maps,
-		lights_fragment_end: lights_fragment_end,
-		logdepthbuf_fragment: logdepthbuf_fragment,
-		logdepthbuf_pars_fragment: logdepthbuf_pars_fragment,
-		logdepthbuf_pars_vertex: logdepthbuf_pars_vertex,
-		logdepthbuf_vertex: logdepthbuf_vertex,
-		map_fragment: map_fragment,
-		map_pars_fragment: map_pars_fragment,
-		map_particle_fragment: map_particle_fragment,
-		map_particle_pars_fragment: map_particle_pars_fragment,
-		metalnessmap_fragment: metalnessmap_fragment,
-		metalnessmap_pars_fragment: metalnessmap_pars_fragment,
-		morphnormal_vertex: morphnormal_vertex,
-		morphtarget_pars_vertex: morphtarget_pars_vertex,
-		morphtarget_vertex: morphtarget_vertex,
-		normal_fragment_begin: normal_fragment_begin,
-		normal_fragment_maps: normal_fragment_maps,
-		normalmap_pars_fragment: normalmap_pars_fragment,
-		clearcoat_normal_fragment_begin: clearcoat_normal_fragment_begin,
-		clearcoat_normal_fragment_maps: clearcoat_normal_fragment_maps,
-		clearcoat_pars_fragment: clearcoat_pars_fragment,
-		packing: packing,
-		premultiplied_alpha_fragment: premultiplied_alpha_fragment,
-		project_vertex: project_vertex,
-		dithering_fragment: dithering_fragment,
-		dithering_pars_fragment: dithering_pars_fragment,
-		roughnessmap_fragment: roughnessmap_fragment,
-		roughnessmap_pars_fragment: roughnessmap_pars_fragment,
-		shadowmap_pars_fragment: shadowmap_pars_fragment,
-		shadowmap_pars_vertex: shadowmap_pars_vertex,
-		shadowmap_vertex: shadowmap_vertex,
-		shadowmask_pars_fragment: shadowmask_pars_fragment,
-		skinbase_vertex: skinbase_vertex,
-		skinning_pars_vertex: skinning_pars_vertex,
-		skinning_vertex: skinning_vertex,
-		skinnormal_vertex: skinnormal_vertex,
-		specularmap_fragment: specularmap_fragment,
-		specularmap_pars_fragment: specularmap_pars_fragment,
-		tonemapping_fragment: tonemapping_fragment,
-		tonemapping_pars_fragment: tonemapping_pars_fragment,
-		uv_pars_fragment: uv_pars_fragment,
-		uv_pars_vertex: uv_pars_vertex,
-		uv_vertex: uv_vertex,
-		uv2_pars_fragment: uv2_pars_fragment,
-		uv2_pars_vertex: uv2_pars_vertex,
-		uv2_vertex: uv2_vertex,
-		worldpos_vertex: worldpos_vertex,
-
-		background_frag: background_frag,
-		background_vert: background_vert,
-		cube_frag: cube_frag,
-		cube_vert: cube_vert,
-		depth_frag: depth_frag,
-		depth_vert: depth_vert,
-		distanceRGBA_frag: distanceRGBA_frag,
-		distanceRGBA_vert: distanceRGBA_vert,
-		equirect_frag: equirect_frag,
-		equirect_vert: equirect_vert,
-		linedashed_frag: linedashed_frag,
-		linedashed_vert: linedashed_vert,
-		meshbasic_frag: meshbasic_frag,
-		meshbasic_vert: meshbasic_vert,
-		meshlambert_frag: meshlambert_frag,
-		meshlambert_vert: meshlambert_vert,
-		meshmatcap_frag: meshmatcap_frag,
-		meshmatcap_vert: meshmatcap_vert,
-		meshtoon_frag: meshtoon_frag,
-		meshtoon_vert: meshtoon_vert,
-		meshphong_frag: meshphong_frag,
-		meshphong_vert: meshphong_vert,
-		meshphysical_frag: meshphysical_frag,
-		meshphysical_vert: meshphysical_vert,
-		normal_frag: normal_frag,
-		normal_vert: normal_vert,
-		points_frag: points_frag,
-		points_vert: points_vert,
-		shadow_frag: shadow_frag,
-		shadow_vert: shadow_vert,
-		sprite_frag: sprite_frag,
-		sprite_vert: sprite_vert
-	};
-
-	/**
-	 * @author alteredq / http://alteredqualia.com/
-	 * @author mrdoob / http://mrdoob.com/
-	 * @author mikael emtinger / http://gomo.se/
-	 */
-
-	var ShaderLib = {
-
-		basic: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.common,
-				UniformsLib.specularmap,
-				UniformsLib.envmap,
-				UniformsLib.aomap,
-				UniformsLib.lightmap,
-				UniformsLib.fog
-			] ),
-
-			vertexShader: ShaderChunk.meshbasic_vert,
-			fragmentShader: ShaderChunk.meshbasic_frag
-
-		},
-
-		lambert: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.common,
-				UniformsLib.specularmap,
-				UniformsLib.envmap,
-				UniformsLib.aomap,
-				UniformsLib.lightmap,
-				UniformsLib.emissivemap,
-				UniformsLib.fog,
-				UniformsLib.lights,
-				{
-					emissive: { value: new Color( 0x000000 ) }
-				}
-			] ),
-
-			vertexShader: ShaderChunk.meshlambert_vert,
-			fragmentShader: ShaderChunk.meshlambert_frag
-
-		},
-
-		phong: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.common,
-				UniformsLib.specularmap,
-				UniformsLib.envmap,
-				UniformsLib.aomap,
-				UniformsLib.lightmap,
-				UniformsLib.emissivemap,
-				UniformsLib.bumpmap,
-				UniformsLib.normalmap,
-				UniformsLib.displacementmap,
-				UniformsLib.fog,
-				UniformsLib.lights,
-				{
-					emissive: { value: new Color( 0x000000 ) },
-					specular: { value: new Color( 0x111111 ) },
-					shininess: { value: 30 }
-				}
-			] ),
-
-			vertexShader: ShaderChunk.meshphong_vert,
-			fragmentShader: ShaderChunk.meshphong_frag
-
-		},
-
-		standard: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.common,
-				UniformsLib.envmap,
-				UniformsLib.aomap,
-				UniformsLib.lightmap,
-				UniformsLib.emissivemap,
-				UniformsLib.bumpmap,
-				UniformsLib.normalmap,
-				UniformsLib.displacementmap,
-				UniformsLib.roughnessmap,
-				UniformsLib.metalnessmap,
-				UniformsLib.fog,
-				UniformsLib.lights,
-				{
-					emissive: { value: new Color( 0x000000 ) },
-					roughness: { value: 1.0 },
-					metalness: { value: 0.0 },
-					envMapIntensity: { value: 1 } // temporary
-				}
-			] ),
-
-			vertexShader: ShaderChunk.meshphysical_vert,
-			fragmentShader: ShaderChunk.meshphysical_frag
-
-		},
-
-		toon: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.common,
-				UniformsLib.specularmap,
-				UniformsLib.aomap,
-				UniformsLib.lightmap,
-				UniformsLib.emissivemap,
-				UniformsLib.bumpmap,
-				UniformsLib.normalmap,
-				UniformsLib.displacementmap,
-				UniformsLib.gradientmap,
-				UniformsLib.fog,
-				UniformsLib.lights,
-				{
-					emissive: { value: new Color( 0x000000 ) },
-					specular: { value: new Color( 0x111111 ) },
-					shininess: { value: 30 }
-				}
-			] ),
-
-			vertexShader: ShaderChunk.meshtoon_vert,
-			fragmentShader: ShaderChunk.meshtoon_frag
-
-		},
-
-		matcap: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.common,
-				UniformsLib.bumpmap,
-				UniformsLib.normalmap,
-				UniformsLib.displacementmap,
-				UniformsLib.fog,
-				{
-					matcap: { value: null }
-				}
-			] ),
-
-			vertexShader: ShaderChunk.meshmatcap_vert,
-			fragmentShader: ShaderChunk.meshmatcap_frag
-
-		},
-
-		points: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.points,
-				UniformsLib.fog
-			] ),
-
-			vertexShader: ShaderChunk.points_vert,
-			fragmentShader: ShaderChunk.points_frag
-
-		},
-
-		dashed: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.common,
-				UniformsLib.fog,
-				{
-					scale: { value: 1 },
-					dashSize: { value: 1 },
-					totalSize: { value: 2 }
-				}
-			] ),
-
-			vertexShader: ShaderChunk.linedashed_vert,
-			fragmentShader: ShaderChunk.linedashed_frag
-
-		},
-
-		depth: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.common,
-				UniformsLib.displacementmap
-			] ),
-
-			vertexShader: ShaderChunk.depth_vert,
-			fragmentShader: ShaderChunk.depth_frag
-
-		},
-
-		normal: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.common,
-				UniformsLib.bumpmap,
-				UniformsLib.normalmap,
-				UniformsLib.displacementmap,
-				{
-					opacity: { value: 1.0 }
-				}
-			] ),
-
-			vertexShader: ShaderChunk.normal_vert,
-			fragmentShader: ShaderChunk.normal_frag
-
-		},
-
-		sprite: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.sprite,
-				UniformsLib.fog
-			] ),
-
-			vertexShader: ShaderChunk.sprite_vert,
-			fragmentShader: ShaderChunk.sprite_frag
-
-		},
-
-		background: {
-
-			uniforms: {
-				uvTransform: { value: new Matrix3() },
-				t2D: { value: null },
-			},
-
-			vertexShader: ShaderChunk.background_vert,
-			fragmentShader: ShaderChunk.background_frag
-
-		},
-		/* -------------------------------------------------------------------------
-		//	Cube map shader
-		 ------------------------------------------------------------------------- */
-
-		cube: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.envmap,
-				{
-					opacity: { value: 1.0 }
-				}
-			] ),
-
-			vertexShader: ShaderChunk.cube_vert,
-			fragmentShader: ShaderChunk.cube_frag
-
-		},
-
-		equirect: {
-
-			uniforms: {
-				tEquirect: { value: null },
-			},
-
-			vertexShader: ShaderChunk.equirect_vert,
-			fragmentShader: ShaderChunk.equirect_frag
-
-		},
-
-		distanceRGBA: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.common,
-				UniformsLib.displacementmap,
-				{
-					referencePosition: { value: new Vector3() },
-					nearDistance: { value: 1 },
-					farDistance: { value: 1000 }
-				}
-			] ),
-
-			vertexShader: ShaderChunk.distanceRGBA_vert,
-			fragmentShader: ShaderChunk.distanceRGBA_frag
-
-		},
-
-		shadow: {
-
-			uniforms: mergeUniforms( [
-				UniformsLib.lights,
-				UniformsLib.fog,
-				{
-					color: { value: new Color( 0x00000 ) },
-					opacity: { value: 1.0 }
-				},
-			] ),
-
-			vertexShader: ShaderChunk.shadow_vert,
-			fragmentShader: ShaderChunk.shadow_frag
-
-		}
-
-	};
-
-	ShaderLib.physical = {
-
-		uniforms: mergeUniforms( [
-			ShaderLib.standard.uniforms,
-			{
-				clearcoat: { value: 0 },
-				clearcoatMap: { value: null },
-				clearcoatRoughness: { value: 0 },
-				clearcoatRoughnessMap: { value: null },
-				clearcoatNormalScale: { value: new Vector2( 1, 1 ) },
-				clearcoatNormalMap: { value: null },
-				sheen: { value: new Color( 0x000000 ) },
-				transparency: { value: 0 },
-			}
-		] ),
-
-		vertexShader: ShaderChunk.meshphysical_vert,
-		fragmentShader: ShaderChunk.meshphysical_frag
-
-	};
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -15533,10 +15515,10 @@ var Spacekit = (function (exports) {
 
 		var planeMesh;
 		var boxMesh;
-
+		// Store the current background texture and its `version`
+		// so we can recompile the material accordingly.
 		var currentBackground = null;
 		var currentBackgroundVersion = 0;
-		var currentTonemapping = null;
 
 		function render( renderList, scene, camera, forceClear ) {
 
@@ -15545,8 +15527,8 @@ var Spacekit = (function (exports) {
 			// Ignore background in AR
 			// TODO: Reconsider this.
 
-			var xr = renderer.xr;
-			var session = xr.getSession && xr.getSession();
+			var vr = renderer.vr;
+			var session = vr.getSession && vr.getSession();
 
 			if ( session && session.environmentBlendMode === 'additive' ) {
 
@@ -15557,11 +15539,15 @@ var Spacekit = (function (exports) {
 			if ( background === null ) {
 
 				setClear( clearColor, clearAlpha );
+				currentBackground = null;
+				currentBackgroundVersion = 0;
 
 			} else if ( background && background.isColor ) {
 
 				setClear( background, 1 );
 				forceClear = true;
+				currentBackground = null;
+				currentBackgroundVersion = 0;
 
 			}
 
@@ -15571,7 +15557,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			if ( background && ( background.isCubeTexture || background.isWebGLCubeRenderTarget || background.mapping === CubeUVReflectionMapping ) ) {
+			if ( background && ( background.isCubeTexture || background.isWebGLRenderTargetCube ) ) {
 
 				if ( boxMesh === undefined ) {
 
@@ -15589,8 +15575,8 @@ var Spacekit = (function (exports) {
 						} )
 					);
 
-					boxMesh.geometry.deleteAttribute( 'normal' );
-					boxMesh.geometry.deleteAttribute( 'uv' );
+					boxMesh.geometry.removeAttribute( 'normal' );
+					boxMesh.geometry.removeAttribute( 'uv' );
 
 					boxMesh.onBeforeRender = function ( renderer, scene, camera ) {
 
@@ -15599,11 +15585,11 @@ var Spacekit = (function (exports) {
 					};
 
 					// enable code injection for non-built-in material
-					Object.defineProperty( boxMesh.material, 'envMap', {
+					Object.defineProperty( boxMesh.material, 'map', {
 
 						get: function () {
 
-							return this.uniforms.envMap.value;
+							return this.uniforms.tCube.value;
 
 						}
 
@@ -15613,20 +15599,17 @@ var Spacekit = (function (exports) {
 
 				}
 
-				var texture = background.isWebGLCubeRenderTarget ? background.texture : background;
-
-				boxMesh.material.uniforms.envMap.value = texture;
-				boxMesh.material.uniforms.flipEnvMap.value = texture.isCubeTexture ? - 1 : 1;
+				var texture = background.isWebGLRenderTargetCube ? background.texture : background;
+				boxMesh.material.uniforms.tCube.value = texture;
+				boxMesh.material.uniforms.tFlip.value = ( background.isWebGLRenderTargetCube ) ? 1 : - 1;
 
 				if ( currentBackground !== background ||
-					currentBackgroundVersion !== texture.version ||
-					currentTonemapping !== renderer.toneMapping ) {
+				     currentBackgroundVersion !== texture.version ) {
 
 					boxMesh.material.needsUpdate = true;
 
 					currentBackground = background;
 					currentBackgroundVersion = texture.version;
-					currentTonemapping = renderer.toneMapping;
 
 				}
 
@@ -15651,7 +15634,7 @@ var Spacekit = (function (exports) {
 						} )
 					);
 
-					planeMesh.geometry.deleteAttribute( 'normal' );
+					planeMesh.geometry.removeAttribute( 'normal' );
 
 					// enable code injection for non-built-in material
 					Object.defineProperty( planeMesh.material, 'map', {
@@ -15679,14 +15662,12 @@ var Spacekit = (function (exports) {
 				planeMesh.material.uniforms.uvTransform.value.copy( background.matrix );
 
 				if ( currentBackground !== background ||
-					currentBackgroundVersion !== background.version ||
-					currentTonemapping !== renderer.toneMapping ) {
+					   currentBackgroundVersion !== background.version ) {
 
 					planeMesh.material.needsUpdate = true;
 
 					currentBackground = background;
 					currentBackgroundVersion = background.version;
-					currentTonemapping = renderer.toneMapping;
 
 				}
 
@@ -15741,8 +15722,6 @@ var Spacekit = (function (exports) {
 
 	function WebGLBufferRenderer( gl, extensions, info, capabilities ) {
 
-		var isWebGL2 = capabilities.isWebGL2;
-
 		var mode;
 
 		function setMode( value ) {
@@ -15759,21 +15738,17 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function renderInstances( geometry, start, count, primcount ) {
+		function renderInstances( geometry, start, count ) {
 
-			if ( primcount === 0 ) return;
+			var extension;
 
-			var extension, methodName;
-
-			if ( isWebGL2 ) {
+			if ( capabilities.isWebGL2 ) {
 
 				extension = gl;
-				methodName = 'drawArraysInstanced';
 
 			} else {
 
 				extension = extensions.get( 'ANGLE_instanced_arrays' );
-				methodName = 'drawArraysInstancedANGLE';
 
 				if ( extension === null ) {
 
@@ -15784,9 +15759,9 @@ var Spacekit = (function (exports) {
 
 			}
 
-			extension[ methodName ]( mode, start, count, primcount );
+			extension[ capabilities.isWebGL2 ? 'drawArraysInstanced' : 'drawArraysInstancedANGLE' ]( mode, start, count, geometry.maxInstancedCount );
 
-			info.update( count, mode, primcount );
+			info.update( count, mode, geometry.maxInstancedCount );
 
 		}
 
@@ -15831,7 +15806,7 @@ var Spacekit = (function (exports) {
 			if ( precision === 'highp' ) {
 
 				if ( gl.getShaderPrecisionFormat( 35633, 36338 ).precision > 0 &&
-					gl.getShaderPrecisionFormat( 35632, 36338 ).precision > 0 ) {
+				     gl.getShaderPrecisionFormat( 35632, 36338 ).precision > 0 ) {
 
 					return 'highp';
 
@@ -15844,7 +15819,7 @@ var Spacekit = (function (exports) {
 			if ( precision === 'mediump' ) {
 
 				if ( gl.getShaderPrecisionFormat( 35633, 36337 ).precision > 0 &&
-					gl.getShaderPrecisionFormat( 35632, 36337 ).precision > 0 ) {
+				     gl.getShaderPrecisionFormat( 35632, 36337 ).precision > 0 ) {
 
 					return 'mediump';
 
@@ -15856,10 +15831,7 @@ var Spacekit = (function (exports) {
 
 		}
 
-		/* eslint-disable no-undef */
-		var isWebGL2 = ( typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext ) ||
-			( typeof WebGL2ComputeRenderingContext !== 'undefined' && gl instanceof WebGL2ComputeRenderingContext );
-		/* eslint-enable no-undef */
+		var isWebGL2 = typeof WebGL2RenderingContext !== 'undefined' && gl instanceof WebGL2RenderingContext;
 
 		var precision = parameters.precision !== undefined ? parameters.precision : 'highp';
 		var maxPrecision = getMaxPrecision( precision );
@@ -16071,7 +16043,6 @@ var Spacekit = (function (exports) {
 			}
 
 			scope.numPlanes = nPlanes;
-			scope.numIntersection = 0;
 
 			return dstArray;
 
@@ -16144,13 +16115,13 @@ var Spacekit = (function (exports) {
 
 	function WebGLGeometries( gl, attributes, info ) {
 
-		var geometries = new WeakMap();
-		var wireframeAttributes = new WeakMap();
+		var geometries = {};
+		var wireframeAttributes = {};
 
 		function onGeometryDispose( event ) {
 
 			var geometry = event.target;
-			var buffergeometry = geometries.get( geometry );
+			var buffergeometry = geometries[ geometry.id ];
 
 			if ( buffergeometry.index !== null ) {
 
@@ -16166,14 +16137,14 @@ var Spacekit = (function (exports) {
 
 			geometry.removeEventListener( 'dispose', onGeometryDispose );
 
-			geometries.delete( geometry );
+			delete geometries[ geometry.id ];
 
-			var attribute = wireframeAttributes.get( buffergeometry );
+			var attribute = wireframeAttributes[ buffergeometry.id ];
 
 			if ( attribute ) {
 
 				attributes.remove( attribute );
-				wireframeAttributes.delete( buffergeometry );
+				delete wireframeAttributes[ buffergeometry.id ];
 
 			}
 
@@ -16185,7 +16156,7 @@ var Spacekit = (function (exports) {
 
 		function get( object, geometry ) {
 
-			var buffergeometry = geometries.get( geometry );
+			var buffergeometry = geometries[ geometry.id ];
 
 			if ( buffergeometry ) return buffergeometry;
 
@@ -16207,7 +16178,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			geometries.set( geometry, buffergeometry );
+			geometries[ geometry.id ] = buffergeometry;
 
 			info.memory.geometries ++;
 
@@ -16297,19 +16268,19 @@ var Spacekit = (function (exports) {
 
 			//
 
-			var previousAttribute = wireframeAttributes.get( geometry );
+			var previousAttribute = wireframeAttributes[ geometry.id ];
 
 			if ( previousAttribute ) attributes.remove( previousAttribute );
 
 			//
 
-			wireframeAttributes.set( geometry, attribute );
+			wireframeAttributes[ geometry.id ] = attribute;
 
 		}
 
 		function getWireframeAttribute( geometry ) {
 
-			var currentAttribute = wireframeAttributes.get( geometry );
+			var currentAttribute = wireframeAttributes[ geometry.id ];
 
 			if ( currentAttribute ) {
 
@@ -16333,7 +16304,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			return wireframeAttributes.get( geometry );
+			return wireframeAttributes[ geometry.id ];
 
 		}
 
@@ -16353,8 +16324,6 @@ var Spacekit = (function (exports) {
 	 */
 
 	function WebGLIndexedBufferRenderer( gl, extensions, info, capabilities ) {
-
-		var isWebGL2 = capabilities.isWebGL2;
 
 		var mode;
 
@@ -16381,21 +16350,17 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function renderInstances( geometry, start, count, primcount ) {
+		function renderInstances( geometry, start, count ) {
 
-			if ( primcount === 0 ) return;
+			var extension;
 
-			var extension, methodName;
-
-			if ( isWebGL2 ) {
+			if ( capabilities.isWebGL2 ) {
 
 				extension = gl;
-				methodName = 'drawElementsInstanced';
 
 			} else {
 
-				extension = extensions.get( 'ANGLE_instanced_arrays' );
-				methodName = 'drawElementsInstancedANGLE';
+				var extension = extensions.get( 'ANGLE_instanced_arrays' );
 
 				if ( extension === null ) {
 
@@ -16406,9 +16371,9 @@ var Spacekit = (function (exports) {
 
 			}
 
-			extension[ methodName ]( mode, count, type, start * bytesPerElement, primcount );
+			extension[ capabilities.isWebGL2 ? 'drawElementsInstanced' : 'drawElementsInstancedANGLE' ]( mode, count, type, start * bytesPerElement, geometry.maxInstancedCount );
 
-			info.update( count, mode, primcount );
+			info.update( count, mode, geometry.maxInstancedCount );
 
 		}
 
@@ -16450,6 +16415,11 @@ var Spacekit = (function (exports) {
 
 				case 4:
 					render.triangles += instanceCount * ( count / 3 );
+					break;
+
+				case 5:
+				case 6:
+					render.triangles += instanceCount * ( count - 2 );
 					break;
 
 				case 1:
@@ -16516,10 +16486,7 @@ var Spacekit = (function (exports) {
 
 			var objectInfluences = object.morphTargetInfluences;
 
-			// When object doesn't have morph target influences defined, we treat it as a 0-length array
-			// This is important to make sure we set up morphTargetBaseInfluence / morphTargetInfluences
-
-			var length = objectInfluences === undefined ? 0 : objectInfluences.length;
+			var length = objectInfluences.length;
 
 			var influences = influencesList[ geometry.id ];
 
@@ -16550,8 +16517,8 @@ var Spacekit = (function (exports) {
 
 				if ( influence[ 1 ] !== 0 ) {
 
-					if ( morphTargets ) geometry.deleteAttribute( 'morphTarget' + i );
-					if ( morphNormals ) geometry.deleteAttribute( 'morphNormal' + i );
+					if ( morphTargets ) geometry.removeAttribute( 'morphTarget' + i );
+					if ( morphNormals ) geometry.removeAttribute( 'morphNormal' + i );
 
 				}
 
@@ -16572,8 +16539,6 @@ var Spacekit = (function (exports) {
 
 			// Add morphAttributes
 
-			var morphInfluencesSum = 0;
-
 			for ( var i = 0; i < 8; i ++ ) {
 
 				var influence = influences[ i ];
@@ -16585,11 +16550,10 @@ var Spacekit = (function (exports) {
 
 					if ( value ) {
 
-						if ( morphTargets ) geometry.setAttribute( 'morphTarget' + i, morphTargets[ index ] );
-						if ( morphNormals ) geometry.setAttribute( 'morphNormal' + i, morphNormals[ index ] );
+						if ( morphTargets ) geometry.addAttribute( 'morphTarget' + i, morphTargets[ index ] );
+						if ( morphNormals ) geometry.addAttribute( 'morphNormal' + i, morphNormals[ index ] );
 
 						morphInfluences[ i ] = value;
-						morphInfluencesSum += value;
 						continue;
 
 					}
@@ -16600,12 +16564,6 @@ var Spacekit = (function (exports) {
 
 			}
 
-			// GLSL shader uses formula baseinfluence * base + sum(target * influence)
-			// This allows us to switch between absolute morphs and relative morphs without changing shader code
-			// When baseinfluence = 1 - sum(influence), the above is equivalent to sum((target - base) * influence)
-			var morphBaseInfluence = geometry.morphTargetsRelative ? 1 : 1 - morphInfluencesSum;
-
-			program.getUniforms().setValue( gl, 'morphTargetBaseInfluence', morphBaseInfluence );
 			program.getUniforms().setValue( gl, 'morphTargetInfluences', morphInfluences );
 
 		}
@@ -16622,9 +16580,9 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-	function WebGLObjects( gl, geometries, attributes, info ) {
+	function WebGLObjects( geometries, info ) {
 
-		var updateMap = new WeakMap();
+		var updateList = {};
 
 		function update( object ) {
 
@@ -16635,7 +16593,7 @@ var Spacekit = (function (exports) {
 
 			// Update once per frame
 
-			if ( updateMap.get( buffergeometry ) !== frame ) {
+			if ( updateList[ buffergeometry.id ] !== frame ) {
 
 				if ( geometry.isGeometry ) {
 
@@ -16645,13 +16603,7 @@ var Spacekit = (function (exports) {
 
 				geometries.update( buffergeometry );
 
-				updateMap.set( buffergeometry, frame );
-
-			}
-
-			if ( object.isInstancedMesh ) {
-
-				attributes.update( object.instanceMatrix, 34962 );
+				updateList[ buffergeometry.id ] = frame;
 
 			}
 
@@ -16661,7 +16613,7 @@ var Spacekit = (function (exports) {
 
 		function dispose() {
 
-			updateMap = new WeakMap();
+			updateList = {};
 
 		}
 
@@ -16719,7 +16671,7 @@ var Spacekit = (function (exports) {
 
 		Texture.call( this, null );
 
-		this.image = { data: data || null, width: width || 1, height: height || 1, depth: depth || 1 };
+		this.image = { data: data, width: width, height: height, depth: depth };
 
 		this.magFilter = NearestFilter;
 		this.minFilter = NearestFilter;
@@ -16728,8 +16680,6 @@ var Spacekit = (function (exports) {
 
 		this.generateMipmaps = false;
 		this.flipY = false;
-
-		this.needsUpdate = true;
 
 	}
 
@@ -16753,7 +16703,7 @@ var Spacekit = (function (exports) {
 
 		Texture.call( this, null );
 
-		this.image = { data: data || null, width: width || 1, height: height || 1, depth: depth || 1 };
+		this.image = { data: data, width: width, height: height, depth: depth };
 
 		this.magFilter = NearestFilter;
 		this.minFilter = NearestFilter;
@@ -16762,9 +16712,6 @@ var Spacekit = (function (exports) {
 
 		this.generateMipmaps = false;
 		this.flipY = false;
-
-		this.needsUpdate = true;
-
 
 	}
 
@@ -17234,20 +17181,6 @@ var Spacekit = (function (exports) {
 
 	}
 
-	// uint
-
-	function setValueV1ui( gl, v ) {
-
-		var cache = this.cache;
-
-		if ( cache[ 0 ] === v ) return;
-
-		gl.uniform1ui( this.addr, v );
-
-		cache[ 0 ] = v;
-
-	}
-
 	// Helper to pick the right setter for the singular case
 
 	function getSingularSetter( type ) {
@@ -17263,36 +17196,15 @@ var Spacekit = (function (exports) {
 			case 0x8b5b: return setValueM3; // _MAT3
 			case 0x8b5c: return setValueM4; // _MAT4
 
+			case 0x8b5e: case 0x8d66: return setValueT1; // SAMPLER_2D, SAMPLER_EXTERNAL_OES
+			case 0x8b5f: return setValueT3D1; // SAMPLER_3D
+			case 0x8b60: return setValueT6; // SAMPLER_CUBE
+			case 0x8DC1: return setValueT2DArray1; // SAMPLER_2D_ARRAY
+
 			case 0x1404: case 0x8b56: return setValueV1i; // INT, BOOL
 			case 0x8b53: case 0x8b57: return setValueV2i; // _VEC2
 			case 0x8b54: case 0x8b58: return setValueV3i; // _VEC3
 			case 0x8b55: case 0x8b59: return setValueV4i; // _VEC4
-
-			case 0x1405: return setValueV1ui; // UINT
-
-			case 0x8b5e: // SAMPLER_2D
-			case 0x8d66: // SAMPLER_EXTERNAL_OES
-			case 0x8dca: // INT_SAMPLER_2D
-			case 0x8dd2: // UNSIGNED_INT_SAMPLER_2D
-			case 0x8b62: // SAMPLER_2D_SHADOW
-				return setValueT1;
-
-			case 0x8b5f: // SAMPLER_3D
-			case 0x8dcb: // INT_SAMPLER_3D
-			case 0x8dd3: // UNSIGNED_INT_SAMPLER_3D
-				return setValueT3D1;
-
-			case 0x8b60: // SAMPLER_CUBE
-			case 0x8dcc: // INT_SAMPLER_CUBE
-			case 0x8dd4: // UNSIGNED_INT_SAMPLER_CUBE
-			case 0x8dc5: // SAMPLER_CUBE_SHADOW
-				return setValueT6;
-
-			case 0x8dc1: // SAMPLER_2D_ARRAY
-			case 0x8dcf: // INT_SAMPLER_2D_ARRAY
-			case 0x8dd7: // UNSIGNED_INT_SAMPLER_2D_ARRAY
-			case 0x8dc4: // SAMPLER_2D_ARRAY_SHADOW
-				return setValueT2DArray1;
 
 		}
 
@@ -17432,23 +17344,13 @@ var Spacekit = (function (exports) {
 			case 0x8b5b: return setValueM3Array; // _MAT3
 			case 0x8b5c: return setValueM4Array; // _MAT4
 
+			case 0x8b5e: return setValueT1Array; // SAMPLER_2D
+			case 0x8b60: return setValueT6Array; // SAMPLER_CUBE
+
 			case 0x1404: case 0x8b56: return setValueV1iArray; // INT, BOOL
 			case 0x8b53: case 0x8b57: return setValueV2iArray; // _VEC2
 			case 0x8b54: case 0x8b58: return setValueV3iArray; // _VEC3
 			case 0x8b55: case 0x8b59: return setValueV4iArray; // _VEC4
-
-			case 0x8b5e: // SAMPLER_2D
-			case 0x8d66: // SAMPLER_EXTERNAL_OES
-			case 0x8dca: // INT_SAMPLER_2D
-			case 0x8dd2: // UNSIGNED_INT_SAMPLER_2D
-			case 0x8b62: // SAMPLER_2D_SHADOW
-				return setValueT1Array;
-
-			case 0x8b60: // SAMPLER_CUBE
-			case 0x8dcc: // INT_SAMPLER_CUBE
-			case 0x8dd4: // UNSIGNED_INT_SAMPLER_CUBE
-			case 0x8dc5: // SAMPLER_CUBE_SHADOW
-				return setValueT6Array;
 
 		}
 
@@ -17712,8 +17614,6 @@ var Spacekit = (function (exports) {
 				return [ 'RGBD', '( value, 256.0 )' ];
 			case GammaEncoding:
 				return [ 'Gamma', '( value, float( GAMMA_FACTOR ) )' ];
-			case LogLuvEncoding:
-				return [ 'LogLuv', '( value )' ];
 			default:
 				throw new Error( 'unsupported encoding: ' + encoding );
 
@@ -17786,13 +17686,15 @@ var Spacekit = (function (exports) {
 
 	}
 
-	function generateExtensions( parameters ) {
+	function generateExtensions( extensions, parameters, rendererExtensions ) {
+
+		extensions = extensions || {};
 
 		var chunks = [
-			( parameters.extensionDerivatives || parameters.envMapCubeUV || parameters.bumpMap || parameters.tangentSpaceNormalMap || parameters.clearcoatNormalMap || parameters.flatShading || parameters.shaderID === 'physical' ) ? '#extension GL_OES_standard_derivatives : enable' : '',
-			( parameters.extensionFragDepth || parameters.logarithmicDepthBuffer ) && parameters.rendererExtensionFragDepth ? '#extension GL_EXT_frag_depth : enable' : '',
-			( parameters.extensionDrawBuffers && parameters.rendererExtensionDrawBuffers ) ? '#extension GL_EXT_draw_buffers : require' : '',
-			( parameters.extensionShaderTextureLOD || parameters.envMap ) && parameters.rendererExtensionShaderTextureLod ? '#extension GL_EXT_shader_texture_lod : enable' : ''
+			( extensions.derivatives || parameters.envMapCubeUV || parameters.bumpMap || ( parameters.normalMap && ! parameters.objectSpaceNormalMap ) || parameters.flatShading ) ? '#extension GL_OES_standard_derivatives : enable' : '',
+			( extensions.fragDepth || parameters.logarithmicDepthBuffer ) && rendererExtensions.get( 'EXT_frag_depth' ) ? '#extension GL_EXT_frag_depth : enable' : '',
+			( extensions.drawBuffers ) && rendererExtensions.get( 'WEBGL_draw_buffers' ) ? '#extension GL_EXT_draw_buffers : require' : '',
+			( extensions.shaderTextureLOD || parameters.envMap ) && rendererExtensions.get( 'EXT_shader_texture_lod' ) ? '#extension GL_EXT_shader_texture_lod : enable' : ''
 		];
 
 		return chunks.filter( filterEmptyLine ).join( '\n' );
@@ -17851,10 +17753,7 @@ var Spacekit = (function (exports) {
 			.replace( /NUM_SPOT_LIGHTS/g, parameters.numSpotLights )
 			.replace( /NUM_RECT_AREA_LIGHTS/g, parameters.numRectAreaLights )
 			.replace( /NUM_POINT_LIGHTS/g, parameters.numPointLights )
-			.replace( /NUM_HEMI_LIGHTS/g, parameters.numHemiLights )
-			.replace( /NUM_DIR_LIGHT_SHADOWS/g, parameters.numDirLightShadows )
-			.replace( /NUM_SPOT_LIGHT_SHADOWS/g, parameters.numSpotLightShadows )
-			.replace( /NUM_POINT_LIGHT_SHADOWS/g, parameters.numPointLightShadows );
+			.replace( /NUM_HEMI_LIGHTS/g, parameters.numHemiLights );
 
 	}
 
@@ -17866,91 +17765,58 @@ var Spacekit = (function (exports) {
 
 	}
 
-	// Resolve Includes
+	function parseIncludes( string ) {
 
-	var includePattern = /^[ \t]*#include +<([\w\d./]+)>/gm;
+		var pattern = /^[ \t]*#include +<([\w\d./]+)>/gm;
 
-	function resolveIncludes( string ) {
+		function replace( match, include ) {
 
-		return string.replace( includePattern, includeReplacer );
+			var replace = ShaderChunk[ include ];
 
-	}
+			if ( replace === undefined ) {
 
-	function includeReplacer( match, include ) {
+				throw new Error( 'Can not resolve #include <' + include + '>' );
 
-		var string = ShaderChunk[ include ];
+			}
 
-		if ( string === undefined ) {
-
-			throw new Error( 'Can not resolve #include <' + include + '>' );
+			return parseIncludes( replace );
 
 		}
 
-		return resolveIncludes( string );
+		return string.replace( pattern, replace );
 
 	}
-
-	// Unroll Loops
-
-	var deprecatedUnrollLoopPattern = /#pragma unroll_loop[\s]+?for \( int i \= (\d+)\; i < (\d+)\; i \+\+ \) \{([\s\S]+?)(?=\})\}/g;
-	var unrollLoopPattern = /#pragma unroll_loop_start[\s]+?for \( int i \= (\d+)\; i < (\d+)\; i \+\+ \) \{([\s\S]+?)(?=\})\}[\s]+?#pragma unroll_loop_end/g;
 
 	function unrollLoops( string ) {
 
-		return string
-			.replace( unrollLoopPattern, loopReplacer )
-			.replace( deprecatedUnrollLoopPattern, deprecatedLoopReplacer );
+		var pattern = /#pragma unroll_loop[\s]+?for \( int i \= (\d+)\; i < (\d+)\; i \+\+ \) \{([\s\S]+?)(?=\})\}/g;
 
-	}
+		function replace( match, start, end, snippet ) {
 
-	function deprecatedLoopReplacer( match, start, end, snippet ) {
+			var unroll = '';
 
-		console.warn( 'WebGLProgram: #pragma unroll_loop shader syntax is deprecated. Please use #pragma unroll_loop_start syntax instead.' );
-		return loopReplacer( match, start, end, snippet );
+			for ( var i = parseInt( start ); i < parseInt( end ); i ++ ) {
 
-	}
+				unroll += snippet.replace( /\[ i \]/g, '[ ' + i + ' ]' );
 
-	function loopReplacer( match, start, end, snippet ) {
+			}
 
-		var string = '';
-
-		for ( var i = parseInt( start ); i < parseInt( end ); i ++ ) {
-
-			string += snippet
-				.replace( /\[ i \]/g, '[ ' + i + ' ]' )
-				.replace( /UNROLLED_LOOP_INDEX/g, i );
+			return unroll;
 
 		}
 
-		return string;
+		return string.replace( pattern, replace );
 
 	}
 
-	//
+	function WebGLProgram( renderer, extensions, code, material, shader, parameters, capabilities ) {
 
-	function generatePrecision( parameters ) {
+		var gl = renderer.getContext();
 
-		var precisionstring = "precision " + parameters.precision + " float;\nprecision " + parameters.precision + " int;";
+		var defines = material.defines;
 
-		if ( parameters.precision === "highp" ) {
-
-			precisionstring += "\n#define HIGH_PRECISION";
-
-		} else if ( parameters.precision === "mediump" ) {
-
-			precisionstring += "\n#define MEDIUM_PRECISION";
-
-		} else if ( parameters.precision === "lowp" ) {
-
-			precisionstring += "\n#define LOW_PRECISION";
-
-		}
-
-		return precisionstring;
-
-	}
-
-	function generateShadowMapTypeDefine( parameters ) {
+		var vertexShader = shader.vertexShader;
+		var fragmentShader = shader.fragmentShader;
 
 		var shadowMapTypeDefine = 'SHADOWMAP_TYPE_BASIC';
 
@@ -17962,23 +17828,15 @@ var Spacekit = (function (exports) {
 
 			shadowMapTypeDefine = 'SHADOWMAP_TYPE_PCF_SOFT';
 
-		} else if ( parameters.shadowMapType === VSMShadowMap ) {
-
-			shadowMapTypeDefine = 'SHADOWMAP_TYPE_VSM';
-
 		}
 
-		return shadowMapTypeDefine;
-
-	}
-
-	function generateEnvMapTypeDefine( parameters ) {
-
 		var envMapTypeDefine = 'ENVMAP_TYPE_CUBE';
+		var envMapModeDefine = 'ENVMAP_MODE_REFLECTION';
+		var envMapBlendingDefine = 'ENVMAP_BLENDING_MULTIPLY';
 
 		if ( parameters.envMap ) {
 
-			switch ( parameters.envMapMode ) {
+			switch ( material.envMap.mapping ) {
 
 				case CubeReflectionMapping:
 				case CubeRefractionMapping:
@@ -18001,19 +17859,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-		}
-
-		return envMapTypeDefine;
-
-	}
-
-	function generateEnvMapModeDefine( parameters ) {
-
-		var envMapModeDefine = 'ENVMAP_MODE_REFLECTION';
-
-		if ( parameters.envMap ) {
-
-			switch ( parameters.envMapMode ) {
+			switch ( material.envMap.mapping ) {
 
 				case CubeRefractionMapping:
 				case EquirectangularRefractionMapping:
@@ -18022,19 +17868,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-		}
-
-		return envMapModeDefine;
-
-	}
-
-	function generateEnvMapBlendingDefine( parameters ) {
-
-		var envMapBlendingDefine = 'ENVMAP_BLENDING_NONE';
-
-		if ( parameters.envMap ) {
-
-			switch ( parameters.combine ) {
+			switch ( material.combine ) {
 
 				case MultiplyOperation:
 					envMapBlendingDefine = 'ENVMAP_BLENDING_MULTIPLY';
@@ -18052,35 +17886,23 @@ var Spacekit = (function (exports) {
 
 		}
 
-		return envMapBlendingDefine;
-
-	}
-
-	function WebGLProgram( renderer, cacheKey, parameters ) {
-
-		var gl = renderer.getContext();
-
-		var defines = parameters.defines;
-
-		var vertexShader = parameters.vertexShader;
-		var fragmentShader = parameters.fragmentShader;
-		var shadowMapTypeDefine = generateShadowMapTypeDefine( parameters );
-		var envMapTypeDefine = generateEnvMapTypeDefine( parameters );
-		var envMapModeDefine = generateEnvMapModeDefine( parameters );
-		var envMapBlendingDefine = generateEnvMapBlendingDefine( parameters );
-
-
 		var gammaFactorDefine = ( renderer.gammaFactor > 0 ) ? renderer.gammaFactor : 1.0;
 
-		var customExtensions = parameters.isWebGL2 ? '' : generateExtensions( parameters );
+		// console.log( 'building new program ' );
+
+		//
+
+		var customExtensions = capabilities.isWebGL2 ? '' : generateExtensions( material.extensions, parameters, extensions );
 
 		var customDefines = generateDefines( defines );
+
+		//
 
 		var program = gl.createProgram();
 
 		var prefixVertex, prefixFragment;
 
-		if ( parameters.isRawShaderMaterial ) {
+		if ( material.isRawShaderMaterial ) {
 
 			prefixVertex = [
 
@@ -18111,20 +17933,20 @@ var Spacekit = (function (exports) {
 
 			prefixVertex = [
 
-				generatePrecision( parameters ),
+				'precision ' + parameters.precision + ' float;',
+				'precision ' + parameters.precision + ' int;',
 
-				'#define SHADER_NAME ' + parameters.shaderName,
+				'#define SHADER_NAME ' + shader.name,
 
 				customDefines,
 
-				parameters.instancing ? '#define USE_INSTANCING' : '',
 				parameters.supportsVertexTextures ? '#define VERTEX_TEXTURES' : '',
 
 				'#define GAMMA_FACTOR ' + gammaFactorDefine,
 
 				'#define MAX_BONES ' + parameters.maxBones,
 				( parameters.useFog && parameters.fog ) ? '#define USE_FOG' : '',
-				( parameters.useFog && parameters.fogExp2 ) ? '#define FOG_EXP2' : '',
+				( parameters.useFog && parameters.fogExp ) ? '#define FOG_EXP2' : '',
 
 				parameters.map ? '#define USE_MAP' : '',
 				parameters.envMap ? '#define USE_ENVMAP' : '',
@@ -18135,11 +17957,6 @@ var Spacekit = (function (exports) {
 				parameters.bumpMap ? '#define USE_BUMPMAP' : '',
 				parameters.normalMap ? '#define USE_NORMALMAP' : '',
 				( parameters.normalMap && parameters.objectSpaceNormalMap ) ? '#define OBJECTSPACE_NORMALMAP' : '',
-				( parameters.normalMap && parameters.tangentSpaceNormalMap ) ? '#define TANGENTSPACE_NORMALMAP' : '',
-
-				parameters.clearcoatMap ? '#define USE_CLEARCOATMAP' : '',
-				parameters.clearcoatRoughnessMap ? '#define USE_CLEARCOAT_ROUGHNESSMAP' : '',
-				parameters.clearcoatNormalMap ? '#define USE_CLEARCOAT_NORMALMAP' : '',
 				parameters.displacementMap && parameters.supportsVertexTextures ? '#define USE_DISPLACEMENTMAP' : '',
 				parameters.specularMap ? '#define USE_SPECULARMAP' : '',
 				parameters.roughnessMap ? '#define USE_ROUGHNESSMAP' : '',
@@ -18148,8 +17965,6 @@ var Spacekit = (function (exports) {
 
 				parameters.vertexTangents ? '#define USE_TANGENT' : '',
 				parameters.vertexColors ? '#define USE_COLOR' : '',
-				parameters.vertexUvs ? '#define USE_UV' : '',
-				parameters.uvsVertexOnly ? '#define UVS_VERTEX_ONLY' : '',
 
 				parameters.flatShading ? '#define FLAT_SHADED' : '',
 
@@ -18167,7 +17982,7 @@ var Spacekit = (function (exports) {
 				parameters.sizeAttenuation ? '#define USE_SIZEATTENUATION' : '',
 
 				parameters.logarithmicDepthBuffer ? '#define USE_LOGDEPTHBUF' : '',
-				( parameters.logarithmicDepthBuffer && parameters.rendererExtensionFragDepth ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
+				parameters.logarithmicDepthBuffer && ( capabilities.isWebGL2 || extensions.get( 'EXT_frag_depth' ) ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
 
 				'uniform mat4 modelMatrix;',
 				'uniform mat4 modelViewMatrix;',
@@ -18175,13 +17990,6 @@ var Spacekit = (function (exports) {
 				'uniform mat4 viewMatrix;',
 				'uniform mat3 normalMatrix;',
 				'uniform vec3 cameraPosition;',
-				'uniform bool isOrthographic;',
-
-				'#ifdef USE_INSTANCING',
-
-				' attribute mat4 instanceMatrix;',
-
-				'#endif',
 
 				'attribute vec3 position;',
 				'attribute vec3 normal;',
@@ -18239,9 +18047,10 @@ var Spacekit = (function (exports) {
 
 				customExtensions,
 
-				generatePrecision( parameters ),
+				'precision ' + parameters.precision + ' float;',
+				'precision ' + parameters.precision + ' int;',
 
-				'#define SHADER_NAME ' + parameters.shaderName,
+				'#define SHADER_NAME ' + shader.name,
 
 				customDefines,
 
@@ -18250,7 +18059,7 @@ var Spacekit = (function (exports) {
 				'#define GAMMA_FACTOR ' + gammaFactorDefine,
 
 				( parameters.useFog && parameters.fog ) ? '#define USE_FOG' : '',
-				( parameters.useFog && parameters.fogExp2 ) ? '#define FOG_EXP2' : '',
+				( parameters.useFog && parameters.fogExp ) ? '#define FOG_EXP2' : '',
 
 				parameters.map ? '#define USE_MAP' : '',
 				parameters.matcap ? '#define USE_MATCAP' : '',
@@ -18264,21 +18073,13 @@ var Spacekit = (function (exports) {
 				parameters.bumpMap ? '#define USE_BUMPMAP' : '',
 				parameters.normalMap ? '#define USE_NORMALMAP' : '',
 				( parameters.normalMap && parameters.objectSpaceNormalMap ) ? '#define OBJECTSPACE_NORMALMAP' : '',
-				( parameters.normalMap && parameters.tangentSpaceNormalMap ) ? '#define TANGENTSPACE_NORMALMAP' : '',
-				parameters.clearcoatMap ? '#define USE_CLEARCOATMAP' : '',
-				parameters.clearcoatRoughnessMap ? '#define USE_CLEARCOAT_ROUGHNESSMAP' : '',
-				parameters.clearcoatNormalMap ? '#define USE_CLEARCOAT_NORMALMAP' : '',
 				parameters.specularMap ? '#define USE_SPECULARMAP' : '',
 				parameters.roughnessMap ? '#define USE_ROUGHNESSMAP' : '',
 				parameters.metalnessMap ? '#define USE_METALNESSMAP' : '',
 				parameters.alphaMap ? '#define USE_ALPHAMAP' : '',
 
-				parameters.sheen ? '#define USE_SHEEN' : '',
-
 				parameters.vertexTangents ? '#define USE_TANGENT' : '',
 				parameters.vertexColors ? '#define USE_COLOR' : '',
-				parameters.vertexUvs ? '#define USE_UV' : '',
-				parameters.uvsVertexOnly ? '#define UVS_VERTEX_ONLY' : '',
 
 				parameters.gradientMap ? '#define USE_GRADIENTMAP' : '',
 
@@ -18295,13 +18096,12 @@ var Spacekit = (function (exports) {
 				parameters.physicallyCorrectLights ? '#define PHYSICALLY_CORRECT_LIGHTS' : '',
 
 				parameters.logarithmicDepthBuffer ? '#define USE_LOGDEPTHBUF' : '',
-				( parameters.logarithmicDepthBuffer && parameters.rendererExtensionFragDepth ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
+				parameters.logarithmicDepthBuffer && ( capabilities.isWebGL2 || extensions.get( 'EXT_frag_depth' ) ) ? '#define USE_LOGDEPTHBUF_EXT' : '',
 
-				( ( parameters.extensionShaderTextureLOD || parameters.envMap ) && parameters.rendererExtensionShaderTextureLod ) ? '#define TEXTURE_LOD_EXT' : '',
+				parameters.envMap && ( capabilities.isWebGL2 || extensions.get( 'EXT_shader_texture_lod' ) ) ? '#define TEXTURE_LOD_EXT' : '',
 
 				'uniform mat4 viewMatrix;',
 				'uniform vec3 cameraPosition;',
-				'uniform bool isOrthographic;',
 
 				( parameters.toneMapping !== NoToneMapping ) ? '#define TONE_MAPPING' : '',
 				( parameters.toneMapping !== NoToneMapping ) ? ShaderChunk[ 'tonemapping_pars_fragment' ] : '', // this code is required here because it is used by the toneMapping() function defined below
@@ -18309,16 +18109,15 @@ var Spacekit = (function (exports) {
 
 				parameters.dithering ? '#define DITHERING' : '',
 
-				( parameters.outputEncoding || parameters.mapEncoding || parameters.matcapEncoding || parameters.envMapEncoding || parameters.emissiveMapEncoding || parameters.lightMapEncoding ) ?
+				( parameters.outputEncoding || parameters.mapEncoding || parameters.matcapEncoding || parameters.envMapEncoding || parameters.emissiveMapEncoding ) ?
 					ShaderChunk[ 'encodings_pars_fragment' ] : '', // this code is required here because it is used by the various encoding/decoding function defined below
 				parameters.mapEncoding ? getTexelDecodingFunction( 'mapTexelToLinear', parameters.mapEncoding ) : '',
 				parameters.matcapEncoding ? getTexelDecodingFunction( 'matcapTexelToLinear', parameters.matcapEncoding ) : '',
 				parameters.envMapEncoding ? getTexelDecodingFunction( 'envMapTexelToLinear', parameters.envMapEncoding ) : '',
 				parameters.emissiveMapEncoding ? getTexelDecodingFunction( 'emissiveMapTexelToLinear', parameters.emissiveMapEncoding ) : '',
-				parameters.lightMapEncoding ? getTexelDecodingFunction( 'lightMapTexelToLinear', parameters.lightMapEncoding ) : '',
 				parameters.outputEncoding ? getTexelEncodingFunction( 'linearToOutputTexel', parameters.outputEncoding ) : '',
 
-				parameters.depthPacking ? '#define DEPTH_PACKING ' + parameters.depthPacking : '',
+				parameters.depthPacking ? '#define DEPTH_PACKING ' + material.depthPacking : '',
 
 				'\n'
 
@@ -18326,24 +18125,24 @@ var Spacekit = (function (exports) {
 
 		}
 
-		vertexShader = resolveIncludes( vertexShader );
+		vertexShader = parseIncludes( vertexShader );
 		vertexShader = replaceLightNums( vertexShader, parameters );
 		vertexShader = replaceClippingPlaneNums( vertexShader, parameters );
 
-		fragmentShader = resolveIncludes( fragmentShader );
+		fragmentShader = parseIncludes( fragmentShader );
 		fragmentShader = replaceLightNums( fragmentShader, parameters );
 		fragmentShader = replaceClippingPlaneNums( fragmentShader, parameters );
 
 		vertexShader = unrollLoops( vertexShader );
 		fragmentShader = unrollLoops( fragmentShader );
 
-		if ( parameters.isWebGL2 && ! parameters.isRawShaderMaterial ) {
+		if ( capabilities.isWebGL2 && ! material.isRawShaderMaterial ) {
 
 			var isGLSL3ShaderMaterial = false;
 
 			var versionRegex = /^\s*#version\s+300\s+es\s*\n/;
 
-			if ( parameters.isShaderMaterial &&
+			if ( material.isShaderMaterial &&
 				vertexShader.match( versionRegex ) !== null &&
 				fragmentShader.match( versionRegex ) !== null ) {
 
@@ -18355,7 +18154,6 @@ var Spacekit = (function (exports) {
 			}
 
 			// GLSL 3.0 conversion
-
 			prefixVertex = [
 				'#version 300 es\n',
 				'#define attribute in',
@@ -18396,9 +18194,9 @@ var Spacekit = (function (exports) {
 
 		// Force a particular attribute to index 0.
 
-		if ( parameters.index0AttributeName !== undefined ) {
+		if ( material.index0AttributeName !== undefined ) {
 
-			gl.bindAttribLocation( program, 0, parameters.index0AttributeName );
+			gl.bindAttribLocation( program, 0, material.index0AttributeName );
 
 		} else if ( parameters.morphTargets === true ) {
 
@@ -18443,6 +18241,7 @@ var Spacekit = (function (exports) {
 				this.diagnostics = {
 
 					runnable: runnable,
+					material: material,
 
 					programLog: programLog,
 
@@ -18466,11 +18265,7 @@ var Spacekit = (function (exports) {
 
 		}
 
-		// Clean up
-
-		// Crashes in iOS9 and iOS10. #18402
-		// gl.detachShader( program, glVertexShader );
-		// gl.detachShader( program, glFragmentShader );
+		// clean up
 
 		gl.deleteShader( glVertexShader );
 		gl.deleteShader( glFragmentShader );
@@ -18518,9 +18313,9 @@ var Spacekit = (function (exports) {
 
 		//
 
-		this.name = parameters.shaderName;
+		this.name = shader.name;
 		this.id = programIdCount ++;
-		this.cacheKey = cacheKey;
+		this.code = code;
 		this.usedTimes = 1;
 		this.program = program;
 		this.vertexShader = glVertexShader;
@@ -18538,13 +18333,6 @@ var Spacekit = (function (exports) {
 
 		var programs = [];
 
-		var isWebGL2 = capabilities.isWebGL2;
-		var logarithmicDepthBuffer = capabilities.logarithmicDepthBuffer;
-		var floatVertexTextures = capabilities.floatVertexTextures;
-		var precision = capabilities.precision;
-		var maxVertexUniforms = capabilities.maxVertexUniforms;
-		var vertexTextures = capabilities.vertexTextures;
-
 		var shaderIDs = {
 			MeshDepthMaterial: 'depth',
 			MeshDistanceMaterial: 'distanceRGBA',
@@ -18552,7 +18340,7 @@ var Spacekit = (function (exports) {
 			MeshBasicMaterial: 'basic',
 			MeshLambertMaterial: 'lambert',
 			MeshPhongMaterial: 'phong',
-			MeshToonMaterial: 'toon',
+			MeshToonMaterial: 'phong',
 			MeshStandardMaterial: 'physical',
 			MeshPhysicalMaterial: 'physical',
 			MeshMatcapMaterial: 'matcap',
@@ -18564,57 +18352,25 @@ var Spacekit = (function (exports) {
 		};
 
 		var parameterNames = [
-			"precision", "isWebGL2", "supportsVertexTextures", "outputEncoding", "instancing",
-			"map", "mapEncoding", "matcap", "matcapEncoding", "envMap", "envMapMode", "envMapEncoding", "envMapCubeUV",
-			"lightMap", "lightMapEncoding", "aoMap", "emissiveMap", "emissiveMapEncoding", "bumpMap", "normalMap", "objectSpaceNormalMap", "tangentSpaceNormalMap", "clearcoatMap", "clearcoatRoughnessMap", "clearcoatNormalMap", "displacementMap", "specularMap",
+			"precision", "supportsVertexTextures", "map", "mapEncoding", "matcap", "matcapEncoding", "envMap", "envMapMode", "envMapEncoding",
+			"lightMap", "aoMap", "emissiveMap", "emissiveMapEncoding", "bumpMap", "normalMap", "objectSpaceNormalMap", "displacementMap", "specularMap",
 			"roughnessMap", "metalnessMap", "gradientMap",
-			"alphaMap", "combine", "vertexColors", "vertexTangents", "vertexUvs", "uvsVertexOnly", "fog", "useFog", "fogExp2",
+			"alphaMap", "combine", "vertexColors", "vertexTangents", "fog", "useFog", "fogExp",
 			"flatShading", "sizeAttenuation", "logarithmicDepthBuffer", "skinning",
 			"maxBones", "useVertexTexture", "morphTargets", "morphNormals",
 			"maxMorphTargets", "maxMorphNormals", "premultipliedAlpha",
 			"numDirLights", "numPointLights", "numSpotLights", "numHemiLights", "numRectAreaLights",
-			"numDirLightShadows", "numPointLightShadows", "numSpotLightShadows",
 			"shadowMapEnabled", "shadowMapType", "toneMapping", 'physicallyCorrectLights',
-			"alphaTest", "doubleSided", "flipSided", "numClippingPlanes", "numClipIntersection", "depthPacking", "dithering",
-			"sheen"
+			"alphaTest", "doubleSided", "flipSided", "numClippingPlanes", "numClipIntersection", "depthPacking", "dithering"
 		];
 
-		function getShaderObject( material, shaderID ) {
-
-			var shaderobject;
-
-			if ( shaderID ) {
-
-				var shader = ShaderLib[ shaderID ];
-
-				shaderobject = {
-					name: material.type,
-					uniforms: UniformsUtils.clone( shader.uniforms ),
-					vertexShader: shader.vertexShader,
-					fragmentShader: shader.fragmentShader
-				};
-
-			} else {
-
-				shaderobject = {
-					name: material.type,
-					uniforms: material.uniforms,
-					vertexShader: material.vertexShader,
-					fragmentShader: material.fragmentShader
-				};
-
-			}
-
-			return shaderobject;
-
-		}
 
 		function allocateBones( object ) {
 
 			var skeleton = object.skeleton;
 			var bones = skeleton.bones;
 
-			if ( floatVertexTextures ) {
+			if ( capabilities.floatVertexTextures ) {
 
 				return 1024;
 
@@ -18627,7 +18383,7 @@ var Spacekit = (function (exports) {
 				//  - limit here is ANGLE's 254 max uniform vectors
 				//    (up to 54 should be safe)
 
-				var nVertexUniforms = maxVertexUniforms;
+				var nVertexUniforms = capabilities.maxVertexUniforms;
 				var nVertexMatrices = Math.floor( ( nVertexUniforms - 20 ) / 4 );
 
 				var maxBones = Math.min( nVertexMatrices, bones.length );
@@ -18645,7 +18401,7 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function getTextureEncodingFromMap( map ) {
+		function getTextureEncodingFromMap( map, gammaOverrideLinear ) {
 
 			var encoding;
 
@@ -18664,16 +18420,18 @@ var Spacekit = (function (exports) {
 
 			}
 
+			// add backwards compatibility for WebGLRenderer.gammaInput/gammaOutput parameter, should probably be removed at some point.
+			if ( encoding === LinearEncoding && gammaOverrideLinear ) {
+
+				encoding = GammaEncoding;
+
+			}
+
 			return encoding;
 
 		}
 
-		this.getParameters = function ( material, lights, shadows, scene, nClipPlanes, nClipIntersection, object ) {
-
-			var fog = scene.fog;
-			var environment = material.isMeshStandardMaterial ? scene.environment : null;
-
-			var envMap = material.envMap || environment;
+		this.getParameters = function ( material, lights, shadows, fog, nClipPlanes, nClipIntersection, object ) {
 
 			var shaderID = shaderIDs[ material.type ];
 
@@ -18681,6 +18439,7 @@ var Spacekit = (function (exports) {
 			// (not to blow over maxLights budget)
 
 			var maxBones = object.isSkinnedMesh ? allocateBones( object ) : 0;
+			var precision = capabilities.precision;
 
 			if ( material.precision !== null ) {
 
@@ -18694,52 +18453,30 @@ var Spacekit = (function (exports) {
 
 			}
 
-			var shaderobject = getShaderObject( material, shaderID );
-			material.onBeforeCompile( shaderobject, renderer );
-
 			var currentRenderTarget = renderer.getRenderTarget();
 
 			var parameters = {
 
-				isWebGL2: isWebGL2,
-
 				shaderID: shaderID,
-				shaderName: shaderobject.name,
-
-				uniforms: shaderobject.uniforms,
-				vertexShader: shaderobject.vertexShader,
-				fragmentShader: shaderobject.fragmentShader,
-				defines: material.defines,
-
-				isRawShaderMaterial: material.isRawShaderMaterial,
-				isShaderMaterial: material.isShaderMaterial,
 
 				precision: precision,
-
-				instancing: object.isInstancedMesh === true,
-
-				supportsVertexTextures: vertexTextures,
-				outputEncoding: ( currentRenderTarget !== null ) ? getTextureEncodingFromMap( currentRenderTarget.texture ) : renderer.outputEncoding,
+				supportsVertexTextures: capabilities.vertexTextures,
+				outputEncoding: getTextureEncodingFromMap( ( ! currentRenderTarget ) ? null : currentRenderTarget.texture, renderer.gammaOutput ),
 				map: !! material.map,
-				mapEncoding: getTextureEncodingFromMap( material.map ),
+				mapEncoding: getTextureEncodingFromMap( material.map, renderer.gammaInput ),
 				matcap: !! material.matcap,
-				matcapEncoding: getTextureEncodingFromMap( material.matcap ),
-				envMap: !! envMap,
-				envMapMode: envMap && envMap.mapping,
-				envMapEncoding: getTextureEncodingFromMap( envMap ),
-				envMapCubeUV: ( !! envMap ) && ( ( envMap.mapping === CubeUVReflectionMapping ) || ( envMap.mapping === CubeUVRefractionMapping ) ),
+				matcapEncoding: getTextureEncodingFromMap( material.matcap, renderer.gammaInput ),
+				envMap: !! material.envMap,
+				envMapMode: material.envMap && material.envMap.mapping,
+				envMapEncoding: getTextureEncodingFromMap( material.envMap, renderer.gammaInput ),
+				envMapCubeUV: ( !! material.envMap ) && ( ( material.envMap.mapping === CubeUVReflectionMapping ) || ( material.envMap.mapping === CubeUVRefractionMapping ) ),
 				lightMap: !! material.lightMap,
-				lightMapEncoding: getTextureEncodingFromMap( material.lightMap ),
 				aoMap: !! material.aoMap,
 				emissiveMap: !! material.emissiveMap,
-				emissiveMapEncoding: getTextureEncodingFromMap( material.emissiveMap ),
+				emissiveMapEncoding: getTextureEncodingFromMap( material.emissiveMap, renderer.gammaInput ),
 				bumpMap: !! material.bumpMap,
 				normalMap: !! material.normalMap,
 				objectSpaceNormalMap: material.normalMapType === ObjectSpaceNormalMap,
-				tangentSpaceNormalMap: material.normalMapType === TangentSpaceNormalMap,
-				clearcoatMap: !! material.clearcoatMap,
-				clearcoatRoughnessMap: !! material.clearcoatRoughnessMap,
-				clearcoatNormalMap: !! material.clearcoatNormalMap,
 				displacementMap: !! material.displacementMap,
 				roughnessMap: !! material.roughnessMap,
 				metalnessMap: !! material.metalnessMap,
@@ -18748,27 +18485,23 @@ var Spacekit = (function (exports) {
 
 				gradientMap: !! material.gradientMap,
 
-				sheen: !! material.sheen,
-
 				combine: material.combine,
 
 				vertexTangents: ( material.normalMap && material.vertexTangents ),
 				vertexColors: material.vertexColors,
-				vertexUvs: !! material.map || !! material.bumpMap || !! material.normalMap || !! material.specularMap || !! material.alphaMap || !! material.emissiveMap || !! material.roughnessMap || !! material.metalnessMap || !! material.clearcoatMap || !! material.clearcoatRoughnessMap || !! material.clearcoatNormalMap || !! material.displacementMap,
-				uvsVertexOnly: ! ( !! material.map || !! material.bumpMap || !! material.normalMap || !! material.specularMap || !! material.alphaMap || !! material.emissiveMap || !! material.roughnessMap || !! material.metalnessMap || !! material.clearcoatNormalMap ) && !! material.displacementMap,
 
 				fog: !! fog,
 				useFog: material.fog,
-				fogExp2: ( fog && fog.isFogExp2 ),
+				fogExp: ( fog && fog.isFogExp2 ),
 
 				flatShading: material.flatShading,
 
 				sizeAttenuation: material.sizeAttenuation,
-				logarithmicDepthBuffer: logarithmicDepthBuffer,
+				logarithmicDepthBuffer: capabilities.logarithmicDepthBuffer,
 
 				skinning: material.skinning && maxBones > 0,
 				maxBones: maxBones,
-				useVertexTexture: floatVertexTextures,
+				useVertexTexture: capabilities.floatVertexTextures,
 
 				morphTargets: material.morphTargets,
 				morphNormals: material.morphNormals,
@@ -18781,19 +18514,15 @@ var Spacekit = (function (exports) {
 				numRectAreaLights: lights.rectArea.length,
 				numHemiLights: lights.hemi.length,
 
-				numDirLightShadows: lights.directionalShadowMap.length,
-				numPointLightShadows: lights.pointShadowMap.length,
-				numSpotLightShadows: lights.spotShadowMap.length,
-
 				numClippingPlanes: nClipPlanes,
 				numClipIntersection: nClipIntersection,
 
 				dithering: material.dithering,
 
-				shadowMapEnabled: renderer.shadowMap.enabled && shadows.length > 0,
+				shadowMapEnabled: renderer.shadowMap.enabled && object.receiveShadow && shadows.length > 0,
 				shadowMapType: renderer.shadowMap.type,
 
-				toneMapping: material.toneMapped ? renderer.toneMapping : NoToneMapping,
+				toneMapping: renderer.toneMapping,
 				physicallyCorrectLights: renderer.physicallyCorrectLights,
 
 				premultipliedAlpha: material.premultipliedAlpha,
@@ -18802,20 +18531,7 @@ var Spacekit = (function (exports) {
 				doubleSided: material.side === DoubleSide,
 				flipSided: material.side === BackSide,
 
-				depthPacking: ( material.depthPacking !== undefined ) ? material.depthPacking : false,
-
-				index0AttributeName: material.index0AttributeName,
-
-				extensionDerivatives: material.extensions && material.extensions.derivatives,
-				extensionFragDepth: material.extensions && material.extensions.fragDepth,
-				extensionDrawBuffers: material.extensions && material.extensions.drawBuffers,
-				extensionShaderTextureLOD: material.extensions && material.extensions.shaderTextureLOD,
-
-				rendererExtensionFragDepth: isWebGL2 || extensions.get( 'EXT_frag_depth' ) !== null,
-				rendererExtensionDrawBuffers: isWebGL2 || extensions.get( 'WEBGL_draw_buffers' ) !== null,
-				rendererExtensionShaderTextureLod: isWebGL2 || extensions.get( 'EXT_shader_texture_lod' ) !== null,
-
-				onBeforeCompile: material.onBeforeCompile
+				depthPacking: ( material.depthPacking !== undefined ) ? material.depthPacking : false
 
 			};
 
@@ -18823,7 +18539,7 @@ var Spacekit = (function (exports) {
 
 		};
 
-		this.getProgramCacheKey = function ( parameters ) {
+		this.getProgramCode = function ( material, parameters ) {
 
 			var array = [];
 
@@ -18833,53 +18549,50 @@ var Spacekit = (function (exports) {
 
 			} else {
 
-				array.push( parameters.fragmentShader );
-				array.push( parameters.vertexShader );
+				array.push( material.fragmentShader );
+				array.push( material.vertexShader );
 
 			}
 
-			if ( parameters.defines !== undefined ) {
+			if ( material.defines !== undefined ) {
 
-				for ( var name in parameters.defines ) {
+				for ( var name in material.defines ) {
 
 					array.push( name );
-					array.push( parameters.defines[ name ] );
+					array.push( material.defines[ name ] );
 
 				}
 
 			}
 
-			if ( parameters.isRawShaderMaterial === undefined ) {
+			for ( var i = 0; i < parameterNames.length; i ++ ) {
 
-				for ( var i = 0; i < parameterNames.length; i ++ ) {
-
-					array.push( parameters[ parameterNames[ i ] ] );
-
-				}
-
-				array.push( renderer.outputEncoding );
-				array.push( renderer.gammaFactor );
+				array.push( parameters[ parameterNames[ i ] ] );
 
 			}
 
-			array.push( parameters.onBeforeCompile.toString() );
+			array.push( material.onBeforeCompile.toString() );
+
+			array.push( renderer.gammaOutput );
+
+			array.push( renderer.gammaFactor );
 
 			return array.join();
 
 		};
 
-		this.acquireProgram = function ( parameters, cacheKey ) {
+		this.acquireProgram = function ( material, shader, parameters, code ) {
 
 			var program;
 
 			// Check if code has been already compiled
 			for ( var p = 0, pl = programs.length; p < pl; p ++ ) {
 
-				var preexistingProgram = programs[ p ];
+				var programInfo = programs[ p ];
 
-				if ( preexistingProgram.cacheKey === cacheKey ) {
+				if ( programInfo.code === code ) {
 
-					program = preexistingProgram;
+					program = programInfo;
 					++ program.usedTimes;
 
 					break;
@@ -18890,7 +18603,7 @@ var Spacekit = (function (exports) {
 
 			if ( program === undefined ) {
 
-				program = new WebGLProgram( renderer, cacheKey, parameters );
+				program = new WebGLProgram( renderer, extensions, code, material, shader, parameters, capabilities );
 				programs.push( program );
 
 			}
@@ -19102,31 +18815,10 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function sort( customOpaqueSort, customTransparentSort ) {
+		function sort() {
 
-			if ( opaque.length > 1 ) opaque.sort( customOpaqueSort || painterSortStable );
-			if ( transparent.length > 1 ) transparent.sort( customTransparentSort || reversePainterSortStable );
-
-		}
-
-		function finish() {
-
-			// Clear references from inactive renderItems in the list
-
-			for ( var i = renderItemsIndex, il = renderItems.length; i < il; i ++ ) {
-
-				var renderItem = renderItems[ i ];
-
-				if ( renderItem.id === null ) break;
-
-				renderItem.id = null;
-				renderItem.object = null;
-				renderItem.geometry = null;
-				renderItem.material = null;
-				renderItem.program = null;
-				renderItem.group = null;
-
-			}
+			if ( opaque.length > 1 ) opaque.sort( painterSortStable );
+			if ( transparent.length > 1 ) transparent.sort( reversePainterSortStable );
 
 		}
 
@@ -19137,7 +18829,6 @@ var Spacekit = (function (exports) {
 			init: init,
 			push: push,
 			unshift: unshift,
-			finish: finish,
 
 			sort: sort
 		};
@@ -19146,7 +18837,7 @@ var Spacekit = (function (exports) {
 
 	function WebGLRenderLists() {
 
-		var lists = new WeakMap();
+		var lists = {};
 
 		function onSceneDispose( event ) {
 
@@ -19154,29 +18845,29 @@ var Spacekit = (function (exports) {
 
 			scene.removeEventListener( 'dispose', onSceneDispose );
 
-			lists.delete( scene );
+			delete lists[ scene.id ];
 
 		}
 
 		function get( scene, camera ) {
 
-			var cameras = lists.get( scene );
+			var cameras = lists[ scene.id ];
 			var list;
 			if ( cameras === undefined ) {
 
 				list = new WebGLRenderList();
-				lists.set( scene, new WeakMap() );
-				lists.get( scene ).set( camera, list );
+				lists[ scene.id ] = {};
+				lists[ scene.id ][ camera.id ] = list;
 
 				scene.addEventListener( 'dispose', onSceneDispose );
 
 			} else {
 
-				list = cameras.get( camera );
+				list = cameras[ camera.id ];
 				if ( list === undefined ) {
 
 					list = new WebGLRenderList();
-					cameras.set( camera, list );
+					cameras[ camera.id ] = list;
 
 				}
 
@@ -19188,7 +18879,7 @@ var Spacekit = (function (exports) {
 
 		function dispose() {
 
-			lists = new WeakMap();
+			lists = {};
 
 		}
 
@@ -19224,7 +18915,12 @@ var Spacekit = (function (exports) {
 					case 'DirectionalLight':
 						uniforms = {
 							direction: new Vector3(),
-							color: new Color()
+							color: new Color(),
+
+							shadow: false,
+							shadowBias: 0,
+							shadowRadius: 1,
+							shadowMapSize: new Vector2()
 						};
 						break;
 
@@ -19236,7 +18932,12 @@ var Spacekit = (function (exports) {
 							distance: 0,
 							coneCos: 0,
 							penumbraCos: 0,
-							decay: 0
+							decay: 0,
+
+							shadow: false,
+							shadowBias: 0,
+							shadowRadius: 1,
+							shadowMapSize: new Vector2()
 						};
 						break;
 
@@ -19245,7 +18946,14 @@ var Spacekit = (function (exports) {
 							position: new Vector3(),
 							color: new Color(),
 							distance: 0,
-							decay: 0
+							decay: 0,
+
+							shadow: false,
+							shadowBias: 0,
+							shadowRadius: 1,
+							shadowMapSize: new Vector2(),
+							shadowCameraNear: 1,
+							shadowCameraFar: 1000
 						};
 						break;
 
@@ -19263,6 +18971,7 @@ var Spacekit = (function (exports) {
 							position: new Vector3(),
 							halfWidth: new Vector3(),
 							halfHeight: new Vector3()
+							// TODO (abelnation): set RectAreaLight shadow uniforms
 						};
 						break;
 
@@ -19277,80 +18986,12 @@ var Spacekit = (function (exports) {
 		};
 
 	}
-
-	function ShadowUniformsCache() {
-
-		var lights = {};
-
-		return {
-
-			get: function ( light ) {
-
-				if ( lights[ light.id ] !== undefined ) {
-
-					return lights[ light.id ];
-
-				}
-
-				var uniforms;
-
-				switch ( light.type ) {
-
-					case 'DirectionalLight':
-						uniforms = {
-							shadowBias: 0,
-							shadowRadius: 1,
-							shadowMapSize: new Vector2()
-						};
-						break;
-
-					case 'SpotLight':
-						uniforms = {
-							shadowBias: 0,
-							shadowRadius: 1,
-							shadowMapSize: new Vector2()
-						};
-						break;
-
-					case 'PointLight':
-						uniforms = {
-							shadowBias: 0,
-							shadowRadius: 1,
-							shadowMapSize: new Vector2(),
-							shadowCameraNear: 1,
-							shadowCameraFar: 1000
-						};
-						break;
-
-					// TODO (abelnation): set RectAreaLight shadow uniforms
-
-				}
-
-				lights[ light.id ] = uniforms;
-
-				return uniforms;
-
-			}
-
-		};
-
-	}
-
-
 
 	var nextVersion = 0;
-
-	function shadowCastingLightsFirst( lightA, lightB ) {
-
-		return ( lightB.castShadow ? 1 : 0 ) - ( lightA.castShadow ? 1 : 0 );
-
-	}
 
 	function WebGLLights() {
 
 		var cache = new UniformsCache();
-
-		var shadowCache = ShadowUniformsCache();
 
 		var state = {
 
@@ -19362,25 +19003,19 @@ var Spacekit = (function (exports) {
 				spotLength: - 1,
 				rectAreaLength: - 1,
 				hemiLength: - 1,
-
-				numDirectionalShadows: - 1,
-				numPointShadows: - 1,
-				numSpotShadows: - 1
+				shadowsLength: - 1,
 			},
 
 			ambient: [ 0, 0, 0 ],
 			probe: [],
 			directional: [],
-			directionalShadow: [],
 			directionalShadowMap: [],
 			directionalShadowMatrix: [],
 			spot: [],
-			spotShadow: [],
 			spotShadowMap: [],
 			spotShadowMatrix: [],
 			rectArea: [],
 			point: [],
-			pointShadow: [],
 			pointShadowMap: [],
 			pointShadowMatrix: [],
 			hemi: []
@@ -19405,13 +19040,7 @@ var Spacekit = (function (exports) {
 			var rectAreaLength = 0;
 			var hemiLength = 0;
 
-			var numDirectionalShadows = 0;
-			var numPointShadows = 0;
-			var numSpotShadows = 0;
-
 			var viewMatrix = camera.matrixWorldInverse;
-
-			lights.sort( shadowCastingLightsFirst );
 
 			for ( var i = 0, l = lights.length; i < l; i ++ ) {
 
@@ -19447,24 +19076,20 @@ var Spacekit = (function (exports) {
 					uniforms.direction.sub( vector3 );
 					uniforms.direction.transformDirection( viewMatrix );
 
+					uniforms.shadow = light.castShadow;
+
 					if ( light.castShadow ) {
 
 						var shadow = light.shadow;
 
-						var shadowUniforms = shadowCache.get( light );
-
-						shadowUniforms.shadowBias = shadow.bias;
-						shadowUniforms.shadowRadius = shadow.radius;
-						shadowUniforms.shadowMapSize = shadow.mapSize;
-
-						state.directionalShadow[ directionalLength ] = shadowUniforms;
-						state.directionalShadowMap[ directionalLength ] = shadowMap;
-						state.directionalShadowMatrix[ directionalLength ] = light.shadow.matrix;
-
-						numDirectionalShadows ++;
+						uniforms.shadowBias = shadow.bias;
+						uniforms.shadowRadius = shadow.radius;
+						uniforms.shadowMapSize = shadow.mapSize;
 
 					}
 
+					state.directionalShadowMap[ directionalLength ] = shadowMap;
+					state.directionalShadowMatrix[ directionalLength ] = light.shadow.matrix;
 					state.directional[ directionalLength ] = uniforms;
 
 					directionalLength ++;
@@ -19488,24 +19113,20 @@ var Spacekit = (function (exports) {
 					uniforms.penumbraCos = Math.cos( light.angle * ( 1 - light.penumbra ) );
 					uniforms.decay = light.decay;
 
+					uniforms.shadow = light.castShadow;
+
 					if ( light.castShadow ) {
 
 						var shadow = light.shadow;
 
-						var shadowUniforms = shadowCache.get( light );
-
-						shadowUniforms.shadowBias = shadow.bias;
-						shadowUniforms.shadowRadius = shadow.radius;
-						shadowUniforms.shadowMapSize = shadow.mapSize;
-
-						state.spotShadow[ spotLength ] = shadowUniforms;
-						state.spotShadowMap[ spotLength ] = shadowMap;
-						state.spotShadowMatrix[ spotLength ] = light.shadow.matrix;
-
-						numSpotShadows ++;
+						uniforms.shadowBias = shadow.bias;
+						uniforms.shadowRadius = shadow.radius;
+						uniforms.shadowMapSize = shadow.mapSize;
 
 					}
 
+					state.spotShadowMap[ spotLength ] = shadowMap;
+					state.spotShadowMatrix[ spotLength ] = light.shadow.matrix;
 					state.spot[ spotLength ] = uniforms;
 
 					spotLength ++;
@@ -19553,26 +19174,22 @@ var Spacekit = (function (exports) {
 					uniforms.distance = light.distance;
 					uniforms.decay = light.decay;
 
+					uniforms.shadow = light.castShadow;
+
 					if ( light.castShadow ) {
 
 						var shadow = light.shadow;
 
-						var shadowUniforms = shadowCache.get( light );
-
-						shadowUniforms.shadowBias = shadow.bias;
-						shadowUniforms.shadowRadius = shadow.radius;
-						shadowUniforms.shadowMapSize = shadow.mapSize;
-						shadowUniforms.shadowCameraNear = shadow.camera.near;
-						shadowUniforms.shadowCameraFar = shadow.camera.far;
-
-						state.pointShadow[ pointLength ] = shadowUniforms;
-						state.pointShadowMap[ pointLength ] = shadowMap;
-						state.pointShadowMatrix[ pointLength ] = light.shadow.matrix;
-
-						numPointShadows ++;
+						uniforms.shadowBias = shadow.bias;
+						uniforms.shadowRadius = shadow.radius;
+						uniforms.shadowMapSize = shadow.mapSize;
+						uniforms.shadowCameraNear = shadow.camera.near;
+						uniforms.shadowCameraFar = shadow.camera.far;
 
 					}
 
+					state.pointShadowMap[ pointLength ] = shadowMap;
+					state.pointShadowMatrix[ pointLength ] = light.shadow.matrix;
 					state.point[ pointLength ] = uniforms;
 
 					pointLength ++;
@@ -19607,9 +19224,7 @@ var Spacekit = (function (exports) {
 				hash.spotLength !== spotLength ||
 				hash.rectAreaLength !== rectAreaLength ||
 				hash.hemiLength !== hemiLength ||
-				hash.numDirectionalShadows !== numDirectionalShadows ||
-				hash.numPointShadows !== numPointShadows ||
-				hash.numSpotShadows !== numSpotShadows ) {
+				hash.shadowsLength !== shadows.length ) {
 
 				state.directional.length = directionalLength;
 				state.spot.length = spotLength;
@@ -19617,25 +19232,12 @@ var Spacekit = (function (exports) {
 				state.point.length = pointLength;
 				state.hemi.length = hemiLength;
 
-				state.directionalShadow.length = numDirectionalShadows;
-				state.directionalShadowMap.length = numDirectionalShadows;
-				state.pointShadow.length = numPointShadows;
-				state.pointShadowMap.length = numPointShadows;
-				state.spotShadow.length = numSpotShadows;
-				state.spotShadowMap.length = numSpotShadows;
-				state.directionalShadowMatrix.length = numDirectionalShadows;
-				state.pointShadowMatrix.length = numPointShadows;
-				state.spotShadowMatrix.length = numSpotShadows;
-
 				hash.directionalLength = directionalLength;
 				hash.pointLength = pointLength;
 				hash.spotLength = spotLength;
 				hash.rectAreaLength = rectAreaLength;
 				hash.hemiLength = hemiLength;
-
-				hash.numDirectionalShadows = numDirectionalShadows;
-				hash.numPointShadows = numPointShadows;
-				hash.numSpotShadows = numSpotShadows;
+				hash.shadowsLength = shadows.length;
 
 				state.version = nextVersion ++;
 
@@ -19706,7 +19308,7 @@ var Spacekit = (function (exports) {
 
 	function WebGLRenderStates() {
 
-		var renderStates = new WeakMap();
+		var renderStates = {};
 
 		function onSceneDispose( event ) {
 
@@ -19714,7 +19316,7 @@ var Spacekit = (function (exports) {
 
 			scene.removeEventListener( 'dispose', onSceneDispose );
 
-			renderStates.delete( scene );
+			delete renderStates[ scene.id ];
 
 		}
 
@@ -19722,24 +19324,24 @@ var Spacekit = (function (exports) {
 
 			var renderState;
 
-			if ( renderStates.has( scene ) === false ) {
+			if ( renderStates[ scene.id ] === undefined ) {
 
 				renderState = new WebGLRenderState();
-				renderStates.set( scene, new WeakMap() );
-				renderStates.get( scene ).set( camera, renderState );
+				renderStates[ scene.id ] = {};
+				renderStates[ scene.id ][ camera.id ] = renderState;
 
 				scene.addEventListener( 'dispose', onSceneDispose );
 
 			} else {
 
-				if ( renderStates.get( scene ).has( camera ) === false ) {
+				if ( renderStates[ scene.id ][ camera.id ] === undefined ) {
 
 					renderState = new WebGLRenderState();
-					renderStates.get( scene ).set( camera, renderState );
+					renderStates[ scene.id ][ camera.id ] = renderState;
 
 				} else {
 
-					renderState = renderStates.get( scene ).get( camera );
+					renderState = renderStates[ scene.id ][ camera.id ];
 
 				}
 
@@ -19751,7 +19353,7 @@ var Spacekit = (function (exports) {
 
 		function dispose() {
 
-			renderStates = new WeakMap();
+			renderStates = {};
 
 		}
 
@@ -19808,6 +19410,7 @@ var Spacekit = (function (exports) {
 		this.wireframeLinewidth = 1;
 
 		this.fog = false;
+		this.lights = false;
 
 		this.setValues( parameters );
 
@@ -19887,6 +19490,7 @@ var Spacekit = (function (exports) {
 		this.displacementBias = 0;
 
 		this.fog = false;
+		this.lights = false;
 
 		this.setValues( parameters );
 
@@ -19920,10 +19524,6 @@ var Spacekit = (function (exports) {
 
 	};
 
-	var vsm_frag = "uniform sampler2D shadow_pass;\nuniform vec2 resolution;\nuniform float radius;\n#include <packing>\nvoid main() {\n  float mean = 0.0;\n  float squared_mean = 0.0;\n\tfloat depth = unpackRGBAToDepth( texture2D( shadow_pass, ( gl_FragCoord.xy  ) / resolution ) );\n  for ( float i = -1.0; i < 1.0 ; i += SAMPLE_RATE) {\n    #ifdef HORIZONAL_PASS\n      vec2 distribution = unpackRGBATo2Half( texture2D( shadow_pass, ( gl_FragCoord.xy + vec2( i, 0.0 ) * radius ) / resolution ) );\n      mean += distribution.x;\n      squared_mean += distribution.y * distribution.y + distribution.x * distribution.x;\n    #else\n      float depth = unpackRGBAToDepth( texture2D( shadow_pass, ( gl_FragCoord.xy + vec2( 0.0,  i )  * radius ) / resolution ) );\n      mean += depth;\n      squared_mean += depth * depth;\n    #endif\n  }\n  mean = mean * HALF_SAMPLE_RATE;\n  squared_mean = squared_mean * HALF_SAMPLE_RATE;\n  float std_dev = sqrt( squared_mean - mean * mean );\n  gl_FragColor = pack2HalfToRGBA( vec2( mean, std_dev ) );\n}";
-
-	var vsm_vert = "void main() {\n\tgl_Position = vec4( position, 1.0 );\n}";
-
 	/**
 	 * @author alteredq / http://alteredqualia.com/
 	 * @author mrdoob / http://mrdoob.com/
@@ -19932,51 +19532,73 @@ var Spacekit = (function (exports) {
 	function WebGLShadowMap( _renderer, _objects, maxTextureSize ) {
 
 		var _frustum = new Frustum(),
+			_projScreenMatrix = new Matrix4(),
 
 			_shadowMapSize = new Vector2(),
-			_viewportSize = new Vector2(),
+			_maxShadowMapSize = new Vector2( maxTextureSize, maxTextureSize ),
 
-			_viewport = new Vector4(),
+			_lookTarget = new Vector3(),
+			_lightPositionWorld = new Vector3(),
 
-			_depthMaterials = [],
-			_distanceMaterials = [],
+			_MorphingFlag = 1,
+			_SkinningFlag = 2,
+
+			_NumberOfMaterialVariants = ( _MorphingFlag | _SkinningFlag ) + 1,
+
+			_depthMaterials = new Array( _NumberOfMaterialVariants ),
+			_distanceMaterials = new Array( _NumberOfMaterialVariants ),
 
 			_materialCache = {};
 
 		var shadowSide = { 0: BackSide, 1: FrontSide, 2: DoubleSide };
 
-		var shadowMaterialVertical = new ShaderMaterial( {
+		var cubeDirections = [
+			new Vector3( 1, 0, 0 ), new Vector3( - 1, 0, 0 ), new Vector3( 0, 0, 1 ),
+			new Vector3( 0, 0, - 1 ), new Vector3( 0, 1, 0 ), new Vector3( 0, - 1, 0 )
+		];
 
-			defines: {
-				SAMPLE_RATE: 2.0 / 8.0,
-				HALF_SAMPLE_RATE: 1.0 / 8.0
-			},
+		var cubeUps = [
+			new Vector3( 0, 1, 0 ), new Vector3( 0, 1, 0 ), new Vector3( 0, 1, 0 ),
+			new Vector3( 0, 1, 0 ), new Vector3( 0, 0, 1 ),	new Vector3( 0, 0, - 1 )
+		];
 
-			uniforms: {
-				shadow_pass: { value: null },
-				resolution: { value: new Vector2() },
-				radius: { value: 4.0 }
-			},
+		var cube2DViewPorts = [
+			new Vector4(), new Vector4(), new Vector4(),
+			new Vector4(), new Vector4(), new Vector4()
+		];
 
-			vertexShader: vsm_vert,
+		// init
 
-			fragmentShader: vsm_frag
+		for ( var i = 0; i !== _NumberOfMaterialVariants; ++ i ) {
 
-		} );
+			var useMorphing = ( i & _MorphingFlag ) !== 0;
+			var useSkinning = ( i & _SkinningFlag ) !== 0;
 
-		var shadowMaterialHorizonal = shadowMaterialVertical.clone();
-		shadowMaterialHorizonal.defines.HORIZONAL_PASS = 1;
+			var depthMaterial = new MeshDepthMaterial( {
 
-		var fullScreenTri = new BufferGeometry();
-		fullScreenTri.setAttribute(
-			"position",
-			new BufferAttribute(
-				new Float32Array( [ - 1, - 1, 0.5, 3, - 1, 0.5, - 1, 3, 0.5 ] ),
-				3
-			)
-		);
+				depthPacking: RGBADepthPacking,
 
-		var fullScreenMesh = new Mesh( fullScreenTri, shadowMaterialVertical );
+				morphTargets: useMorphing,
+				skinning: useSkinning
+
+			} );
+
+			_depthMaterials[ i ] = depthMaterial;
+
+			//
+
+			var distanceMaterial = new MeshDistanceMaterial( {
+
+				morphTargets: useMorphing,
+				skinning: useSkinning
+
+			} );
+
+			_distanceMaterials[ i ] = distanceMaterial;
+
+		}
+
+		//
 
 		var scope = this;
 
@@ -20008,10 +19630,13 @@ var Spacekit = (function (exports) {
 
 			// render depth map
 
+			var faceCount;
+
 			for ( var i = 0, il = lights.length; i < il; i ++ ) {
 
 				var light = lights[ i ];
 				var shadow = light.shadow;
+				var isPointLight = light && light.isPointLight;
 
 				if ( shadow === undefined ) {
 
@@ -20020,44 +19645,44 @@ var Spacekit = (function (exports) {
 
 				}
 
+				var shadowCamera = shadow.camera;
+
 				_shadowMapSize.copy( shadow.mapSize );
+				_shadowMapSize.min( _maxShadowMapSize );
 
-				var shadowFrameExtents = shadow.getFrameExtents();
+				if ( isPointLight ) {
 
-				_shadowMapSize.multiply( shadowFrameExtents );
+					var vpWidth = _shadowMapSize.x;
+					var vpHeight = _shadowMapSize.y;
 
-				_viewportSize.copy( shadow.mapSize );
+					// These viewports map a cube-map onto a 2D texture with the
+					// following orientation:
+					//
+					//  xzXZ
+					//   y Y
+					//
+					// X - Positive x direction
+					// x - Negative x direction
+					// Y - Positive y direction
+					// y - Negative y direction
+					// Z - Positive z direction
+					// z - Negative z direction
 
-				if ( _shadowMapSize.x > maxTextureSize || _shadowMapSize.y > maxTextureSize ) {
+					// positive X
+					cube2DViewPorts[ 0 ].set( vpWidth * 2, vpHeight, vpWidth, vpHeight );
+					// negative X
+					cube2DViewPorts[ 1 ].set( 0, vpHeight, vpWidth, vpHeight );
+					// positive Z
+					cube2DViewPorts[ 2 ].set( vpWidth * 3, vpHeight, vpWidth, vpHeight );
+					// negative Z
+					cube2DViewPorts[ 3 ].set( vpWidth, vpHeight, vpWidth, vpHeight );
+					// positive Y
+					cube2DViewPorts[ 4 ].set( vpWidth * 3, 0, vpWidth, vpHeight );
+					// negative Y
+					cube2DViewPorts[ 5 ].set( vpWidth, 0, vpWidth, vpHeight );
 
-					if ( _shadowMapSize.x > maxTextureSize ) {
-
-						_viewportSize.x = Math.floor( maxTextureSize / shadowFrameExtents.x );
-						_shadowMapSize.x = _viewportSize.x * shadowFrameExtents.x;
-						shadow.mapSize.x = _viewportSize.x;
-
-					}
-
-					if ( _shadowMapSize.y > maxTextureSize ) {
-
-						_viewportSize.y = Math.floor( maxTextureSize / shadowFrameExtents.y );
-						_shadowMapSize.y = _viewportSize.y * shadowFrameExtents.y;
-						shadow.mapSize.y = _viewportSize.y;
-
-					}
-
-				}
-
-				if ( shadow.map === null && ! shadow.isPointLightShadow && this.type === VSMShadowMap ) {
-
-					var pars = { minFilter: LinearFilter, magFilter: LinearFilter, format: RGBAFormat };
-
-					shadow.map = new WebGLRenderTarget( _shadowMapSize.x, _shadowMapSize.y, pars );
-					shadow.map.texture.name = light.name + ".shadowMap";
-
-					shadow.mapPass = new WebGLRenderTarget( _shadowMapSize.x, _shadowMapSize.y, pars );
-
-					shadow.camera.updateProjectionMatrix();
+					_shadowMapSize.x *= 4.0;
+					_shadowMapSize.y *= 2.0;
 
 				}
 
@@ -20068,41 +19693,82 @@ var Spacekit = (function (exports) {
 					shadow.map = new WebGLRenderTarget( _shadowMapSize.x, _shadowMapSize.y, pars );
 					shadow.map.texture.name = light.name + ".shadowMap";
 
-					shadow.camera.updateProjectionMatrix();
+					shadowCamera.updateProjectionMatrix();
 
 				}
 
-				_renderer.setRenderTarget( shadow.map );
-				_renderer.clear();
+				if ( shadow.isSpotLightShadow ) {
 
-				var viewportCount = shadow.getViewportCount();
+					shadow.update( light );
 
-				for ( var vp = 0; vp < viewportCount; vp ++ ) {
+				}
 
-					var viewport = shadow.getViewport( vp );
+				var shadowMap = shadow.map;
+				var shadowMatrix = shadow.matrix;
 
-					_viewport.set(
-						_viewportSize.x * viewport.x,
-						_viewportSize.y * viewport.y,
-						_viewportSize.x * viewport.z,
-						_viewportSize.y * viewport.w
+				_lightPositionWorld.setFromMatrixPosition( light.matrixWorld );
+				shadowCamera.position.copy( _lightPositionWorld );
+
+				if ( isPointLight ) {
+
+					faceCount = 6;
+
+					// for point lights we set the shadow matrix to be a translation-only matrix
+					// equal to inverse of the light's position
+
+					shadowMatrix.makeTranslation( - _lightPositionWorld.x, - _lightPositionWorld.y, - _lightPositionWorld.z );
+
+				} else {
+
+					faceCount = 1;
+
+					_lookTarget.setFromMatrixPosition( light.target.matrixWorld );
+					shadowCamera.lookAt( _lookTarget );
+					shadowCamera.updateMatrixWorld();
+
+					// compute shadow matrix
+
+					shadowMatrix.set(
+						0.5, 0.0, 0.0, 0.5,
+						0.0, 0.5, 0.0, 0.5,
+						0.0, 0.0, 0.5, 0.5,
+						0.0, 0.0, 0.0, 1.0
 					);
 
-					_state.viewport( _viewport );
-
-					shadow.updateMatrices( light, vp );
-
-					_frustum = shadow.getFrustum();
-
-					renderObject( scene, camera, shadow.camera, light, this.type );
+					shadowMatrix.multiply( shadowCamera.projectionMatrix );
+					shadowMatrix.multiply( shadowCamera.matrixWorldInverse );
 
 				}
 
-				// do blur pass for VSM
+				_renderer.setRenderTarget( shadowMap );
+				_renderer.clear();
 
-				if ( ! shadow.isPointLightShadow && this.type === VSMShadowMap ) {
+				// render shadow map for each cube face (if omni-directional) or
+				// run a single pass if not
 
-					VSMPass( shadow, camera );
+				for ( var face = 0; face < faceCount; face ++ ) {
+
+					if ( isPointLight ) {
+
+						_lookTarget.copy( shadowCamera.position );
+						_lookTarget.add( cubeDirections[ face ] );
+						shadowCamera.up.copy( cubeUps[ face ] );
+						shadowCamera.lookAt( _lookTarget );
+						shadowCamera.updateMatrixWorld();
+
+						var vpDimensions = cube2DViewPorts[ face ];
+						_state.viewport( vpDimensions );
+
+					}
+
+					// update camera matrices and frustum
+
+					_projScreenMatrix.multiplyMatrices( shadowCamera.projectionMatrix, shadowCamera.matrixWorldInverse );
+					_frustum.setFromMatrix( _projScreenMatrix );
+
+					// set object matrices & frustum culling
+
+					renderObject( scene, camera, shadowCamera, isPointLight );
 
 				}
 
@@ -20114,121 +19780,54 @@ var Spacekit = (function (exports) {
 
 		};
 
-		function VSMPass( shadow, camera ) {
+		function getDepthMaterial( object, material, isPointLight, lightPositionWorld, shadowCameraNear, shadowCameraFar ) {
 
-			var geometry = _objects.update( fullScreenMesh );
-
-			// vertical pass
-
-			shadowMaterialVertical.uniforms.shadow_pass.value = shadow.map.texture;
-			shadowMaterialVertical.uniforms.resolution.value = shadow.mapSize;
-			shadowMaterialVertical.uniforms.radius.value = shadow.radius;
-			_renderer.setRenderTarget( shadow.mapPass );
-			_renderer.clear();
-			_renderer.renderBufferDirect( camera, null, geometry, shadowMaterialVertical, fullScreenMesh, null );
-
-			// horizonal pass
-
-			shadowMaterialHorizonal.uniforms.shadow_pass.value = shadow.mapPass.texture;
-			shadowMaterialHorizonal.uniforms.resolution.value = shadow.mapSize;
-			shadowMaterialHorizonal.uniforms.radius.value = shadow.radius;
-			_renderer.setRenderTarget( shadow.map );
-			_renderer.clear();
-			_renderer.renderBufferDirect( camera, null, geometry, shadowMaterialHorizonal, fullScreenMesh, null );
-
-		}
-
-		function getDepthMaterialVariant( useMorphing, useSkinning, useInstancing ) {
-
-			var index = useMorphing << 0 | useSkinning << 1 | useInstancing << 2;
-
-			var material = _depthMaterials[ index ];
-
-			if ( material === undefined ) {
-
-				material = new MeshDepthMaterial( {
-
-					depthPacking: RGBADepthPacking,
-
-					morphTargets: useMorphing,
-					skinning: useSkinning
-
-				} );
-
-				_depthMaterials[ index ] = material;
-
-			}
-
-			return material;
-
-		}
-
-		function getDistanceMaterialVariant( useMorphing, useSkinning, useInstancing ) {
-
-			var index = useMorphing << 0 | useSkinning << 1 | useInstancing << 2;
-
-			var material = _distanceMaterials[ index ];
-
-			if ( material === undefined ) {
-
-				material = new MeshDistanceMaterial( {
-
-					morphTargets: useMorphing,
-					skinning: useSkinning
-
-				} );
-
-				_distanceMaterials[ index ] = material;
-
-			}
-
-			return material;
-
-		}
-
-		function getDepthMaterial( object, geometry, material, light, shadowCameraNear, shadowCameraFar, type ) {
+			var geometry = object.geometry;
 
 			var result = null;
 
-			var getMaterialVariant = getDepthMaterialVariant;
+			var materialVariants = _depthMaterials;
 			var customMaterial = object.customDepthMaterial;
 
-			if ( light.isPointLight === true ) {
+			if ( isPointLight ) {
 
-				getMaterialVariant = getDistanceMaterialVariant;
+				materialVariants = _distanceMaterials;
 				customMaterial = object.customDistanceMaterial;
 
 			}
 
-			if ( customMaterial === undefined ) {
+			if ( ! customMaterial ) {
 
 				var useMorphing = false;
 
-				if ( material.morphTargets === true ) {
+				if ( material.morphTargets ) {
 
-					useMorphing = geometry.morphAttributes && geometry.morphAttributes.position && geometry.morphAttributes.position.length > 0;
+					if ( geometry && geometry.isBufferGeometry ) {
 
-				}
+						useMorphing = geometry.morphAttributes && geometry.morphAttributes.position && geometry.morphAttributes.position.length > 0;
 
-				var useSkinning = false;
+					} else if ( geometry && geometry.isGeometry ) {
 
-				if ( object.isSkinnedMesh === true ) {
-
-					if ( material.skinning === true ) {
-
-						useSkinning = true;
-
-					} else {
-
-						console.warn( 'THREE.WebGLShadowMap: THREE.SkinnedMesh with material.skinning set to false:', object );
+						useMorphing = geometry.morphTargets && geometry.morphTargets.length > 0;
 
 					}
 
 				}
 
-				var useInstancing = object.isInstancedMesh === true;
+				if ( object.isSkinnedMesh && material.skinning === false ) {
 
-				result = getMaterialVariant( useMorphing, useSkinning, useInstancing );
+					console.warn( 'THREE.WebGLShadowMap: THREE.SkinnedMesh with material.skinning set to false:', object );
+
+				}
+
+				var useSkinning = object.isSkinnedMesh && material.skinning;
+
+				var variantIndex = 0;
+
+				if ( useMorphing ) variantIndex |= _MorphingFlag;
+				if ( useSkinning ) variantIndex |= _SkinningFlag;
+
+				result = materialVariants[ variantIndex ];
 
 			} else {
 
@@ -20270,15 +19869,7 @@ var Spacekit = (function (exports) {
 			result.visible = material.visible;
 			result.wireframe = material.wireframe;
 
-			if ( type === VSMShadowMap ) {
-
-				result.side = ( material.shadowSide !== null ) ? material.shadowSide : material.side;
-
-			} else {
-
-				result.side = ( material.shadowSide !== null ) ? material.shadowSide : shadowSide[ material.side ];
-
-			}
+			result.side = ( material.shadowSide != null ) ? material.shadowSide : shadowSide[ material.side ];
 
 			result.clipShadows = material.clipShadows;
 			result.clippingPlanes = material.clippingPlanes;
@@ -20287,9 +19878,9 @@ var Spacekit = (function (exports) {
 			result.wireframeLinewidth = material.wireframeLinewidth;
 			result.linewidth = material.linewidth;
 
-			if ( light.isPointLight === true && result.isMeshDistanceMaterial === true ) {
+			if ( isPointLight && result.isMeshDistanceMaterial ) {
 
-				result.referencePosition.setFromMatrixPosition( light.matrixWorld );
+				result.referencePosition.copy( lightPositionWorld );
 				result.nearDistance = shadowCameraNear;
 				result.farDistance = shadowCameraFar;
 
@@ -20299,7 +19890,7 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function renderObject( object, camera, shadowCamera, light, type ) {
+		function renderObject( object, camera, shadowCamera, isPointLight ) {
 
 			if ( object.visible === false ) return;
 
@@ -20307,7 +19898,7 @@ var Spacekit = (function (exports) {
 
 			if ( visible && ( object.isMesh || object.isLine || object.isPoints ) ) {
 
-				if ( ( object.castShadow || ( object.receiveShadow && type === VSMShadowMap ) ) && ( ! object.frustumCulled || _frustum.intersectsObject( object ) ) ) {
+				if ( object.castShadow && ( ! object.frustumCulled || _frustum.intersectsObject( object ) ) ) {
 
 					object.modelViewMatrix.multiplyMatrices( shadowCamera.matrixWorldInverse, object.matrixWorld );
 
@@ -20325,8 +19916,7 @@ var Spacekit = (function (exports) {
 
 							if ( groupMaterial && groupMaterial.visible ) {
 
-								var depthMaterial = getDepthMaterial( object, geometry, groupMaterial, light, shadowCamera.near, shadowCamera.far, type );
-
+								var depthMaterial = getDepthMaterial( object, groupMaterial, isPointLight, _lightPositionWorld, shadowCamera.near, shadowCamera.far );
 								_renderer.renderBufferDirect( shadowCamera, null, geometry, depthMaterial, object, group );
 
 							}
@@ -20335,8 +19925,7 @@ var Spacekit = (function (exports) {
 
 					} else if ( material.visible ) {
 
-						var depthMaterial = getDepthMaterial( object, geometry, material, light, shadowCamera.near, shadowCamera.far, type );
-
+						var depthMaterial = getDepthMaterial( object, material, isPointLight, _lightPositionWorld, shadowCamera.near, shadowCamera.far );
 						_renderer.renderBufferDirect( shadowCamera, null, geometry, depthMaterial, object, null );
 
 					}
@@ -20349,7 +19938,7 @@ var Spacekit = (function (exports) {
 
 			for ( var i = 0, l = children.length; i < l; i ++ ) {
 
-				renderObject( children[ i ], camera, shadowCamera, light, type );
+				renderObject( children[ i ], camera, shadowCamera, isPointLight );
 
 			}
 
@@ -20361,9 +19950,7 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-	function WebGLState( gl, extensions, capabilities ) {
-
-		var isWebGL2 = capabilities.isWebGL2;
+	function WebGLState( gl, extensions, utils, capabilities ) {
 
 		function ColorBuffer() {
 
@@ -20573,17 +20160,13 @@ var Spacekit = (function (exports) {
 
 				setTest: function ( stencilTest ) {
 
-					if ( ! locked ) {
+					if ( stencilTest ) {
 
-						if ( stencilTest ) {
+						enable( 2960 );
 
-							enable( 2960 );
+					} else {
 
-						} else {
-
-							disable( 2960 );
-
-						}
+						disable( 2960 );
 
 					}
 
@@ -20680,6 +20263,8 @@ var Spacekit = (function (exports) {
 		var attributeDivisors = new Uint8Array( maxVertexAttributes );
 
 		var enabledCapabilities = {};
+
+		var compressedTextureFormats = null;
 
 		var currentProgram = null;
 
@@ -20794,9 +20379,9 @@ var Spacekit = (function (exports) {
 
 			if ( attributeDivisors[ attribute ] !== meshPerAttribute ) {
 
-				var extension = isWebGL2 ? gl : extensions.get( 'ANGLE_instanced_arrays' );
+				var extension = capabilities.isWebGL2 ? gl : extensions.get( 'ANGLE_instanced_arrays' );
 
-				extension[ isWebGL2 ? 'vertexAttribDivisor' : 'vertexAttribDivisorANGLE' ]( attribute, meshPerAttribute );
+				extension[ capabilities.isWebGL2 ? 'vertexAttribDivisor' : 'vertexAttribDivisorANGLE' ]( attribute, meshPerAttribute );
 				attributeDivisors[ attribute ] = meshPerAttribute;
 
 			}
@@ -20813,20 +20398,6 @@ var Spacekit = (function (exports) {
 					enabledAttributes[ i ] = 0;
 
 				}
-
-			}
-
-		}
-
-		function vertexAttribPointer( index, size, type, normalized, stride, offset ) {
-
-			if ( isWebGL2 === true && ( type === 5124 || type === 5125 ) ) {
-
-				gl.vertexAttribIPointer( index, size, type, normalized, stride, offset );
-
-			} else {
-
-				gl.vertexAttribPointer( index, size, type, normalized, stride, offset );
 
 			}
 
@@ -20854,6 +20425,33 @@ var Spacekit = (function (exports) {
 
 		}
 
+		function getCompressedTextureFormats() {
+
+			if ( compressedTextureFormats === null ) {
+
+				compressedTextureFormats = [];
+
+				if ( extensions.get( 'WEBGL_compressed_texture_pvrtc' ) ||
+				     extensions.get( 'WEBGL_compressed_texture_s3tc' ) ||
+				     extensions.get( 'WEBGL_compressed_texture_etc1' ) ||
+				     extensions.get( 'WEBGL_compressed_texture_astc' ) ) {
+
+					var formats = gl.getParameter( 34467 );
+
+					for ( var i = 0; i < formats.length; i ++ ) {
+
+						compressedTextureFormats.push( formats[ i ] );
+
+					}
+
+				}
+
+			}
+
+			return compressedTextureFormats;
+
+		}
+
 		function useProgram( program ) {
 
 			if ( currentProgram !== program ) {
@@ -20869,44 +20467,6 @@ var Spacekit = (function (exports) {
 			return false;
 
 		}
-
-		var equationToGL = {
-			[ AddEquation ]: 32774,
-			[ SubtractEquation ]: 32778,
-			[ ReverseSubtractEquation ]: 32779
-		};
-
-		if ( isWebGL2 ) {
-
-			equationToGL[ MinEquation ] = 32775;
-			equationToGL[ MaxEquation ] = 32776;
-
-		} else {
-
-			var extension = extensions.get( 'EXT_blend_minmax' );
-
-			if ( extension !== null ) {
-
-				equationToGL[ MinEquation ] = extension.MIN_EXT;
-				equationToGL[ MaxEquation ] = extension.MAX_EXT;
-
-			}
-
-		}
-
-		var factorToGL = {
-			[ ZeroFactor ]: 0,
-			[ OneFactor ]: 1,
-			[ SrcColorFactor ]: 768,
-			[ SrcAlphaFactor ]: 770,
-			[ SrcAlphaSaturateFactor ]: 776,
-			[ DstColorFactor ]: 774,
-			[ DstAlphaFactor ]: 772,
-			[ OneMinusSrcColorFactor ]: 769,
-			[ OneMinusSrcAlphaFactor ]: 771,
-			[ OneMinusDstColorFactor ]: 775,
-			[ OneMinusDstAlphaFactor ]: 773
-		};
 
 		function setBlending( blending, blendEquation, blendSrc, blendDst, blendEquationAlpha, blendSrcAlpha, blendDstAlpha, premultipliedAlpha ) {
 
@@ -21019,7 +20579,7 @@ var Spacekit = (function (exports) {
 
 			if ( blendEquation !== currentBlendEquation || blendEquationAlpha !== currentBlendEquationAlpha ) {
 
-				gl.blendEquationSeparate( equationToGL[ blendEquation ], equationToGL[ blendEquationAlpha ] );
+				gl.blendEquationSeparate( utils.convert( blendEquation ), utils.convert( blendEquationAlpha ) );
 
 				currentBlendEquation = blendEquation;
 				currentBlendEquationAlpha = blendEquationAlpha;
@@ -21028,7 +20588,7 @@ var Spacekit = (function (exports) {
 
 			if ( blendSrc !== currentBlendSrc || blendDst !== currentBlendDst || blendSrcAlpha !== currentBlendSrcAlpha || blendDstAlpha !== currentBlendDstAlpha ) {
 
-				gl.blendFuncSeparate( factorToGL[ blendSrc ], factorToGL[ blendDst ], factorToGL[ blendSrcAlpha ], factorToGL[ blendDstAlpha ] );
+				gl.blendFuncSeparate( utils.convert( blendSrc ), utils.convert( blendDst ), utils.convert( blendSrcAlpha ), utils.convert( blendDstAlpha ) );
 
 				currentBlendSrc = blendSrc;
 				currentBlendDst = blendDst;
@@ -21066,8 +20626,7 @@ var Spacekit = (function (exports) {
 			stencilBuffer.setTest( stencilWrite );
 			if ( stencilWrite ) {
 
-				stencilBuffer.setMask( material.stencilWriteMask );
-				stencilBuffer.setFunc( material.stencilFunc, material.stencilRef, material.stencilFuncMask );
+				stencilBuffer.setFunc( material.stencilFunc, material.stencilRef, material.stencilMask );
 				stencilBuffer.setOp( material.stencilFail, material.stencilZFail, material.stencilZPass );
 
 			}
@@ -21224,21 +20783,6 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function unbindTexture() {
-
-			var boundTexture = currentBoundTextures[ currentTextureSlot ];
-
-			if ( boundTexture !== undefined && boundTexture.type !== undefined ) {
-
-				gl.bindTexture( boundTexture.type, null );
-
-				boundTexture.type = undefined;
-				boundTexture.texture = undefined;
-
-			}
-
-		}
-
 		function compressedTexImage2D() {
 
 			try {
@@ -21322,6 +20866,8 @@ var Spacekit = (function (exports) {
 
 			enabledCapabilities = {};
 
+			compressedTextureFormats = null;
+
 			currentTextureSlot = null;
 			currentBoundTextures = {};
 
@@ -21350,9 +20896,9 @@ var Spacekit = (function (exports) {
 			enableAttribute: enableAttribute,
 			enableAttributeAndDivisor: enableAttributeAndDivisor,
 			disableUnusedAttributes: disableUnusedAttributes,
-			vertexAttribPointer: vertexAttribPointer,
 			enable: enable,
 			disable: disable,
+			getCompressedTextureFormats: getCompressedTextureFormats,
 
 			useProgram: useProgram,
 
@@ -21369,7 +20915,6 @@ var Spacekit = (function (exports) {
 
 			activeTexture: activeTexture,
 			bindTexture: bindTexture,
-			unbindTexture: unbindTexture,
 			compressedTexImage2D: compressedTexImage2D,
 			texImage2D: texImage2D,
 			texImage3D: texImage3D,
@@ -21389,31 +20934,12 @@ var Spacekit = (function (exports) {
 
 	function WebGLTextures( _gl, extensions, state, properties, capabilities, utils, info ) {
 
-		var isWebGL2 = capabilities.isWebGL2;
-		var maxTextures = capabilities.maxTextures;
-		var maxCubemapSize = capabilities.maxCubemapSize;
-		var maxTextureSize = capabilities.maxTextureSize;
-		var maxSamples = capabilities.maxSamples;
-
-		var _videoTextures = new WeakMap();
+		var _videoTextures = {};
 		var _canvas;
 
-		// cordova iOS (as of 5.0) still uses UIWebView, which provides OffscreenCanvas,
-		// also OffscreenCanvas.getContext("webgl"), but not OffscreenCanvas.getContext("2d")!
-		// Some implementations may only implement OffscreenCanvas partially (e.g. lacking 2d).
+		//
 
-		var useOffscreenCanvas = false;
-
-		try {
-
-			useOffscreenCanvas = typeof OffscreenCanvas !== 'undefined'
-				&& ( new OffscreenCanvas( 1, 1 ).getContext( "2d" ) ) !== null;
-
-		} catch ( err ) {
-
-			// Ignore any errors
-
-		}
+		var useOffscreenCanvas = typeof OffscreenCanvas !== 'undefined';
 
 		function createCanvas( width, height ) {
 
@@ -21447,7 +20973,7 @@ var Spacekit = (function (exports) {
 					( typeof HTMLCanvasElement !== 'undefined' && image instanceof HTMLCanvasElement ) ||
 					( typeof ImageBitmap !== 'undefined' && image instanceof ImageBitmap ) ) {
 
-					var floor = needsPowerOfTwo ? MathUtils.floorPowerOfTwo : Math.floor;
+					var floor = needsPowerOfTwo ? _Math.floorPowerOfTwo : Math.floor;
 
 					var width = floor( scale * image.width );
 					var height = floor( scale * image.height );
@@ -21488,13 +21014,13 @@ var Spacekit = (function (exports) {
 
 		function isPowerOfTwo( image ) {
 
-			return MathUtils.isPowerOfTwo( image.width ) && MathUtils.isPowerOfTwo( image.height );
+			return _Math.isPowerOfTwo( image.width ) && _Math.isPowerOfTwo( image.height );
 
 		}
 
 		function textureNeedsPowerOfTwo( texture ) {
 
-			if ( isWebGL2 ) return false;
+			if ( capabilities.isWebGL2 ) return false;
 
 			return ( texture.wrapS !== ClampToEdgeWrapping || texture.wrapT !== ClampToEdgeWrapping ) ||
 				( texture.minFilter !== NearestFilter && texture.minFilter !== LinearFilter );
@@ -21519,17 +21045,9 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function getInternalFormat( internalFormatName, glFormat, glType ) {
+		function getInternalFormat( glFormat, glType ) {
 
-			if ( isWebGL2 === false ) return glFormat;
-
-			if ( internalFormatName !== null ) {
-
-				if ( _gl[ internalFormatName ] !== undefined ) return _gl[ internalFormatName ];
-
-				console.warn( 'THREE.WebGLRenderer: Attempt to use non-existing WebGL internal format \'' + internalFormatName + '\'' );
-
-			}
+			if ( ! capabilities.isWebGL2 ) return glFormat;
 
 			var internalFormat = glFormat;
 
@@ -21561,6 +21079,10 @@ var Spacekit = (function (exports) {
 				internalFormat === 34842 || internalFormat === 34836 ) {
 
 				extensions.get( 'EXT_color_buffer_float' );
+
+			} else if ( internalFormat === 34843 || internalFormat === 34837 ) {
+
+				console.warn( 'THREE.WebGLRenderer: Floating point textures with RGB format not supported. Please use RGBA instead.' );
 
 			}
 
@@ -21594,7 +21116,7 @@ var Spacekit = (function (exports) {
 
 			if ( texture.isVideoTexture ) {
 
-				_videoTextures.delete( texture );
+				delete _videoTextures[ texture.id ];
 
 			}
 
@@ -21647,7 +21169,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			if ( renderTarget.isWebGLCubeRenderTarget ) {
+			if ( renderTarget.isWebGLRenderTargetCube ) {
 
 				for ( var i = 0; i < 6; i ++ ) {
 
@@ -21660,9 +21182,6 @@ var Spacekit = (function (exports) {
 
 				_gl.deleteFramebuffer( renderTargetProperties.__webglFramebuffer );
 				if ( renderTargetProperties.__webglDepthbuffer ) _gl.deleteRenderbuffer( renderTargetProperties.__webglDepthbuffer );
-				if ( renderTargetProperties.__webglMultisampledFramebuffer ) _gl.deleteFramebuffer( renderTargetProperties.__webglMultisampledFramebuffer );
-				if ( renderTargetProperties.__webglColorRenderbuffer ) _gl.deleteRenderbuffer( renderTargetProperties.__webglColorRenderbuffer );
-				if ( renderTargetProperties.__webglDepthRenderbuffer ) _gl.deleteRenderbuffer( renderTargetProperties.__webglDepthRenderbuffer );
 
 			}
 
@@ -21685,9 +21204,9 @@ var Spacekit = (function (exports) {
 
 			var textureUnit = textureUnits;
 
-			if ( textureUnit >= maxTextures ) {
+			if ( textureUnit >= capabilities.maxTextures ) {
 
-				console.warn( 'THREE.WebGLTextures: Trying to use ' + textureUnit + ' texture units while this GPU supports only ' + maxTextures );
+				console.warn( 'THREE.WebGLTextures: Trying to use ' + textureUnit + ' texture units while this GPU supports only ' + capabilities.maxTextures );
 
 			}
 
@@ -21765,110 +21284,85 @@ var Spacekit = (function (exports) {
 
 		function setTextureCube( texture, slot ) {
 
-			if ( texture.image.length !== 6 ) return;
-
 			var textureProperties = properties.get( texture );
 
-			if ( texture.version > 0 && textureProperties.__version !== texture.version ) {
+			if ( texture.image.length === 6 ) {
 
-				initTexture( textureProperties, texture );
+				if ( texture.version > 0 && textureProperties.__version !== texture.version ) {
 
-				state.activeTexture( 33984 + slot );
-				state.bindTexture( 34067, textureProperties.__webglTexture );
+					initTexture( textureProperties, texture );
 
-				_gl.pixelStorei( 37440, texture.flipY );
+					state.activeTexture( 33984 + slot );
+					state.bindTexture( 34067, textureProperties.__webglTexture );
 
-				var isCompressed = ( texture && ( texture.isCompressedTexture || texture.image[ 0 ].isCompressedTexture ) );
-				var isDataTexture = ( texture.image[ 0 ] && texture.image[ 0 ].isDataTexture );
+					_gl.pixelStorei( 37440, texture.flipY );
 
-				var cubeImage = [];
+					var isCompressed = ( texture && texture.isCompressedTexture );
+					var isDataTexture = ( texture.image[ 0 ] && texture.image[ 0 ].isDataTexture );
 
-				for ( var i = 0; i < 6; i ++ ) {
-
-					if ( ! isCompressed && ! isDataTexture ) {
-
-						cubeImage[ i ] = resizeImage( texture.image[ i ], false, true, maxCubemapSize );
-
-					} else {
-
-						cubeImage[ i ] = isDataTexture ? texture.image[ i ].image : texture.image[ i ];
-
-					}
-
-				}
-
-				var image = cubeImage[ 0 ],
-					supportsMips = isPowerOfTwo( image ) || isWebGL2,
-					glFormat = utils.convert( texture.format ),
-					glType = utils.convert( texture.type ),
-					glInternalFormat = getInternalFormat( texture.internalFormat, glFormat, glType );
-
-				setTextureParameters( 34067, texture, supportsMips );
-
-				var mipmaps;
-
-				if ( isCompressed ) {
+					var cubeImage = [];
 
 					for ( var i = 0; i < 6; i ++ ) {
 
-						mipmaps = cubeImage[ i ].mipmaps;
+						if ( ! isCompressed && ! isDataTexture ) {
 
-						for ( var j = 0; j < mipmaps.length; j ++ ) {
+							cubeImage[ i ] = resizeImage( texture.image[ i ], false, true, capabilities.maxCubemapSize );
 
-							var mipmap = mipmaps[ j ];
+						} else {
 
-							if ( texture.format !== RGBAFormat && texture.format !== RGBFormat ) {
-
-								if ( glFormat !== null ) {
-
-									state.compressedTexImage2D( 34069 + i, j, glInternalFormat, mipmap.width, mipmap.height, 0, mipmap.data );
-
-								} else {
-
-									console.warn( 'THREE.WebGLRenderer: Attempt to load unsupported compressed texture format in .setTextureCube()' );
-
-								}
-
-							} else {
-
-								state.texImage2D( 34069 + i, j, glInternalFormat, mipmap.width, mipmap.height, 0, glFormat, glType, mipmap.data );
-
-							}
+							cubeImage[ i ] = isDataTexture ? texture.image[ i ].image : texture.image[ i ];
 
 						}
 
 					}
 
-					textureProperties.__maxMipLevel = mipmaps.length - 1;
+					var image = cubeImage[ 0 ],
+						supportsMips = isPowerOfTwo( image ) || capabilities.isWebGL2,
+						glFormat = utils.convert( texture.format ),
+						glType = utils.convert( texture.type ),
+						glInternalFormat = getInternalFormat( glFormat, glType );
 
-				} else {
-
-					mipmaps = texture.mipmaps;
+					setTextureParameters( 34067, texture, supportsMips );
 
 					for ( var i = 0; i < 6; i ++ ) {
 
-						if ( isDataTexture ) {
+						if ( ! isCompressed ) {
 
-							state.texImage2D( 34069 + i, 0, glInternalFormat, cubeImage[ i ].width, cubeImage[ i ].height, 0, glFormat, glType, cubeImage[ i ].data );
+							if ( isDataTexture ) {
 
-							for ( var j = 0; j < mipmaps.length; j ++ ) {
+								state.texImage2D( 34069 + i, 0, glInternalFormat, cubeImage[ i ].width, cubeImage[ i ].height, 0, glFormat, glType, cubeImage[ i ].data );
 
-								var mipmap = mipmaps[ j ];
-								var mipmapImage = mipmap.image[ i ].image;
+							} else {
 
-								state.texImage2D( 34069 + i, j + 1, glInternalFormat, mipmapImage.width, mipmapImage.height, 0, glFormat, glType, mipmapImage.data );
+								state.texImage2D( 34069 + i, 0, glInternalFormat, glFormat, glType, cubeImage[ i ] );
 
 							}
 
 						} else {
 
-							state.texImage2D( 34069 + i, 0, glInternalFormat, glFormat, glType, cubeImage[ i ] );
+							var mipmap, mipmaps = cubeImage[ i ].mipmaps;
 
-							for ( var j = 0; j < mipmaps.length; j ++ ) {
+							for ( var j = 0, jl = mipmaps.length; j < jl; j ++ ) {
 
-								var mipmap = mipmaps[ j ];
+								mipmap = mipmaps[ j ];
 
-								state.texImage2D( 34069 + i, j + 1, glInternalFormat, glFormat, glType, mipmap.image[ i ] );
+								if ( texture.format !== RGBAFormat && texture.format !== RGBFormat ) {
+
+									if ( state.getCompressedTextureFormats().indexOf( glFormat ) > - 1 ) {
+
+										state.compressedTexImage2D( 34069 + i, j, glInternalFormat, mipmap.width, mipmap.height, 0, mipmap.data );
+
+									} else {
+
+										console.warn( 'THREE.WebGLRenderer: Attempt to load unsupported compressed texture format in .setTextureCube()' );
+
+									}
+
+								} else {
+
+									state.texImage2D( 34069 + i, j, glInternalFormat, mipmap.width, mipmap.height, 0, glFormat, glType, mipmap.data );
+
+								}
 
 							}
 
@@ -21876,25 +21370,33 @@ var Spacekit = (function (exports) {
 
 					}
 
-					textureProperties.__maxMipLevel = mipmaps.length;
+					if ( ! isCompressed ) {
+
+						textureProperties.__maxMipLevel = 0;
+
+					} else {
+
+						textureProperties.__maxMipLevel = mipmaps.length - 1;
+
+					}
+
+					if ( textureNeedsGenerateMipmaps( texture, supportsMips ) ) {
+
+						// We assume images for cube map have the same size.
+						generateMipmap( 34067, texture, image.width, image.height );
+
+					}
+
+					textureProperties.__version = texture.version;
+
+					if ( texture.onUpdate ) texture.onUpdate( texture );
+
+				} else {
+
+					state.activeTexture( 33984 + slot );
+					state.bindTexture( 34067, textureProperties.__webglTexture );
 
 				}
-
-				if ( textureNeedsGenerateMipmaps( texture, supportsMips ) ) {
-
-					// We assume images for cube map have the same size.
-					generateMipmap( 34067, texture, image.width, image.height );
-
-				}
-
-				textureProperties.__version = texture.version;
-
-				if ( texture.onUpdate ) texture.onUpdate( texture );
-
-			} else {
-
-				state.activeTexture( 33984 + slot );
-				state.bindTexture( 34067, textureProperties.__webglTexture );
 
 			}
 
@@ -21907,37 +21409,23 @@ var Spacekit = (function (exports) {
 
 		}
 
-		var wrappingToGL = {
-			[ RepeatWrapping ]: 10497,
-			[ ClampToEdgeWrapping ]: 33071,
-			[ MirroredRepeatWrapping ]: 33648
-		};
-
-		var filterToGL = {
-			[ NearestFilter ]: 9728,
-			[ NearestMipmapNearestFilter ]: 9984,
-			[ NearestMipmapLinearFilter ]: 9986,
-
-			[ LinearFilter ]: 9729,
-			[ LinearMipmapNearestFilter ]: 9985,
-			[ LinearMipmapLinearFilter ]: 9987
-		};
-
 		function setTextureParameters( textureType, texture, supportsMips ) {
+
+			var extension;
 
 			if ( supportsMips ) {
 
-				_gl.texParameteri( textureType, 10242, wrappingToGL[ texture.wrapS ] );
-				_gl.texParameteri( textureType, 10243, wrappingToGL[ texture.wrapT ] );
+				_gl.texParameteri( textureType, 10242, utils.convert( texture.wrapS ) );
+				_gl.texParameteri( textureType, 10243, utils.convert( texture.wrapT ) );
 
 				if ( textureType === 32879 || textureType === 35866 ) {
 
-					_gl.texParameteri( textureType, 32882, wrappingToGL[ texture.wrapR ] );
+					_gl.texParameteri( textureType, 32882, utils.convert( texture.wrapR ) );
 
 				}
 
-				_gl.texParameteri( textureType, 10240, filterToGL[ texture.magFilter ] );
-				_gl.texParameteri( textureType, 10241, filterToGL[ texture.minFilter ] );
+				_gl.texParameteri( textureType, 10240, utils.convert( texture.magFilter ) );
+				_gl.texParameteri( textureType, 10241, utils.convert( texture.minFilter ) );
 
 			} else {
 
@@ -21967,12 +21455,12 @@ var Spacekit = (function (exports) {
 
 			}
 
-			var extension = extensions.get( 'EXT_texture_filter_anisotropic' );
+			extension = extensions.get( 'EXT_texture_filter_anisotropic' );
 
 			if ( extension ) {
 
 				if ( texture.type === FloatType && extensions.get( 'OES_texture_float_linear' ) === null ) return;
-				if ( texture.type === HalfFloatType && ( isWebGL2 || extensions.get( 'OES_texture_half_float_linear' ) ) === null ) return;
+				if ( texture.type === HalfFloatType && ( capabilities.isWebGL2 || extensions.get( 'OES_texture_half_float_linear' ) ) === null ) return;
 
 				if ( texture.anisotropy > 1 || properties.get( texture ).__currentAnisotropy ) {
 
@@ -22018,12 +21506,12 @@ var Spacekit = (function (exports) {
 			_gl.pixelStorei( 3317, texture.unpackAlignment );
 
 			var needsPowerOfTwo = textureNeedsPowerOfTwo( texture ) && isPowerOfTwo( texture.image ) === false;
-			var image = resizeImage( texture.image, needsPowerOfTwo, false, maxTextureSize );
+			var image = resizeImage( texture.image, needsPowerOfTwo, false, capabilities.maxTextureSize );
 
-			var supportsMips = isPowerOfTwo( image ) || isWebGL2,
+			var supportsMips = isPowerOfTwo( image ) || capabilities.isWebGL2,
 				glFormat = utils.convert( texture.format ),
 				glType = utils.convert( texture.type ),
-				glInternalFormat = getInternalFormat( texture.internalFormat, glFormat, glType );
+				glInternalFormat = getInternalFormat( glFormat, glType );
 
 			setTextureParameters( textureType, texture, supportsMips );
 
@@ -22035,37 +21523,17 @@ var Spacekit = (function (exports) {
 
 				glInternalFormat = 6402;
 
-				if ( isWebGL2 ) {
+				if ( texture.type === FloatType ) {
 
-					if ( texture.type === FloatType ) {
+					if ( ! capabilities.isWebGL2 ) throw new Error( 'Float Depth Texture only supported in WebGL2.0' );
+					glInternalFormat = 36012;
 
-						glInternalFormat = 36012;
+				} else if ( capabilities.isWebGL2 ) {
 
-					} else if ( texture.type === UnsignedIntType ) {
-
-						glInternalFormat = 33190;
-
-					} else if ( texture.type === UnsignedInt248Type ) {
-
-						glInternalFormat = 35056;
-
-					} else {
-
-						glInternalFormat = 33189; // WebGL2 requires sized internalformat for glTexImage2D
-
-					}
-
-				} else {
-
-					if ( texture.type === FloatType ) {
-
-						console.error( 'WebGLRenderer: Floating point depth texture requires WebGL2.' );
-
-					}
+					// WebGL 2.0 requires signed internalformat for glTexImage2D
+					glInternalFormat = 33189;
 
 				}
-
-				// validation checks for WebGL 1
 
 				if ( texture.format === DepthFormat && glInternalFormat === 6402 ) {
 
@@ -22083,10 +21551,10 @@ var Spacekit = (function (exports) {
 
 				}
 
-				if ( texture.format === DepthStencilFormat && glInternalFormat === 6402 ) {
+				// Depth stencil textures need the DEPTH_STENCIL internal format
+				// (https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/)
+				if ( texture.format === DepthStencilFormat ) {
 
-					// Depth stencil textures need the DEPTH_STENCIL internal format
-					// (https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/)
 					glInternalFormat = 34041;
 
 					// The error INVALID_OPERATION is generated by texImage2D if format and internalformat are
@@ -22102,8 +21570,6 @@ var Spacekit = (function (exports) {
 					}
 
 				}
-
-				//
 
 				state.texImage2D( 3553, 0, glInternalFormat, image.width, image.height, 0, glFormat, glType, null );
 
@@ -22140,7 +21606,7 @@ var Spacekit = (function (exports) {
 
 					if ( texture.format !== RGBAFormat && texture.format !== RGBFormat ) {
 
-						if ( glFormat !== null ) {
+						if ( state.getCompressedTextureFormats().indexOf( glFormat ) > - 1 ) {
 
 							state.compressedTexImage2D( 3553, i, glInternalFormat, mipmap.width, mipmap.height, 0, mipmap.data );
 
@@ -22201,7 +21667,7 @@ var Spacekit = (function (exports) {
 
 			if ( textureNeedsGenerateMipmaps( texture, supportsMips ) ) {
 
-				generateMipmap( textureType, texture, image.width, image.height );
+				generateMipmap( 3553, texture, image.width, image.height );
 
 			}
 
@@ -22218,7 +21684,7 @@ var Spacekit = (function (exports) {
 
 			var glFormat = utils.convert( renderTarget.texture.format );
 			var glType = utils.convert( renderTarget.texture.type );
-			var glInternalFormat = getInternalFormat( renderTarget.texture.internalFormat, glFormat, glType );
+			var glInternalFormat = getInternalFormat( glFormat, glType );
 			state.texImage2D( textureTarget, 0, glInternalFormat, renderTarget.width, renderTarget.height, 0, glFormat, glType, null );
 			_gl.bindFramebuffer( 36160, framebuffer );
 			_gl.framebufferTexture2D( 36160, attachment, textureTarget, properties.get( renderTarget.texture ).__webglTexture, 0 );
@@ -22233,33 +21699,15 @@ var Spacekit = (function (exports) {
 
 			if ( renderTarget.depthBuffer && ! renderTarget.stencilBuffer ) {
 
-				var glInternalFormat = 33189;
-
 				if ( isMultisample ) {
-
-					var depthTexture = renderTarget.depthTexture;
-
-					if ( depthTexture && depthTexture.isDepthTexture ) {
-
-						if ( depthTexture.type === FloatType ) {
-
-							glInternalFormat = 36012;
-
-						} else if ( depthTexture.type === UnsignedIntType ) {
-
-							glInternalFormat = 33190;
-
-						}
-
-					}
 
 					var samples = getRenderTargetSamples( renderTarget );
 
-					_gl.renderbufferStorageMultisample( 36161, samples, glInternalFormat, renderTarget.width, renderTarget.height );
+					_gl.renderbufferStorageMultisample( 36161, samples, 33189, renderTarget.width, renderTarget.height );
 
 				} else {
 
-					_gl.renderbufferStorage( 36161, glInternalFormat, renderTarget.width, renderTarget.height );
+					_gl.renderbufferStorage( 36161, 33189, renderTarget.width, renderTarget.height );
 
 				}
 
@@ -22286,7 +21734,7 @@ var Spacekit = (function (exports) {
 
 				var glFormat = utils.convert( renderTarget.texture.format );
 				var glType = utils.convert( renderTarget.texture.type );
-				var glInternalFormat = getInternalFormat( renderTarget.texture.internalFormat, glFormat, glType );
+				var glInternalFormat = getInternalFormat( glFormat, glType );
 
 				if ( isMultisample ) {
 
@@ -22309,7 +21757,7 @@ var Spacekit = (function (exports) {
 		// Setup resources for a Depth Texture for a FBO (needs an extension)
 		function setupDepthTexture( framebuffer, renderTarget ) {
 
-			var isCube = ( renderTarget && renderTarget.isWebGLCubeRenderTarget );
+			var isCube = ( renderTarget && renderTarget.isWebGLRenderTargetCube );
 			if ( isCube ) throw new Error( 'Depth Texture with cube render targets is not supported' );
 
 			_gl.bindFramebuffer( 36160, framebuffer );
@@ -22356,7 +21804,7 @@ var Spacekit = (function (exports) {
 
 			var renderTargetProperties = properties.get( renderTarget );
 
-			var isCube = ( renderTarget.isWebGLCubeRenderTarget === true );
+			var isCube = ( renderTarget.isWebGLRenderTargetCube === true );
 
 			if ( renderTarget.depthTexture ) {
 
@@ -22374,7 +21822,7 @@ var Spacekit = (function (exports) {
 
 						_gl.bindFramebuffer( 36160, renderTargetProperties.__webglFramebuffer[ i ] );
 						renderTargetProperties.__webglDepthbuffer[ i ] = _gl.createRenderbuffer();
-						setupRenderBufferStorage( renderTargetProperties.__webglDepthbuffer[ i ], renderTarget, false );
+						setupRenderBufferStorage( renderTargetProperties.__webglDepthbuffer[ i ], renderTarget );
 
 					}
 
@@ -22382,7 +21830,7 @@ var Spacekit = (function (exports) {
 
 					_gl.bindFramebuffer( 36160, renderTargetProperties.__webglFramebuffer );
 					renderTargetProperties.__webglDepthbuffer = _gl.createRenderbuffer();
-					setupRenderBufferStorage( renderTargetProperties.__webglDepthbuffer, renderTarget, false );
+					setupRenderBufferStorage( renderTargetProperties.__webglDepthbuffer, renderTarget );
 
 				}
 
@@ -22404,19 +21852,9 @@ var Spacekit = (function (exports) {
 
 			info.memory.textures ++;
 
-			var isCube = ( renderTarget.isWebGLCubeRenderTarget === true );
+			var isCube = ( renderTarget.isWebGLRenderTargetCube === true );
 			var isMultisample = ( renderTarget.isWebGLMultisampleRenderTarget === true );
-			var supportsMips = isPowerOfTwo( renderTarget ) || isWebGL2;
-
-			// Handles WebGL2 RGBFormat fallback - #18858
-
-			if ( isWebGL2 && renderTarget.texture.format === RGBFormat && ( renderTarget.texture.type === FloatType || renderTarget.texture.type === HalfFloatType ) ) {
-
-				renderTarget.texture.format = RGBAFormat;
-
-				console.warn( 'THREE.WebGLRenderer: Rendering to textures with RGB format is not supported. Using RGBA format instead.' );
-
-			}
+			var supportsMips = isPowerOfTwo( renderTarget ) || capabilities.isWebGL2;
 
 			// Setup framebuffer
 
@@ -22436,16 +21874,15 @@ var Spacekit = (function (exports) {
 
 				if ( isMultisample ) {
 
-					if ( isWebGL2 ) {
+					if ( capabilities.isWebGL2 ) {
 
 						renderTargetProperties.__webglMultisampledFramebuffer = _gl.createFramebuffer();
 						renderTargetProperties.__webglColorRenderbuffer = _gl.createRenderbuffer();
 
 						_gl.bindRenderbuffer( 36161, renderTargetProperties.__webglColorRenderbuffer );
-
 						var glFormat = utils.convert( renderTarget.texture.format );
 						var glType = utils.convert( renderTarget.texture.type );
-						var glInternalFormat = getInternalFormat( renderTarget.texture.internalFormat, glFormat, glType );
+						var glInternalFormat = getInternalFormat( glFormat, glType );
 						var samples = getRenderTargetSamples( renderTarget );
 						_gl.renderbufferStorageMultisample( 36161, samples, glInternalFormat, renderTarget.width, renderTarget.height );
 
@@ -22523,11 +21960,11 @@ var Spacekit = (function (exports) {
 		function updateRenderTargetMipmap( renderTarget ) {
 
 			var texture = renderTarget.texture;
-			var supportsMips = isPowerOfTwo( renderTarget ) || isWebGL2;
+			var supportsMips = isPowerOfTwo( renderTarget ) || capabilities.isWebGL2;
 
 			if ( textureNeedsGenerateMipmaps( texture, supportsMips ) ) {
 
-				var target = renderTarget.isWebGLCubeRenderTarget ? 34067 : 3553;
+				var target = renderTarget.isWebGLRenderTargetCube ? 34067 : 3553;
 				var webglTexture = properties.get( texture ).__webglTexture;
 
 				state.bindTexture( target, webglTexture );
@@ -22542,7 +21979,7 @@ var Spacekit = (function (exports) {
 
 			if ( renderTarget.isWebGLMultisampleRenderTarget ) {
 
-				if ( isWebGL2 ) {
+				if ( capabilities.isWebGL2 ) {
 
 					var renderTargetProperties = properties.get( renderTarget );
 
@@ -22558,8 +21995,6 @@ var Spacekit = (function (exports) {
 
 					_gl.blitFramebuffer( 0, 0, width, height, 0, 0, width, height, mask, 9728 );
 
-					_gl.bindFramebuffer( 36160, renderTargetProperties.__webglMultisampledFramebuffer ); // see #18905
-
 				} else {
 
 					console.warn( 'THREE.WebGLRenderer: WebGLMultisampleRenderTarget can only be used with WebGL2.' );
@@ -22572,20 +22007,21 @@ var Spacekit = (function (exports) {
 
 		function getRenderTargetSamples( renderTarget ) {
 
-			return ( isWebGL2 && renderTarget.isWebGLMultisampleRenderTarget ) ?
-				Math.min( maxSamples, renderTarget.samples ) : 0;
+			return ( capabilities.isWebGL2 && renderTarget.isWebGLMultisampleRenderTarget ) ?
+				Math.min( capabilities.maxSamples, renderTarget.samples ) : 0;
 
 		}
 
 		function updateVideoTexture( texture ) {
 
+			var id = texture.id;
 			var frame = info.render.frame;
 
 			// Check the last frame we updated the VideoTexture
 
-			if ( _videoTextures.get( texture ) !== frame ) {
+			if ( _videoTextures[ id ] !== frame ) {
 
-				_videoTextures.set( texture, frame );
+				_videoTextures[ id ] = frame;
 				texture.update();
 
 			}
@@ -22618,7 +22054,7 @@ var Spacekit = (function (exports) {
 
 		function safeSetTextureCube( texture, slot ) {
 
-			if ( texture && texture.isWebGLCubeRenderTarget ) {
+			if ( texture && texture.isWebGLRenderTargetCube ) {
 
 				if ( warnedTextureCube === false ) {
 
@@ -22631,7 +22067,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			// currently relying on the fact that WebGLCubeRenderTarget.texture is a Texture and NOT a CubeTexture
+			// currently relying on the fact that WebGLRenderTargetCube.texture is a Texture and NOT a CubeTexture
 			// TODO: unify these code paths
 			if ( ( texture && texture.isCubeTexture ) ||
 				( Array.isArray( texture.image ) && texture.image.length === 6 ) ) {
@@ -22643,7 +22079,7 @@ var Spacekit = (function (exports) {
 
 			} else {
 
-				// assumed: texture property of THREE.WebGLCubeRenderTarget
+				// assumed: texture property of THREE.WebGLRenderTargetCube
 				setTextureCubeDynamic( texture, slot );
 
 			}
@@ -22675,11 +22111,21 @@ var Spacekit = (function (exports) {
 
 	function WebGLUtils( gl, extensions, capabilities ) {
 
-		var isWebGL2 = capabilities.isWebGL2;
-
 		function convert( p ) {
 
 			var extension;
+
+			if ( p === RepeatWrapping ) return 10497;
+			if ( p === ClampToEdgeWrapping ) return 33071;
+			if ( p === MirroredRepeatWrapping ) return 33648;
+
+			if ( p === NearestFilter ) return 9728;
+			if ( p === NearestMipmapNearestFilter ) return 9984;
+			if ( p === NearestMipmapLinearFilter ) return 9986;
+
+			if ( p === LinearFilter ) return 9729;
+			if ( p === LinearMipmapNearestFilter ) return 9985;
+			if ( p === LinearMipmapLinearFilter ) return 9987;
 
 			if ( p === UnsignedByteType ) return 5121;
 			if ( p === UnsignedShort4444Type ) return 32819;
@@ -22695,19 +22141,11 @@ var Spacekit = (function (exports) {
 
 			if ( p === HalfFloatType ) {
 
-				if ( isWebGL2 ) return 5131;
+				if ( capabilities.isWebGL2 ) return 5131;
 
 				extension = extensions.get( 'OES_texture_half_float' );
 
-				if ( extension !== null ) {
-
-					return extension.HALF_FLOAT_OES;
-
-				} else {
-
-					return null;
-
-				}
+				if ( extension !== null ) return extension.HALF_FLOAT_OES;
 
 			}
 
@@ -22720,13 +22158,22 @@ var Spacekit = (function (exports) {
 			if ( p === DepthStencilFormat ) return 34041;
 			if ( p === RedFormat ) return 6403;
 
-			// WebGL2 formats.
+			if ( p === AddEquation ) return 32774;
+			if ( p === SubtractEquation ) return 32778;
+			if ( p === ReverseSubtractEquation ) return 32779;
 
-			if ( p === RedIntegerFormat ) return 36244;
-			if ( p === RGFormat ) return 33319;
-			if ( p === RGIntegerFormat ) return 33320;
-			if ( p === RGBIntegerFormat ) return 36248;
-			if ( p === RGBAIntegerFormat ) return 36249;
+			if ( p === ZeroFactor ) return 0;
+			if ( p === OneFactor ) return 1;
+			if ( p === SrcColorFactor ) return 768;
+			if ( p === OneMinusSrcColorFactor ) return 769;
+			if ( p === SrcAlphaFactor ) return 770;
+			if ( p === OneMinusSrcAlphaFactor ) return 771;
+			if ( p === DstAlphaFactor ) return 772;
+			if ( p === OneMinusDstAlphaFactor ) return 773;
+
+			if ( p === DstColorFactor ) return 774;
+			if ( p === OneMinusDstColorFactor ) return 775;
+			if ( p === SrcAlphaSaturateFactor ) return 776;
 
 			if ( p === RGB_S3TC_DXT1_Format || p === RGBA_S3TC_DXT1_Format ||
 				p === RGBA_S3TC_DXT3_Format || p === RGBA_S3TC_DXT5_Format ) {
@@ -22739,10 +22186,6 @@ var Spacekit = (function (exports) {
 					if ( p === RGBA_S3TC_DXT1_Format ) return extension.COMPRESSED_RGBA_S3TC_DXT1_EXT;
 					if ( p === RGBA_S3TC_DXT3_Format ) return extension.COMPRESSED_RGBA_S3TC_DXT3_EXT;
 					if ( p === RGBA_S3TC_DXT5_Format ) return extension.COMPRESSED_RGBA_S3TC_DXT5_EXT;
-
-				} else {
-
-					return null;
 
 				}
 
@@ -22760,10 +22203,6 @@ var Spacekit = (function (exports) {
 					if ( p === RGBA_PVRTC_4BPPV1_Format ) return extension.COMPRESSED_RGBA_PVRTC_4BPPV1_IMG;
 					if ( p === RGBA_PVRTC_2BPPV1_Format ) return extension.COMPRESSED_RGBA_PVRTC_2BPPV1_IMG;
 
-				} else {
-
-					return null;
-
 				}
 
 			}
@@ -22772,28 +22211,7 @@ var Spacekit = (function (exports) {
 
 				extension = extensions.get( 'WEBGL_compressed_texture_etc1' );
 
-				if ( extension !== null ) {
-
-					return extension.COMPRESSED_RGB_ETC1_WEBGL;
-
-				} else {
-
-					return null;
-
-				}
-
-			}
-
-			if ( p === RGB_ETC2_Format || p === RGBA_ETC2_EAC_Format ) {
-
-				extension = extensions.get( 'WEBGL_compressed_texture_etc' );
-
-				if ( extension !== null ) {
-
-					if ( p === RGB_ETC2_Format ) return extension.COMPRESSED_RGB8_ETC2;
-					if ( p === RGBA_ETC2_EAC_Format ) return extension.COMPRESSED_RGBA8_ETC2_EAC;
-
-				}
+				if ( extension !== null ) return extension.COMPRESSED_RGB_ETC1_WEBGL;
 
 			}
 
@@ -22801,42 +22219,33 @@ var Spacekit = (function (exports) {
 				p === RGBA_ASTC_6x5_Format || p === RGBA_ASTC_6x6_Format || p === RGBA_ASTC_8x5_Format ||
 				p === RGBA_ASTC_8x6_Format || p === RGBA_ASTC_8x8_Format || p === RGBA_ASTC_10x5_Format ||
 				p === RGBA_ASTC_10x6_Format || p === RGBA_ASTC_10x8_Format || p === RGBA_ASTC_10x10_Format ||
-				p === RGBA_ASTC_12x10_Format || p === RGBA_ASTC_12x12_Format ||
-				p === SRGB8_ALPHA8_ASTC_4x4_Format || p === SRGB8_ALPHA8_ASTC_5x4_Format || p === SRGB8_ALPHA8_ASTC_5x5_Format ||
-				p === SRGB8_ALPHA8_ASTC_6x5_Format || p === SRGB8_ALPHA8_ASTC_6x6_Format || p === SRGB8_ALPHA8_ASTC_8x5_Format ||
-				p === SRGB8_ALPHA8_ASTC_8x6_Format || p === SRGB8_ALPHA8_ASTC_8x8_Format || p === SRGB8_ALPHA8_ASTC_10x5_Format ||
-				p === SRGB8_ALPHA8_ASTC_10x6_Format || p === SRGB8_ALPHA8_ASTC_10x8_Format || p === SRGB8_ALPHA8_ASTC_10x10_Format ||
-				p === SRGB8_ALPHA8_ASTC_12x10_Format || p === SRGB8_ALPHA8_ASTC_12x12_Format ) {
+				p === RGBA_ASTC_12x10_Format || p === RGBA_ASTC_12x12_Format ) {
 
 				extension = extensions.get( 'WEBGL_compressed_texture_astc' );
 
 				if ( extension !== null ) {
 
-					// TODO Complete?
-
 					return p;
-
-				} else {
-
-					return null;
 
 				}
 
 			}
 
-			if ( p === RGBA_BPTC_Format ) {
+			if ( p === MinEquation || p === MaxEquation ) {
 
-				extension = extensions.get( 'EXT_texture_compression_bptc' );
+				if ( capabilities.isWebGL2 ) {
+
+					if ( p === MinEquation ) return 32775;
+					if ( p === MaxEquation ) return 32776;
+
+				}
+
+				extension = extensions.get( 'EXT_blend_minmax' );
 
 				if ( extension !== null ) {
 
-					// TODO Complete?
-
-					return p;
-
-				} else {
-
-					return null;
+					if ( p === MinEquation ) return extension.MIN_EXT;
+					if ( p === MaxEquation ) return extension.MAX_EXT;
 
 				}
 
@@ -22844,47 +22253,21 @@ var Spacekit = (function (exports) {
 
 			if ( p === UnsignedInt248Type ) {
 
-				if ( isWebGL2 ) return 34042;
+				if ( capabilities.isWebGL2 ) return 34042;
 
 				extension = extensions.get( 'WEBGL_depth_texture' );
 
-				if ( extension !== null ) {
-
-					return extension.UNSIGNED_INT_24_8_WEBGL;
-
-				} else {
-
-					return null;
-
-				}
+				if ( extension !== null ) return extension.UNSIGNED_INT_24_8_WEBGL;
 
 			}
+
+			return 0;
 
 		}
 
 		return { convert: convert };
 
 	}
-
-	/**
-	 * @author mrdoob / http://mrdoob.com/
-	 */
-
-	function ArrayCamera( array ) {
-
-		PerspectiveCamera.call( this );
-
-		this.cameras = array || [];
-
-	}
-
-	ArrayCamera.prototype = Object.assign( Object.create( PerspectiveCamera.prototype ), {
-
-		constructor: ArrayCamera,
-
-		isArrayCamera: true
-
-	} );
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -22907,141 +22290,501 @@ var Spacekit = (function (exports) {
 	} );
 
 	/**
-	 * @author Mugen87 / https://github.com/Mugen87
+	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-	function WebXRController() {
+	function ArrayCamera( array ) {
 
-		this._targetRay = null;
-		this._grip = null;
+		PerspectiveCamera.call( this );
+
+		this.cameras = array || [];
 
 	}
 
-	Object.assign( WebXRController.prototype, {
+	ArrayCamera.prototype = Object.assign( Object.create( PerspectiveCamera.prototype ), {
 
-		constructor: WebXRController,
+		constructor: ArrayCamera,
 
-		getTargetRaySpace: function () {
+		isArrayCamera: true
 
-			if ( this._targetRay === null ) {
+	} );
 
-				this._targetRay = new Group();
-				this._targetRay.matrixAutoUpdate = false;
-				this._targetRay.visible = false;
+	/**
+	 * @author jsantell / https://www.jsantell.com/
+	 * @author mrdoob / http://mrdoob.com/
+	 */
 
-			}
+	var cameraLPos = new Vector3();
+	var cameraRPos = new Vector3();
 
-			return this._targetRay;
+	/**
+	 * Assumes 2 cameras that are parallel and share an X-axis, and that
+	 * the cameras' projection and world matrices have already been set.
+	 * And that near and far planes are identical for both cameras.
+	 * Visualization of this technique: https://computergraphics.stackexchange.com/a/4765
+	 */
+	function setProjectionFromUnion( camera, cameraL, cameraR ) {
 
-		},
+		cameraLPos.setFromMatrixPosition( cameraL.matrixWorld );
+		cameraRPos.setFromMatrixPosition( cameraR.matrixWorld );
 
-		getGripSpace: function () {
+		var ipd = cameraLPos.distanceTo( cameraRPos );
 
-			if ( this._grip === null ) {
+		var projL = cameraL.projectionMatrix.elements;
+		var projR = cameraR.projectionMatrix.elements;
 
-				this._grip = new Group();
-				this._grip.matrixAutoUpdate = false;
-				this._grip.visible = false;
+		// VR systems will have identical far and near planes, and
+		// most likely identical top and bottom frustum extents.
+		// Use the left camera for these values.
+		var near = projL[ 14 ] / ( projL[ 10 ] - 1 );
+		var far = projL[ 14 ] / ( projL[ 10 ] + 1 );
+		var topFov = ( projL[ 9 ] + 1 ) / projL[ 5 ];
+		var bottomFov = ( projL[ 9 ] - 1 ) / projL[ 5 ];
 
-			}
+		var leftFov = ( projL[ 8 ] - 1 ) / projL[ 0 ];
+		var rightFov = ( projR[ 8 ] + 1 ) / projR[ 0 ];
+		var left = near * leftFov;
+		var right = near * rightFov;
 
-			return this._grip;
+		// Calculate the new camera's position offset from the
+		// left camera. xOffset should be roughly half `ipd`.
+		var zOffset = ipd / ( - leftFov + rightFov );
+		var xOffset = zOffset * - leftFov;
 
-		},
+		// TODO: Better way to apply this offset?
+		cameraL.matrixWorld.decompose( camera.position, camera.quaternion, camera.scale );
+		camera.translateX( xOffset );
+		camera.translateZ( zOffset );
+		camera.matrixWorld.compose( camera.position, camera.quaternion, camera.scale );
+		camera.matrixWorldInverse.getInverse( camera.matrixWorld );
 
-		dispatchEvent: function ( event ) {
+		// Find the union of the frustum values of the cameras and scale
+		// the values so that the near plane's position does not change in world space,
+		// although must now be relative to the new union camera.
+		var near2 = near + zOffset;
+		var far2 = far + zOffset;
+		var left2 = left - xOffset;
+		var right2 = right + ( ipd - xOffset );
+		var top2 = topFov * far / far2 * near2;
+		var bottom2 = bottomFov * far / far2 * near2;
 
-			if ( this._targetRay !== null ) {
+		camera.projectionMatrix.makePerspective( left2, right2, top2, bottom2, near2, far2 );
 
-				this._targetRay.dispatchEvent( event );
+	}
 
-			}
+	/**
+	 * @author mrdoob / http://mrdoob.com/
+	 */
 
-			if ( this._grip !== null ) {
+	function WebVRManager( renderer ) {
 
-				this._grip.dispatchEvent( event );
+		var renderWidth, renderHeight;
+		var scope = this;
 
-			}
+		var device = null;
+		var frameData = null;
 
-			return this;
+		var poseTarget = null;
 
-		},
+		var controllers = [];
+		var standingMatrix = new Matrix4();
+		var standingMatrixInverse = new Matrix4();
 
-		disconnect: function ( inputSource ) {
+		var framebufferScaleFactor = 1.0;
 
-			this.dispatchEvent( { type: 'disconnected', data: inputSource } );
+		var referenceSpaceType = 'local-floor';
 
-			if ( this._targetRay !== null ) {
+		if ( typeof window !== 'undefined' && 'VRFrameData' in window ) {
 
-				this._targetRay.visible = false;
-
-			}
-
-			if ( this._grip !== null ) {
-
-				this._grip.visible = false;
-
-			}
-
-			return this;
-
-		},
-
-		update: function ( inputSource, frame, referenceSpace ) {
-
-			var inputPose = null;
-			var gripPose = null;
-
-			var targetRay = this._targetRay;
-			var grip = this._grip;
-
-			if ( inputSource ) {
-
-				if ( targetRay !== null ) {
-
-					inputPose = frame.getPose( inputSource.targetRaySpace, referenceSpace );
-
-					if ( inputPose !== null ) {
-
-						targetRay.matrix.fromArray( inputPose.transform.matrix );
-						targetRay.matrix.decompose( targetRay.position, targetRay.rotation, targetRay.scale );
-
-					}
-
-				}
-
-				if ( grip !== null && inputSource.gripSpace ) {
-
-					gripPose = frame.getPose( inputSource.gripSpace, referenceSpace );
-
-					if ( gripPose !== null ) {
-
-						grip.matrix.fromArray( gripPose.transform.matrix );
-						grip.matrix.decompose( grip.position, grip.rotation, grip.scale );
-
-					}
-
-				}
-
-			}
-
-			if ( targetRay !== null ) {
-
-				targetRay.visible = ( inputPose !== null );
-
-			}
-
-			if ( grip !== null ) {
-
-				grip.visible = ( gripPose !== null );
-
-			}
-
-			return this;
+			frameData = new window.VRFrameData();
+			window.addEventListener( 'vrdisplaypresentchange', onVRDisplayPresentChange, false );
 
 		}
 
-	} );
+		var matrixWorldInverse = new Matrix4();
+		var tempQuaternion = new Quaternion();
+		var tempPosition = new Vector3();
+
+		var cameraL = new PerspectiveCamera();
+		cameraL.viewport = new Vector4();
+		cameraL.layers.enable( 1 );
+
+		var cameraR = new PerspectiveCamera();
+		cameraR.viewport = new Vector4();
+		cameraR.layers.enable( 2 );
+
+		var cameraVR = new ArrayCamera( [ cameraL, cameraR ] );
+		cameraVR.layers.enable( 1 );
+		cameraVR.layers.enable( 2 );
+
+		//
+
+		function isPresenting() {
+
+			return device !== null && device.isPresenting === true;
+
+		}
+
+		var currentSize = new Vector2(), currentPixelRatio;
+
+		function onVRDisplayPresentChange() {
+
+			if ( isPresenting() ) {
+
+				var eyeParameters = device.getEyeParameters( 'left' );
+				renderWidth = 2 * eyeParameters.renderWidth * framebufferScaleFactor;
+				renderHeight = eyeParameters.renderHeight * framebufferScaleFactor;
+
+				currentPixelRatio = renderer.getPixelRatio();
+				renderer.getSize( currentSize );
+
+				renderer.setDrawingBufferSize( renderWidth, renderHeight, 1 );
+
+				cameraL.viewport.set( 0, 0, renderWidth / 2, renderHeight );
+				cameraR.viewport.set( renderWidth / 2, 0, renderWidth / 2, renderHeight );
+
+				animation.start();
+
+				scope.dispatchEvent( { type: 'sessionstart' } );
+
+			} else {
+
+				if ( scope.enabled ) {
+
+					renderer.setDrawingBufferSize( currentSize.width, currentSize.height, currentPixelRatio );
+
+				}
+
+				animation.stop();
+
+				scope.dispatchEvent( { type: 'sessionend' } );
+
+			}
+
+		}
+
+		//
+
+		var triggers = [];
+
+		function findGamepad( id ) {
+
+			var gamepads = navigator.getGamepads && navigator.getGamepads();
+
+			for ( var i = 0, j = 0, l = gamepads.length; i < l; i ++ ) {
+
+				var gamepad = gamepads[ i ];
+
+				if ( gamepad && ( gamepad.id === 'Daydream Controller' ||
+					gamepad.id === 'Gear VR Controller' || gamepad.id === 'Oculus Go Controller' ||
+					gamepad.id === 'OpenVR Gamepad' || gamepad.id.startsWith( 'Oculus Touch' ) ||
+					gamepad.id.startsWith( 'HTC Vive Focus' ) ||
+					gamepad.id.startsWith( 'Spatial Controller' ) ) ) {
+
+					if ( j === id ) return gamepad;
+
+					j ++;
+
+				}
+
+			}
+
+		}
+
+		function updateControllers() {
+
+			for ( var i = 0; i < controllers.length; i ++ ) {
+
+				var controller = controllers[ i ];
+
+				var gamepad = findGamepad( i );
+
+				if ( gamepad !== undefined && gamepad.pose !== undefined ) {
+
+					if ( gamepad.pose === null ) return;
+
+					// Pose
+
+					var pose = gamepad.pose;
+
+					if ( pose.hasPosition === false ) controller.position.set( 0.2, - 0.6, - 0.05 );
+
+					if ( pose.position !== null ) controller.position.fromArray( pose.position );
+					if ( pose.orientation !== null ) controller.quaternion.fromArray( pose.orientation );
+					controller.matrix.compose( controller.position, controller.quaternion, controller.scale );
+					controller.matrix.premultiply( standingMatrix );
+					controller.matrix.decompose( controller.position, controller.quaternion, controller.scale );
+					controller.matrixWorldNeedsUpdate = true;
+					controller.visible = true;
+
+					// Trigger
+
+					var buttonId = gamepad.id === 'Daydream Controller' ? 0 : 1;
+
+					if ( triggers[ i ] === undefined ) triggers[ i ] = false;
+
+					if ( triggers[ i ] !== gamepad.buttons[ buttonId ].pressed ) {
+
+						triggers[ i ] = gamepad.buttons[ buttonId ].pressed;
+
+						if ( triggers[ i ] === true ) {
+
+							controller.dispatchEvent( { type: 'selectstart' } );
+
+						} else {
+
+							controller.dispatchEvent( { type: 'selectend' } );
+							controller.dispatchEvent( { type: 'select' } );
+
+						}
+
+					}
+
+				} else {
+
+					controller.visible = false;
+
+				}
+
+			}
+
+		}
+
+		function updateViewportFromBounds( viewport, bounds ) {
+
+			if ( bounds !== null && bounds.length === 4 ) {
+
+				viewport.set( bounds[ 0 ] * renderWidth, bounds[ 1 ] * renderHeight, bounds[ 2 ] * renderWidth, bounds[ 3 ] * renderHeight );
+
+			}
+
+		}
+
+		//
+
+		this.enabled = false;
+
+		this.getController = function ( id ) {
+
+			var controller = controllers[ id ];
+
+			if ( controller === undefined ) {
+
+				controller = new Group();
+				controller.matrixAutoUpdate = false;
+				controller.visible = false;
+
+				controllers[ id ] = controller;
+
+			}
+
+			return controller;
+
+		};
+
+		this.getDevice = function () {
+
+			return device;
+
+		};
+
+		this.setDevice = function ( value ) {
+
+			if ( value !== undefined ) device = value;
+
+			animation.setContext( value );
+
+		};
+
+		this.setFramebufferScaleFactor = function ( value ) {
+
+			framebufferScaleFactor = value;
+
+		};
+
+		this.setReferenceSpaceType = function ( value ) {
+
+			referenceSpaceType = value;
+
+		};
+
+		this.setPoseTarget = function ( object ) {
+
+			if ( object !== undefined ) poseTarget = object;
+
+		};
+
+		this.getCamera = function ( camera ) {
+
+			var userHeight = referenceSpaceType === 'local-floor' ? 1.6 : 0;
+
+			if ( isPresenting() === false ) {
+
+				camera.position.set( 0, userHeight, 0 );
+				camera.rotation.set( 0, 0, 0 );
+
+				return camera;
+
+			}
+
+			device.depthNear = camera.near;
+			device.depthFar = camera.far;
+
+			device.getFrameData( frameData );
+
+			//
+
+			if ( referenceSpaceType === 'local-floor' ) {
+
+				var stageParameters = device.stageParameters;
+
+				if ( stageParameters ) {
+
+					standingMatrix.fromArray( stageParameters.sittingToStandingTransform );
+
+				} else {
+
+					standingMatrix.makeTranslation( 0, userHeight, 0 );
+
+				}
+
+			}
+
+
+			var pose = frameData.pose;
+			var poseObject = poseTarget !== null ? poseTarget : camera;
+
+			// We want to manipulate poseObject by its position and quaternion components since users may rely on them.
+			poseObject.matrix.copy( standingMatrix );
+			poseObject.matrix.decompose( poseObject.position, poseObject.quaternion, poseObject.scale );
+
+			if ( pose.orientation !== null ) {
+
+				tempQuaternion.fromArray( pose.orientation );
+				poseObject.quaternion.multiply( tempQuaternion );
+
+			}
+
+			if ( pose.position !== null ) {
+
+				tempQuaternion.setFromRotationMatrix( standingMatrix );
+				tempPosition.fromArray( pose.position );
+				tempPosition.applyQuaternion( tempQuaternion );
+				poseObject.position.add( tempPosition );
+
+			}
+
+			poseObject.updateMatrixWorld();
+
+			//
+
+			cameraL.near = camera.near;
+			cameraR.near = camera.near;
+
+			cameraL.far = camera.far;
+			cameraR.far = camera.far;
+
+			cameraL.matrixWorldInverse.fromArray( frameData.leftViewMatrix );
+			cameraR.matrixWorldInverse.fromArray( frameData.rightViewMatrix );
+
+			// TODO (mrdoob) Double check this code
+
+			standingMatrixInverse.getInverse( standingMatrix );
+
+			if ( referenceSpaceType === 'local-floor' ) {
+
+				cameraL.matrixWorldInverse.multiply( standingMatrixInverse );
+				cameraR.matrixWorldInverse.multiply( standingMatrixInverse );
+
+			}
+
+			var parent = poseObject.parent;
+
+			if ( parent !== null ) {
+
+				matrixWorldInverse.getInverse( parent.matrixWorld );
+
+				cameraL.matrixWorldInverse.multiply( matrixWorldInverse );
+				cameraR.matrixWorldInverse.multiply( matrixWorldInverse );
+
+			}
+
+			// envMap and Mirror needs camera.matrixWorld
+
+			cameraL.matrixWorld.getInverse( cameraL.matrixWorldInverse );
+			cameraR.matrixWorld.getInverse( cameraR.matrixWorldInverse );
+
+			cameraL.projectionMatrix.fromArray( frameData.leftProjectionMatrix );
+			cameraR.projectionMatrix.fromArray( frameData.rightProjectionMatrix );
+
+			setProjectionFromUnion( cameraVR, cameraL, cameraR );
+
+			//
+
+			var layers = device.getLayers();
+
+			if ( layers.length ) {
+
+				var layer = layers[ 0 ];
+
+				updateViewportFromBounds( cameraL.viewport, layer.leftBounds );
+				updateViewportFromBounds( cameraR.viewport, layer.rightBounds );
+
+			}
+
+			updateControllers();
+
+			return cameraVR;
+
+		};
+
+		this.getStandingMatrix = function () {
+
+			return standingMatrix;
+
+		};
+
+		this.isPresenting = isPresenting;
+
+		// Animation Loop
+
+		var animation = new WebGLAnimation();
+
+		this.setAnimationLoop = function ( callback ) {
+
+			animation.setAnimationLoop( callback );
+
+			if ( isPresenting() ) animation.start();
+
+		};
+
+		this.submitFrame = function () {
+
+			if ( isPresenting() ) device.submitFrame();
+
+		};
+
+		this.dispose = function () {
+
+			if ( typeof window !== 'undefined' ) {
+
+				window.removeEventListener( 'vrdisplaypresentchange', onVRDisplayPresentChange );
+
+			}
+
+		};
+
+		// DEPRECATED
+
+		this.setFrameOfReferenceType = function () {
+
+			console.warn( 'THREE.WebVRManager: setFrameOfReferenceType() has been deprecated.' );
+
+		};
+
+	}
+
+	Object.assign( WebVRManager.prototype, EventDispatcher.prototype );
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -23053,15 +22796,19 @@ var Spacekit = (function (exports) {
 
 		var session = null;
 
-		var framebufferScaleFactor = 1.0;
-
 		var referenceSpace = null;
 		var referenceSpaceType = 'local-floor';
 
 		var pose = null;
 
 		var controllers = [];
-		var inputSourcesMap = new Map();
+		var inputSources = [];
+
+		function isPresenting() {
+
+			return session !== null && referenceSpace !== null;
+
+		}
 
 		//
 
@@ -23073,48 +22820,29 @@ var Spacekit = (function (exports) {
 		cameraR.layers.enable( 2 );
 		cameraR.viewport = new Vector4();
 
-		var cameras = [ cameraL, cameraR ];
-
-		var cameraVR = new ArrayCamera();
+		var cameraVR = new ArrayCamera( [ cameraL, cameraR ] );
 		cameraVR.layers.enable( 1 );
 		cameraVR.layers.enable( 2 );
-
-		var _currentDepthNear = null;
-		var _currentDepthFar = null;
 
 		//
 
 		this.enabled = false;
 
-		this.isPresenting = false;
+		this.getController = function ( id ) {
 
-		this.getController = function ( index ) {
-
-			var controller = controllers[ index ];
+			var controller = controllers[ id ];
 
 			if ( controller === undefined ) {
 
-				controller = new WebXRController();
-				controllers[ index ] = controller;
+				controller = new Group();
+				controller.matrixAutoUpdate = false;
+				controller.visible = false;
+
+				controllers[ id ] = controller;
 
 			}
 
-			return controller.getTargetRaySpace();
-
-		};
-
-		this.getControllerGrip = function ( index ) {
-
-			var controller = controllers[ index ];
-
-			if ( controller === undefined ) {
-
-				controller = new WebXRController();
-				controllers[ index ] = controller;
-
-			}
-
-			return controller.getGripSpace();
+			return controller;
 
 		};
 
@@ -23122,11 +22850,13 @@ var Spacekit = (function (exports) {
 
 		function onSessionEvent( event ) {
 
-			var controller = inputSourcesMap.get( event.inputSource );
+			for ( var i = 0; i < controllers.length; i ++ ) {
 
-			if ( controller ) {
+				if ( inputSources[ i ] === event.inputSource ) {
 
-				controller.dispatchEvent( { type: event.type } );
+					controllers[ i ].dispatchEvent( { type: event.type } );
+
+				}
 
 			}
 
@@ -23134,21 +22864,9 @@ var Spacekit = (function (exports) {
 
 		function onSessionEnd() {
 
-			inputSourcesMap.forEach( function ( controller, inputSource ) {
-
-				controller.disconnect( inputSource );
-
-			} );
-
-			inputSourcesMap.clear();
-
-			//
-
 			renderer.setFramebuffer( null );
 			renderer.setRenderTarget( renderer.getRenderTarget() ); // Hack #15830
 			animation.stop();
-
-			scope.isPresenting = false;
 
 			scope.dispatchEvent( { type: 'sessionend' } );
 
@@ -23161,39 +22879,17 @@ var Spacekit = (function (exports) {
 			animation.setContext( session );
 			animation.start();
 
-			scope.isPresenting = true;
-
 			scope.dispatchEvent( { type: 'sessionstart' } );
 
 		}
 
 		this.setFramebufferScaleFactor = function ( value ) {
 
-			framebufferScaleFactor = value;
-
-			if ( scope.isPresenting === true ) {
-
-				console.warn( 'THREE.WebXRManager: Cannot change framebuffer scale while presenting.' );
-
-			}
-
 		};
 
 		this.setReferenceSpaceType = function ( value ) {
 
 			referenceSpaceType = value;
-
-			if ( scope.isPresenting === true ) {
-
-				console.warn( 'THREE.WebXRManager: Cannot change reference space type while presenting.' );
-
-			}
-
-		};
-
-		this.getReferenceSpace = function () {
-
-			return referenceSpace;
 
 		};
 
@@ -23212,142 +22908,33 @@ var Spacekit = (function (exports) {
 				session.addEventListener( 'select', onSessionEvent );
 				session.addEventListener( 'selectstart', onSessionEvent );
 				session.addEventListener( 'selectend', onSessionEvent );
-				session.addEventListener( 'squeeze', onSessionEvent );
-				session.addEventListener( 'squeezestart', onSessionEvent );
-				session.addEventListener( 'squeezeend', onSessionEvent );
 				session.addEventListener( 'end', onSessionEnd );
 
-				var attributes = gl.getContextAttributes();
-
-				var layerInit = {
-					antialias: attributes.antialias,
-					alpha: attributes.alpha,
-					depth: attributes.depth,
-					stencil: attributes.stencil,
-					framebufferScaleFactor: framebufferScaleFactor
-				};
-
-				// eslint-disable-next-line no-undef
-				var baseLayer = new XRWebGLLayer( session, gl, layerInit );
-
-				session.updateRenderState( { baseLayer: baseLayer } );
+				session.updateRenderState( { baseLayer: new XRWebGLLayer( session, gl ) } );
 
 				session.requestReferenceSpace( referenceSpaceType ).then( onRequestReferenceSpace );
 
 				//
 
-				session.addEventListener( 'inputsourceschange', updateInputSources );
+				inputSources = session.inputSources;
+
+				session.addEventListener( 'inputsourceschange', function () {
+
+					inputSources = session.inputSources;
+					console.log( inputSources );
+
+					for ( var i = 0; i < controllers.length; i ++ ) {
+
+						var controller = controllers[ i ];
+						controller.userData.inputSource = inputSources[ i ];
+
+					}
+
+				} );
 
 			}
 
 		};
-
-		function updateInputSources( event ) {
-
-			var inputSources = session.inputSources;
-
-			// Assign inputSources to available controllers
-
-			for ( var i = 0; i < controllers.length; i ++ ) {
-
-				inputSourcesMap.set( inputSources[ i ], controllers[ i ] );
-
-			}
-
-			// Notify disconnected
-
-			for ( var i = 0; i < event.removed.length; i ++ ) {
-
-				var inputSource = event.removed[ i ];
-				var controller = inputSourcesMap.get( inputSource );
-
-				if ( controller ) {
-
-					controller.dispatchEvent( { type: 'disconnected', data: inputSource } );
-					inputSourcesMap.delete( inputSource );
-
-				}
-
-			}
-
-			// Notify connected
-
-			for ( var i = 0; i < event.added.length; i ++ ) {
-
-				var inputSource = event.added[ i ];
-				var controller = inputSourcesMap.get( inputSource );
-
-				if ( controller ) {
-
-					controller.dispatchEvent( { type: 'connected', data: inputSource } );
-
-				}
-
-			}
-
-		}
-
-		//
-
-		var cameraLPos = new Vector3();
-		var cameraRPos = new Vector3();
-
-		/**
-		 * @author jsantell / https://www.jsantell.com/
-		 *
-		 * Assumes 2 cameras that are parallel and share an X-axis, and that
-		 * the cameras' projection and world matrices have already been set.
-		 * And that near and far planes are identical for both cameras.
-		 * Visualization of this technique: https://computergraphics.stackexchange.com/a/4765
-		 */
-		function setProjectionFromUnion( camera, cameraL, cameraR ) {
-
-			cameraLPos.setFromMatrixPosition( cameraL.matrixWorld );
-			cameraRPos.setFromMatrixPosition( cameraR.matrixWorld );
-
-			var ipd = cameraLPos.distanceTo( cameraRPos );
-
-			var projL = cameraL.projectionMatrix.elements;
-			var projR = cameraR.projectionMatrix.elements;
-
-			// VR systems will have identical far and near planes, and
-			// most likely identical top and bottom frustum extents.
-			// Use the left camera for these values.
-			var near = projL[ 14 ] / ( projL[ 10 ] - 1 );
-			var far = projL[ 14 ] / ( projL[ 10 ] + 1 );
-			var topFov = ( projL[ 9 ] + 1 ) / projL[ 5 ];
-			var bottomFov = ( projL[ 9 ] - 1 ) / projL[ 5 ];
-
-			var leftFov = ( projL[ 8 ] - 1 ) / projL[ 0 ];
-			var rightFov = ( projR[ 8 ] + 1 ) / projR[ 0 ];
-			var left = near * leftFov;
-			var right = near * rightFov;
-
-			// Calculate the new camera's position offset from the
-			// left camera. xOffset should be roughly half `ipd`.
-			var zOffset = ipd / ( - leftFov + rightFov );
-			var xOffset = zOffset * - leftFov;
-
-			// TODO: Better way to apply this offset?
-			cameraL.matrixWorld.decompose( camera.position, camera.quaternion, camera.scale );
-			camera.translateX( xOffset );
-			camera.translateZ( zOffset );
-			camera.matrixWorld.compose( camera.position, camera.quaternion, camera.scale );
-			camera.matrixWorldInverse.getInverse( camera.matrixWorld );
-
-			// Find the union of the frustum values of the cameras and scale
-			// the values so that the near plane's position does not change in world space,
-			// although must now be relative to the new union camera.
-			var near2 = near + zOffset;
-			var far2 = far + zOffset;
-			var left2 = left - xOffset;
-			var right2 = right + ( ipd - xOffset );
-			var top2 = topFov * far / far2 * near2;
-			var bottom2 = bottomFov * far / far2 * near2;
-
-			camera.projectionMatrix.makePerspective( left2, right2, top2, bottom2, near2, far2 );
-
-		}
 
 		function updateCamera( camera, parent ) {
 
@@ -23367,63 +22954,42 @@ var Spacekit = (function (exports) {
 
 		this.getCamera = function ( camera ) {
 
-			cameraVR.near = cameraR.near = cameraL.near = camera.near;
-			cameraVR.far = cameraR.far = cameraL.far = camera.far;
+			if ( isPresenting() ) {
 
-			if ( _currentDepthNear !== cameraVR.near || _currentDepthFar !== cameraVR.far ) {
+				var parent = camera.parent;
+				var cameras = cameraVR.cameras;
 
-				// Note that the new renderState won't apply until the next frame. See #18320
+				updateCamera( cameraVR, parent );
 
-				session.updateRenderState( {
-					depthNear: cameraVR.near,
-					depthFar: cameraVR.far
-				} );
+				for ( var i = 0; i < cameras.length; i ++ ) {
 
-				_currentDepthNear = cameraVR.near;
-				_currentDepthFar = cameraVR.far;
+					updateCamera( cameras[ i ], parent );
 
-			}
+				}
 
-			var parent = camera.parent;
-			var cameras = cameraVR.cameras;
+				// update camera and its children
 
-			updateCamera( cameraVR, parent );
+				camera.matrixWorld.copy( cameraVR.matrixWorld );
 
-			for ( var i = 0; i < cameras.length; i ++ ) {
+				var children = camera.children;
 
-				updateCamera( cameras[ i ], parent );
+				for ( var i = 0, l = children.length; i < l; i ++ ) {
 
-			}
+					children[ i ].updateMatrixWorld( true );
 
-			// update camera and its children
-
-			camera.matrixWorld.copy( cameraVR.matrixWorld );
-
-			var children = camera.children;
-
-			for ( var i = 0, l = children.length; i < l; i ++ ) {
-
-				children[ i ].updateMatrixWorld( true );
-
-			}
-
-			// update projection matrix for proper view frustum culling
-
-			if ( cameras.length === 2 ) {
+				}
 
 				setProjectionFromUnion( cameraVR, cameraL, cameraR );
 
-			} else {
-
-				// assume single camera setup (AR)
-
-				cameraVR.projectionMatrix.copy( cameraL.projectionMatrix );
+				return cameraVR;
 
 			}
 
-			return cameraVR;
+			return camera;
 
 		};
+
+		this.isPresenting = isPresenting;
 
 		// Animation Loop
 
@@ -23440,24 +23006,14 @@ var Spacekit = (function (exports) {
 
 				renderer.setFramebuffer( baseLayer.framebuffer );
 
-				var cameraVRNeedsUpdate = false;
-
-				// check if it's necessary to rebuild cameraVR's camera list
-
-				if ( views.length !== cameraVR.cameras.length ) {
-
-					cameraVR.cameras.length = 0;
-					cameraVRNeedsUpdate = true;
-
-				}
-
 				for ( var i = 0; i < views.length; i ++ ) {
 
 					var view = views[ i ];
 					var viewport = baseLayer.getViewport( view );
+					var viewMatrix = view.transform.inverse.matrix;
 
-					var camera = cameras[ i ];
-					camera.matrix.fromArray( view.transform.matrix );
+					var camera = cameraVR.cameras[ i ];
+					camera.matrix.fromArray( viewMatrix ).getInverse( camera.matrix );
 					camera.projectionMatrix.fromArray( view.projectionMatrix );
 					camera.viewport.set( viewport.x, viewport.y, viewport.width, viewport.height );
 
@@ -23467,30 +23023,39 @@ var Spacekit = (function (exports) {
 
 					}
 
-					if ( cameraVRNeedsUpdate === true ) {
-
-						cameraVR.cameras.push( camera );
-
-					}
-
 				}
 
 			}
 
 			//
 
-			var inputSources = session.inputSources;
-
 			for ( var i = 0; i < controllers.length; i ++ ) {
 
 				var controller = controllers[ i ];
+
 				var inputSource = inputSources[ i ];
 
-				controller.update( inputSource, frame, referenceSpace );
+				if ( inputSource ) {
+
+					var inputPose = frame.getPose( inputSource.targetRaySpace, referenceSpace );
+
+					if ( inputPose !== null ) {
+
+						controller.matrix.fromArray( inputPose.transform.matrix );
+						controller.matrix.decompose( controller.position, controller.rotation, controller.scale );
+						controller.visible = true;
+
+						continue;
+
+					}
+
+				}
+
+				controller.visible = false;
 
 			}
 
-			if ( onAnimationFrameCallback ) onAnimationFrameCallback( time, frame );
+			if ( onAnimationFrameCallback ) onAnimationFrameCallback( time );
 
 		}
 
@@ -23505,6 +23070,35 @@ var Spacekit = (function (exports) {
 
 		this.dispose = function () {};
 
+		// DEPRECATED
+
+		this.getStandingMatrix = function () {
+
+			console.warn( 'THREE.WebXRManager: getStandingMatrix() is no longer needed.' );
+			return new Matrix4();
+
+		};
+
+		this.getDevice = function () {
+
+			console.warn( 'THREE.WebXRManager: getDevice() has been deprecated.' );
+
+		};
+
+		this.setDevice = function () {
+
+			console.warn( 'THREE.WebXRManager: setDevice() has been deprecated.' );
+
+		};
+
+		this.setFrameOfReferenceType = function () {
+
+			console.warn( 'THREE.WebXRManager: setFrameOfReferenceType() has been deprecated.' );
+
+		};
+
+		this.submitFrame = function () {};
+
 	}
 
 	Object.assign( WebXRManager.prototype, EventDispatcher.prototype );
@@ -23518,6 +23112,8 @@ var Spacekit = (function (exports) {
 	 */
 
 	function WebGLRenderer( parameters ) {
+
+		console.log( 'THREE.WebGLRenderer', REVISION );
 
 		parameters = parameters || {};
 
@@ -23569,7 +23165,8 @@ var Spacekit = (function (exports) {
 		// physically based shading
 
 		this.gammaFactor = 2.0;	// for backwards compatibility
-		this.outputEncoding = LinearEncoding;
+		this.gammaInput = false;
+		this.gammaOutput = false;
 
 		// physical lights
 
@@ -23577,7 +23174,7 @@ var Spacekit = (function (exports) {
 
 		// tone mapping
 
-		this.toneMapping = NoToneMapping;
+		this.toneMapping = LinearToneMapping;
 		this.toneMappingExposure = 1.0;
 		this.toneMappingWhitePoint = 1.0;
 
@@ -23623,8 +23220,6 @@ var Spacekit = (function (exports) {
 			_height = _canvas.height,
 
 			_pixelRatio = 1,
-			_opaqueSort = null,
-			_transparentSort = null,
 
 			_viewport = new Vector4( 0, 0, _width, _height ),
 			_scissor = new Vector4( 0, 0, _width, _height ),
@@ -23724,7 +23319,7 @@ var Spacekit = (function (exports) {
 
 			capabilities = new WebGLCapabilities( _gl, extensions, parameters );
 
-			if ( capabilities.isWebGL2 === false ) {
+			if ( ! capabilities.isWebGL2 ) {
 
 				extensions.get( 'WEBGL_depth_texture' );
 				extensions.get( 'OES_texture_float' );
@@ -23740,16 +23335,16 @@ var Spacekit = (function (exports) {
 
 			utils = new WebGLUtils( _gl, extensions, capabilities );
 
-			state = new WebGLState( _gl, extensions, capabilities );
+			state = new WebGLState( _gl, extensions, utils, capabilities );
 			state.scissor( _currentScissor.copy( _scissor ).multiplyScalar( _pixelRatio ).floor() );
 			state.viewport( _currentViewport.copy( _viewport ).multiplyScalar( _pixelRatio ).floor() );
 
 			info = new WebGLInfo( _gl );
 			properties = new WebGLProperties();
 			textures = new WebGLTextures( _gl, extensions, state, properties, capabilities, utils, info );
-			attributes = new WebGLAttributes( _gl, capabilities );
+			attributes = new WebGLAttributes( _gl );
 			geometries = new WebGLGeometries( _gl, attributes, info );
-			objects = new WebGLObjects( _gl, geometries, attributes, info );
+			objects = new WebGLObjects( geometries, info );
 			morphtargets = new WebGLMorphtargets( _gl );
 			programCache = new WebGLPrograms( _this, extensions, capabilities );
 			renderLists = new WebGLRenderLists();
@@ -23773,11 +23368,11 @@ var Spacekit = (function (exports) {
 
 		initGLContext();
 
-		// xr
+		// vr
 
-		var xr = new WebXRManager( _this, _gl );
+		var vr = ( typeof navigator !== 'undefined' && 'xr' in navigator && 'supportsSession' in navigator.xr ) ? new WebXRManager( _this, _gl ) : new WebVRManager( _this );
 
-		this.xr = xr;
+		this.vr = vr;
 
 		// shadow map
 
@@ -23845,7 +23440,7 @@ var Spacekit = (function (exports) {
 
 		this.setSize = function ( width, height, updateStyle ) {
 
-			if ( xr.isPresenting ) {
+			if ( vr.isPresenting() ) {
 
 				console.warn( 'THREE.WebGLRenderer: Can\'t change size while VR device is presenting.' );
 				return;
@@ -23967,18 +23562,6 @@ var Spacekit = (function (exports) {
 
 		};
 
-		this.setOpaqueSort = function ( method ) {
-
-			_opaqueSort = method;
-
-		};
-
-		this.setTransparentSort = function ( method ) {
-
-			_transparentSort = method;
-
-		};
-
 		// Clearing
 
 		this.getClearColor = function () {
@@ -24047,7 +23630,7 @@ var Spacekit = (function (exports) {
 			properties.dispose();
 			objects.dispose();
 
-			xr.dispose();
+			vr.dispose();
 
 			animation.stop();
 
@@ -24183,17 +23766,13 @@ var Spacekit = (function (exports) {
 
 		};
 
-		var tempScene = new Scene();
-
-		this.renderBufferDirect = function ( camera, scene, geometry, material, object, group ) {
-
-			if ( scene === null ) scene = tempScene; // renderBufferDirect second parameter used to be fog (could be null)
+		this.renderBufferDirect = function ( camera, fog, geometry, material, object, group ) {
 
 			var frontFaceCW = ( object.isMesh && object.matrixWorld.determinant() < 0 );
 
-			var program = setProgram( camera, scene, material, object );
-
 			state.setMaterial( material, frontFaceCW );
+
+			var program = setProgram( camera, fog, material, object );
 
 			var updateBuffers = false;
 
@@ -24208,15 +23787,9 @@ var Spacekit = (function (exports) {
 
 			}
 
-			if ( material.morphTargets || material.morphNormals ) {
+			if ( object.morphTargetInfluences ) {
 
 				morphtargets.update( object, geometry, material, program );
-
-				updateBuffers = true;
-
-			}
-
-			if ( object.isInstancedMesh === true ) {
 
 				updateBuffers = true;
 
@@ -24226,21 +23799,6 @@ var Spacekit = (function (exports) {
 
 			var index = geometry.index;
 			var position = geometry.attributes.position;
-
-			//
-
-			if ( index === null ) {
-
-				if ( position === undefined || position.count === 0 ) return;
-
-			} else if ( index.count === 0 ) {
-
-				return;
-
-			}
-
-			//
-
 			var rangeFactor = 1;
 
 			if ( material.wireframe === true ) {
@@ -24264,7 +23822,7 @@ var Spacekit = (function (exports) {
 
 			if ( updateBuffers ) {
 
-				setupVertexAttributes( object, geometry, material, program );
+				setupVertexAttributes( material, program, geometry );
 
 				if ( index !== null ) {
 
@@ -24276,7 +23834,17 @@ var Spacekit = (function (exports) {
 
 			//
 
-			var dataCount = ( index !== null ) ? index.count : position.count;
+			var dataCount = Infinity;
+
+			if ( index !== null ) {
+
+				dataCount = index.count;
+
+			} else if ( position !== undefined ) {
+
+				dataCount = position.count;
+
+			}
 
 			var rangeStart = geometry.drawRange.start * rangeFactor;
 			var rangeCount = geometry.drawRange.count * rangeFactor;
@@ -24302,9 +23870,24 @@ var Spacekit = (function (exports) {
 
 				} else {
 
-					renderer.setMode( 4 );
+					switch ( object.drawMode ) {
+
+						case TrianglesDrawMode:
+							renderer.setMode( 4 );
+							break;
+
+						case TriangleStripDrawMode:
+							renderer.setMode( 5 );
+							break;
+
+						case TriangleFanDrawMode:
+							renderer.setMode( 6 );
+							break;
+
+					}
 
 				}
+
 
 			} else if ( object.isLine ) {
 
@@ -24338,13 +23921,13 @@ var Spacekit = (function (exports) {
 
 			}
 
-			if ( object.isInstancedMesh ) {
+			if ( geometry && geometry.isInstancedBufferGeometry ) {
 
-				renderer.renderInstances( geometry, drawStart, drawCount, object.count );
+				if ( geometry.maxInstancedCount > 0 ) {
 
-			} else if ( geometry.isInstancedBufferGeometry ) {
+					renderer.renderInstances( geometry, drawStart, drawCount );
 
-				renderer.renderInstances( geometry, drawStart, drawCount, geometry.maxInstancedCount );
+				}
 
 			} else {
 
@@ -24354,11 +23937,16 @@ var Spacekit = (function (exports) {
 
 		};
 
-		function setupVertexAttributes( object, geometry, material, program ) {
+		function setupVertexAttributes( material, program, geometry ) {
 
-			if ( capabilities.isWebGL2 === false && ( object.isInstancedMesh || geometry.isInstancedBufferGeometry ) ) {
+			if ( geometry && geometry.isInstancedBufferGeometry && ! capabilities.isWebGL2 ) {
 
-				if ( extensions.get( 'ANGLE_instanced_arrays' ) === null ) return;
+				if ( extensions.get( 'ANGLE_instanced_arrays' ) === null ) {
+
+					console.error( 'THREE.WebGLRenderer.setupVertexAttributes: using THREE.InstancedBufferGeometry but hardware does not support extension ANGLE_instanced_arrays.' );
+					return;
+
+				}
 
 			}
 
@@ -24416,7 +24004,7 @@ var Spacekit = (function (exports) {
 							}
 
 							_gl.bindBuffer( 34962, buffer );
-							state.vertexAttribPointer( programAttribute, size, type, normalized, stride * bytesPerElement, offset * bytesPerElement );
+							_gl.vertexAttribPointer( programAttribute, size, type, normalized, stride * bytesPerElement, offset * bytesPerElement );
 
 						} else {
 
@@ -24437,32 +24025,9 @@ var Spacekit = (function (exports) {
 							}
 
 							_gl.bindBuffer( 34962, buffer );
-							state.vertexAttribPointer( programAttribute, size, type, normalized, 0, 0 );
+							_gl.vertexAttribPointer( programAttribute, size, type, normalized, 0, 0 );
 
 						}
-
-					} else if ( name === 'instanceMatrix' ) {
-
-						var attribute = attributes.get( object.instanceMatrix );
-
-						// TODO Attribute may not be available on context restore
-
-						if ( attribute === undefined ) continue;
-
-						var buffer = attribute.buffer;
-						var type = attribute.type;
-
-						state.enableAttributeAndDivisor( programAttribute + 0, 1 );
-						state.enableAttributeAndDivisor( programAttribute + 1, 1 );
-						state.enableAttributeAndDivisor( programAttribute + 2, 1 );
-						state.enableAttributeAndDivisor( programAttribute + 3, 1 );
-
-						_gl.bindBuffer( 34962, buffer );
-
-						_gl.vertexAttribPointer( programAttribute + 0, 4, type, false, 64, 0 );
-						_gl.vertexAttribPointer( programAttribute + 1, 4, type, false, 64, 16 );
-						_gl.vertexAttribPointer( programAttribute + 2, 4, type, false, 64, 32 );
-						_gl.vertexAttribPointer( programAttribute + 3, 4, type, false, 64, 48 );
 
 					} else if ( materialDefaultAttributeValues !== undefined ) {
 
@@ -24526,8 +24091,6 @@ var Spacekit = (function (exports) {
 
 			currentRenderState.setupLights( camera );
 
-			var compiled = {};
-
 			scene.traverse( function ( object ) {
 
 				if ( object.material ) {
@@ -24536,19 +24099,13 @@ var Spacekit = (function (exports) {
 
 						for ( var i = 0; i < object.material.length; i ++ ) {
 
-							if ( object.material[ i ].uuid in compiled === false ) {
-
-								initMaterial( object.material[ i ], scene, object );
-								compiled[ object.material[ i ].uuid ] = true;
-
-							}
+							initMaterial( object.material[ i ], scene.fog, object );
 
 						}
 
-					} else if ( object.material.uuid in compiled === false ) {
+					} else {
 
-						initMaterial( object.material, scene, object );
-						compiled[ object.material.uuid ] = true;
+						initMaterial( object.material, scene.fog, object );
 
 					}
 
@@ -24564,7 +24121,7 @@ var Spacekit = (function (exports) {
 
 		function onAnimationFrame( time ) {
 
-			if ( xr.isPresenting ) return;
+			if ( vr.isPresenting() ) return;
 			if ( onAnimationFrameCallback ) onAnimationFrameCallback( time );
 
 		}
@@ -24577,7 +24134,7 @@ var Spacekit = (function (exports) {
 		this.setAnimationLoop = function ( callback ) {
 
 			onAnimationFrameCallback = callback;
-			xr.setAnimationLoop( callback );
+			vr.setAnimationLoop( callback );
 
 			animation.start();
 
@@ -24628,20 +24185,21 @@ var Spacekit = (function (exports) {
 
 			if ( camera.parent === null ) camera.updateMatrixWorld();
 
-			if ( xr.enabled && xr.isPresenting ) {
+			if ( vr.enabled ) {
 
-				camera = xr.getCamera( camera );
+				camera = vr.getCamera( camera );
 
 			}
 
 			//
-			scene.onBeforeRender( _this, scene, camera, renderTarget || _currentRenderTarget );
 
 			currentRenderState = renderStates.get( scene, camera );
 			currentRenderState.init();
 
+			scene.onBeforeRender( _this, scene, camera, renderTarget || _currentRenderTarget );
+
 			_projScreenMatrix.multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse );
-			_frustum.setFromProjectionMatrix( _projScreenMatrix );
+			_frustum.setFromMatrix( _projScreenMatrix );
 
 			_localClippingEnabled = this.localClippingEnabled;
 			_clippingEnabled = _clipping.init( this.clippingPlanes, _localClippingEnabled, camera );
@@ -24651,11 +24209,9 @@ var Spacekit = (function (exports) {
 
 			projectObject( scene, camera, 0, _this.sortObjects );
 
-			currentRenderList.finish();
-
 			if ( _this.sortObjects === true ) {
 
-				currentRenderList.sort( _opaqueSort, _transparentSort );
+				currentRenderList.sort();
 
 			}
 
@@ -24735,6 +24291,12 @@ var Spacekit = (function (exports) {
 
 			state.setPolygonOffset( false );
 
+			if ( vr.enabled ) {
+
+				vr.submitFrame();
+
+			}
+
 			// _gl.finish();
 
 			currentRenderList = null;
@@ -24805,14 +24367,7 @@ var Spacekit = (function (exports) {
 
 					if ( object.isSkinnedMesh ) {
 
-						// update skeleton only once in a frame
-
-						if ( object.skeleton.frame !== info.render.frame ) {
-
-							object.skeleton.update();
-							object.skeleton.frame = info.render.frame;
-
-						}
+						object.skeleton.update();
 
 					}
 
@@ -24922,9 +24477,9 @@ var Spacekit = (function (exports) {
 
 			if ( object.isImmediateRenderObject ) {
 
-				var program = setProgram( camera, scene, material, object );
-
 				state.setMaterial( material );
+
+				var program = setProgram( camera, scene.fog, material, object );
 
 				_currentGeometryProgram.geometry = null;
 				_currentGeometryProgram.program = null;
@@ -24934,7 +24489,7 @@ var Spacekit = (function (exports) {
 
 			} else {
 
-				_this.renderBufferDirect( camera, scene, geometry, material, object, group );
+				_this.renderBufferDirect( camera, scene.fog, geometry, material, object, group );
 
 			}
 
@@ -24943,7 +24498,7 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function initMaterial( material, scene, object ) {
+		function initMaterial( material, fog, object ) {
 
 			var materialProperties = properties.get( material );
 
@@ -24952,8 +24507,10 @@ var Spacekit = (function (exports) {
 
 			var lightsStateVersion = lights.state.version;
 
-			var parameters = programCache.getParameters( material, lights.state, shadowsArray, scene, _clipping.numPlanes, _clipping.numIntersection, object );
-			var programCacheKey = programCache.getProgramCacheKey( parameters );
+			var parameters = programCache.getParameters(
+				material, lights.state, shadowsArray, fog, _clipping.numPlanes, _clipping.numIntersection, object );
+
+			var code = programCache.getProgramCode( material, parameters );
 
 			var program = materialProperties.program;
 			var programChange = true;
@@ -24963,7 +24520,7 @@ var Spacekit = (function (exports) {
 				// new material
 				material.addEventListener( 'dispose', onMaterialDispose );
 
-			} else if ( program.cacheKey !== programCacheKey ) {
+			} else if ( program.code !== code ) {
 
 				// changed glsl or parameters
 				releaseMaterialProgramReference( material );
@@ -24988,11 +24545,36 @@ var Spacekit = (function (exports) {
 
 			if ( programChange ) {
 
-				program = programCache.acquireProgram( parameters, programCacheKey );
+				if ( parameters.shaderID ) {
+
+					var shader = ShaderLib[ parameters.shaderID ];
+
+					materialProperties.shader = {
+						name: material.type,
+						uniforms: cloneUniforms( shader.uniforms ),
+						vertexShader: shader.vertexShader,
+						fragmentShader: shader.fragmentShader
+					};
+
+				} else {
+
+					materialProperties.shader = {
+						name: material.type,
+						uniforms: material.uniforms,
+						vertexShader: material.vertexShader,
+						fragmentShader: material.fragmentShader
+					};
+
+				}
+
+				material.onBeforeCompile( materialProperties.shader, _this );
+
+				// Computing code again as onBeforeCompile may have changed the shaders
+				code = programCache.getProgramCode( material, parameters );
+
+				program = programCache.acquireProgram( material, materialProperties.shader, parameters, code );
 
 				materialProperties.program = program;
-				materialProperties.uniforms = parameters.uniforms;
-				materialProperties.outputEncoding = parameters.outputEncoding;
 				material.program = program;
 
 			}
@@ -25031,7 +24613,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			var uniforms = materialProperties.uniforms;
+			var uniforms = materialProperties.shader.uniforms;
 
 			if ( ! material.isShaderMaterial &&
 				! material.isRawShaderMaterial ||
@@ -25043,27 +24625,22 @@ var Spacekit = (function (exports) {
 
 			}
 
-			materialProperties.environment = material.isMeshStandardMaterial ? scene.environment : null;
-			materialProperties.fog = scene.fog;
+			materialProperties.fog = fog;
 
 			// store the light setup it was created for
 
-			materialProperties.needsLights = materialNeedsLights( material );
 			materialProperties.lightsStateVersion = lightsStateVersion;
 
-			if ( materialProperties.needsLights ) {
+			if ( material.lights ) {
 
 				// wire up the material to this renderer's lighting state
 
 				uniforms.ambientLightColor.value = lights.state.ambient;
 				uniforms.lightProbe.value = lights.state.probe;
 				uniforms.directionalLights.value = lights.state.directional;
-				uniforms.directionalLightShadows.value = lights.state.directionalShadow;
 				uniforms.spotLights.value = lights.state.spot;
-				uniforms.spotLightShadows.value = lights.state.spotShadow;
 				uniforms.rectAreaLights.value = lights.state.rectArea;
 				uniforms.pointLights.value = lights.state.point;
-				uniforms.pointLightShadows.value = lights.state.pointShadow;
 				uniforms.hemisphereLights.value = lights.state.hemi;
 
 				uniforms.directionalShadowMap.value = lights.state.directionalShadowMap;
@@ -25084,13 +24661,9 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function setProgram( camera, scene, material, object ) {
+		function setProgram( camera, fog, material, object ) {
 
 			textures.resetTextureUnits();
-
-			var fog = scene.fog;
-			var environment = material.isMeshStandardMaterial ? scene.environment : null;
-			var encoding = ( _currentRenderTarget === null ) ? _this.outputEncoding : _currentRenderTarget.texture.encoding;
 
 			var materialProperties = properties.get( material );
 			var lights = currentRenderState.state.lights;
@@ -25114,40 +24687,34 @@ var Spacekit = (function (exports) {
 
 			}
 
-			if ( material.version === materialProperties.__version ) {
+			if ( material.needsUpdate === false ) {
 
 				if ( materialProperties.program === undefined ) {
 
-					initMaterial( material, scene, object );
+					material.needsUpdate = true;
 
 				} else if ( material.fog && materialProperties.fog !== fog ) {
 
-					initMaterial( material, scene, object );
+					material.needsUpdate = true;
 
-				} else if ( materialProperties.environment !== environment ) {
+				} else if ( material.lights && materialProperties.lightsStateVersion !== lights.state.version ) {
 
-					initMaterial( material, scene, object );
-
-				} else if ( materialProperties.needsLights && ( materialProperties.lightsStateVersion !== lights.state.version ) ) {
-
-					initMaterial( material, scene, object );
+					material.needsUpdate = true;
 
 				} else if ( materialProperties.numClippingPlanes !== undefined &&
 					( materialProperties.numClippingPlanes !== _clipping.numPlanes ||
 					materialProperties.numIntersection !== _clipping.numIntersection ) ) {
 
-					initMaterial( material, scene, object );
-
-				} else if ( materialProperties.outputEncoding !== encoding ) {
-
-					initMaterial( material, scene, object );
+					material.needsUpdate = true;
 
 				}
 
-			} else {
+			}
 
-				initMaterial( material, scene, object );
-				materialProperties.__version = material.version;
+			if ( material.needsUpdate ) {
+
+				initMaterial( material, fog, object );
+				material.needsUpdate = false;
 
 			}
 
@@ -25157,7 +24724,7 @@ var Spacekit = (function (exports) {
 
 			var program = materialProperties.program,
 				p_uniforms = program.getUniforms(),
-				m_uniforms = materialProperties.uniforms;
+				m_uniforms = materialProperties.shader.uniforms;
 
 			if ( state.useProgram( program.program ) ) {
 
@@ -25204,7 +24771,6 @@ var Spacekit = (function (exports) {
 
 				if ( material.isShaderMaterial ||
 					material.isMeshPhongMaterial ||
-					material.isMeshToonMaterial ||
 					material.isMeshStandardMaterial ||
 					material.envMap ) {
 
@@ -25220,18 +24786,6 @@ var Spacekit = (function (exports) {
 				}
 
 				if ( material.isMeshPhongMaterial ||
-					material.isMeshToonMaterial ||
-					material.isMeshLambertMaterial ||
-					material.isMeshBasicMaterial ||
-					material.isMeshStandardMaterial ||
-					material.isShaderMaterial ) {
-
-					p_uniforms.setValue( _gl, 'isOrthographic', camera.isOrthographicCamera === true );
-
-				}
-
-				if ( material.isMeshPhongMaterial ||
-					material.isMeshToonMaterial ||
 					material.isMeshLambertMaterial ||
 					material.isMeshBasicMaterial ||
 					material.isMeshStandardMaterial ||
@@ -25246,7 +24800,7 @@ var Spacekit = (function (exports) {
 
 			// skinning uniforms must be set even if material didn't change
 			// auto-setting of texture unit for bone texture must go before other textures
-			// otherwise textures used for skinning can take over texture units reserved for other material textures
+			// not sure why, but otherwise weird things happen
 
 			if ( material.skinning ) {
 
@@ -25272,13 +24826,14 @@ var Spacekit = (function (exports) {
 
 
 							var size = Math.sqrt( bones.length * 4 ); // 4 pixels needed for 1 matrix
-							size = MathUtils.ceilPowerOfTwo( size );
+							size = _Math.ceilPowerOfTwo( size );
 							size = Math.max( size, 4 );
 
 							var boneMatrices = new Float32Array( size * size * 4 ); // 4 floats per RGBA pixel
 							boneMatrices.set( skeleton.boneMatrices ); // copy current values
 
 							var boneTexture = new DataTexture( boneMatrices, size, size, RGBAFormat, FloatType );
+							boneTexture.needsUpdate = true;
 
 							skeleton.boneMatrices = boneMatrices;
 							skeleton.boneTexture = boneTexture;
@@ -25299,19 +24854,12 @@ var Spacekit = (function (exports) {
 
 			}
 
-			if ( refreshMaterial || materialProperties.receiveShadow !== object.receiveShadow ) {
-
-				materialProperties.receiveShadow = object.receiveShadow;
-				p_uniforms.setValue( _gl, 'receiveShadow', object.receiveShadow );
-
-			}
-
 			if ( refreshMaterial ) {
 
 				p_uniforms.setValue( _gl, 'toneMappingExposure', _this.toneMappingExposure );
 				p_uniforms.setValue( _gl, 'toneMappingWhitePoint', _this.toneMappingWhitePoint );
 
-				if ( materialProperties.needsLights ) {
+				if ( material.lights ) {
 
 					// the current material requires lighting info
 
@@ -25343,33 +24891,38 @@ var Spacekit = (function (exports) {
 					refreshUniformsCommon( m_uniforms, material );
 					refreshUniformsLambert( m_uniforms, material );
 
-				} else if ( material.isMeshToonMaterial ) {
-
-					refreshUniformsCommon( m_uniforms, material );
-					refreshUniformsToon( m_uniforms, material );
-
 				} else if ( material.isMeshPhongMaterial ) {
 
 					refreshUniformsCommon( m_uniforms, material );
-					refreshUniformsPhong( m_uniforms, material );
 
-				} else if ( material.isMeshStandardMaterial ) {
+					if ( material.isMeshToonMaterial ) {
 
-					refreshUniformsCommon( m_uniforms, material, environment );
-
-					if ( material.isMeshPhysicalMaterial ) {
-
-						refreshUniformsPhysical( m_uniforms, material, environment );
+						refreshUniformsToon( m_uniforms, material );
 
 					} else {
 
-						refreshUniformsStandard( m_uniforms, material, environment );
+						refreshUniformsPhong( m_uniforms, material );
+
+					}
+
+				} else if ( material.isMeshStandardMaterial ) {
+
+					refreshUniformsCommon( m_uniforms, material );
+
+					if ( material.isMeshPhysicalMaterial ) {
+
+						refreshUniformsPhysical( m_uniforms, material );
+
+					} else {
+
+						refreshUniformsStandard( m_uniforms, material );
 
 					}
 
 				} else if ( material.isMeshMatcapMaterial ) {
 
 					refreshUniformsCommon( m_uniforms, material );
+
 					refreshUniformsMatcap( m_uniforms, material );
 
 				} else if ( material.isMeshDepthMaterial ) {
@@ -25420,12 +24973,6 @@ var Spacekit = (function (exports) {
 
 				WebGLUniforms.upload( _gl, materialProperties.uniformsList, m_uniforms, textures );
 
-				if ( material.isShaderMaterial ) {
-
-					material.uniformsNeedUpdate = false; // #15581
-
-				}
-
 			}
 
 			if ( material.isShaderMaterial && material.uniformsNeedUpdate === true ) {
@@ -25453,7 +25000,7 @@ var Spacekit = (function (exports) {
 
 		// Uniforms (refresh uniforms objects)
 
-		function refreshUniformsCommon( uniforms, material, environment ) {
+		function refreshUniformsCommon( uniforms, material ) {
 
 			uniforms.opacity.value = material.opacity;
 
@@ -25487,18 +25034,20 @@ var Spacekit = (function (exports) {
 
 			}
 
-			var envMap = material.envMap || environment;
+			if ( material.envMap ) {
 
-			if ( envMap ) {
+				uniforms.envMap.value = material.envMap;
 
-				uniforms.envMap.value = envMap;
-
-				uniforms.flipEnvMap.value = envMap.isCubeTexture ? - 1 : 1;
+				// don't flip CubeTexture envMaps, flip everything else:
+				//  WebGLRenderTargetCube will be flipped for backwards compatibility
+				//  WebGLRenderTargetCube.texture will be flipped because it's a Texture and NOT a CubeTexture
+				// this check must be handled differently, or removed entirely, if WebGLRenderTargetCube uses a CubeTexture in the future
+				uniforms.flipEnvMap.value = material.envMap.isCubeTexture ? - 1 : 1;
 
 				uniforms.reflectivity.value = material.reflectivity;
 				uniforms.refractionRatio.value = material.refractionRatio;
 
-				uniforms.maxMipLevel.value = properties.get( envMap ).__maxMipLevel;
+				uniforms.maxMipLevel.value = properties.get( material.envMap ).__maxMipLevel;
 
 			}
 
@@ -25583,41 +25132,6 @@ var Spacekit = (function (exports) {
 
 			}
 
-			// uv repeat and offset setting priorities for uv2
-			// 1. ao map
-			// 2. light map
-
-			var uv2ScaleMap;
-
-			if ( material.aoMap ) {
-
-				uv2ScaleMap = material.aoMap;
-
-			} else if ( material.lightMap ) {
-
-				uv2ScaleMap = material.lightMap;
-
-			}
-
-			if ( uv2ScaleMap !== undefined ) {
-
-				// backwards compatibility
-				if ( uv2ScaleMap.isWebGLRenderTarget ) {
-
-					uv2ScaleMap = uv2ScaleMap.texture;
-
-				}
-
-				if ( uv2ScaleMap.matrixAutoUpdate === true ) {
-
-					uv2ScaleMap.updateMatrix();
-
-				}
-
-				uniforms.uv2Transform.value.copy( uv2ScaleMap.matrix );
-
-			}
-
 		}
 
 		function refreshUniformsLine( uniforms, material ) {
@@ -25642,43 +25156,17 @@ var Spacekit = (function (exports) {
 			uniforms.size.value = material.size * _pixelRatio;
 			uniforms.scale.value = _height * 0.5;
 
-			if ( material.map ) {
+			uniforms.map.value = material.map;
 
-				uniforms.map.value = material.map;
+			if ( material.map !== null ) {
 
-			}
+				if ( material.map.matrixAutoUpdate === true ) {
 
-			if ( material.alphaMap ) {
-
-				uniforms.alphaMap.value = material.alphaMap;
-
-			}
-
-			// uv repeat and offset setting priorities
-			// 1. color map
-			// 2. alpha map
-
-			var uvScaleMap;
-
-			if ( material.map ) {
-
-				uvScaleMap = material.map;
-
-			} else if ( material.alphaMap ) {
-
-				uvScaleMap = material.alphaMap;
-
-			}
-
-			if ( uvScaleMap !== undefined ) {
-
-				if ( uvScaleMap.matrixAutoUpdate === true ) {
-
-					uvScaleMap.updateMatrix();
+					material.map.updateMatrix();
 
 				}
 
-				uniforms.uvTransform.value.copy( uvScaleMap.matrix );
+				uniforms.uvTransform.value.copy( material.map.matrix );
 
 			}
 
@@ -25689,44 +25177,17 @@ var Spacekit = (function (exports) {
 			uniforms.diffuse.value.copy( material.color );
 			uniforms.opacity.value = material.opacity;
 			uniforms.rotation.value = material.rotation;
+			uniforms.map.value = material.map;
 
-			if ( material.map ) {
+			if ( material.map !== null ) {
 
-				uniforms.map.value = material.map;
+				if ( material.map.matrixAutoUpdate === true ) {
 
-			}
-
-			if ( material.alphaMap ) {
-
-				uniforms.alphaMap.value = material.alphaMap;
-
-			}
-
-			// uv repeat and offset setting priorities
-			// 1. color map
-			// 2. alpha map
-
-			var uvScaleMap;
-
-			if ( material.map ) {
-
-				uvScaleMap = material.map;
-
-			} else if ( material.alphaMap ) {
-
-				uvScaleMap = material.alphaMap;
-
-			}
-
-			if ( uvScaleMap !== undefined ) {
-
-				if ( uvScaleMap.matrixAutoUpdate === true ) {
-
-					uvScaleMap.updateMatrix();
+					material.map.updateMatrix();
 
 				}
 
-				uniforms.uvTransform.value.copy( uvScaleMap.matrix );
+				uniforms.uvTransform.value.copy( material.map.matrix );
 
 			}
 
@@ -25798,8 +25259,7 @@ var Spacekit = (function (exports) {
 
 		function refreshUniformsToon( uniforms, material ) {
 
-			uniforms.specular.value.copy( material.specular );
-			uniforms.shininess.value = Math.max( material.shininess, 1e-4 ); // to prevent pow( 0.0, 0.0 )
+			refreshUniformsPhong( uniforms, material );
 
 			if ( material.gradientMap ) {
 
@@ -25807,39 +25267,9 @@ var Spacekit = (function (exports) {
 
 			}
 
-			if ( material.emissiveMap ) {
-
-				uniforms.emissiveMap.value = material.emissiveMap;
-
-			}
-
-			if ( material.bumpMap ) {
-
-				uniforms.bumpMap.value = material.bumpMap;
-				uniforms.bumpScale.value = material.bumpScale;
-				if ( material.side === BackSide ) uniforms.bumpScale.value *= - 1;
-
-			}
-
-			if ( material.normalMap ) {
-
-				uniforms.normalMap.value = material.normalMap;
-				uniforms.normalScale.value.copy( material.normalScale );
-				if ( material.side === BackSide ) uniforms.normalScale.value.negate();
-
-			}
-
-			if ( material.displacementMap ) {
-
-				uniforms.displacementMap.value = material.displacementMap;
-				uniforms.displacementScale.value = material.displacementScale;
-				uniforms.displacementBias.value = material.displacementBias;
-
-			}
-
 		}
 
-		function refreshUniformsStandard( uniforms, material, environment ) {
+		function refreshUniformsStandard( uniforms, material ) {
 
 			uniforms.roughness.value = material.roughness;
 			uniforms.metalness.value = material.metalness;
@@ -25886,7 +25316,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			if ( material.envMap || environment ) {
+			if ( material.envMap ) {
 
 				//uniforms.envMap.value = material.envMap; // part of uniforms common
 				uniforms.envMapIntensity.value = material.envMapIntensity;
@@ -25895,42 +25325,14 @@ var Spacekit = (function (exports) {
 
 		}
 
-		function refreshUniformsPhysical( uniforms, material, environment ) {
+		function refreshUniformsPhysical( uniforms, material ) {
 
-			refreshUniformsStandard( uniforms, material, environment );
+			refreshUniformsStandard( uniforms, material );
 
 			uniforms.reflectivity.value = material.reflectivity; // also part of uniforms common
 
-			uniforms.clearcoat.value = material.clearcoat;
-			uniforms.clearcoatRoughness.value = material.clearcoatRoughness;
-			if ( material.sheen ) uniforms.sheen.value.copy( material.sheen );
-
-			if ( material.clearcoatMap ) {
-
-				uniforms.clearcoatMap.value = material.clearcoatMap;
-
-			}
-
-			if ( material.clearcoatRoughnessMap ) {
-
-				uniforms.clearcoatRoughnessMap.value = material.clearcoatRoughnessMap;
-
-			}
-
-			if ( material.clearcoatNormalMap ) {
-
-				uniforms.clearcoatNormalScale.value.copy( material.clearcoatNormalScale );
-				uniforms.clearcoatNormalMap.value = material.clearcoatNormalMap;
-
-				if ( material.side === BackSide ) {
-
-					uniforms.clearcoatNormalScale.value.negate();
-
-				}
-
-			}
-
-			uniforms.transparency.value = material.transparency;
+			uniforms.clearCoat.value = material.clearCoat;
+			uniforms.clearCoatRoughness.value = material.clearCoatRoughness;
 
 		}
 
@@ -26032,28 +25434,17 @@ var Spacekit = (function (exports) {
 			uniforms.lightProbe.needsUpdate = value;
 
 			uniforms.directionalLights.needsUpdate = value;
-			uniforms.directionalLightShadows.needsUpdate = value;
 			uniforms.pointLights.needsUpdate = value;
-			uniforms.pointLightShadows.needsUpdate = value;
 			uniforms.spotLights.needsUpdate = value;
-			uniforms.spotLightShadows.needsUpdate = value;
 			uniforms.rectAreaLights.needsUpdate = value;
 			uniforms.hemisphereLights.needsUpdate = value;
-
-		}
-
-		function materialNeedsLights( material ) {
-
-			return material.isMeshLambertMaterial || material.isMeshToonMaterial || material.isMeshPhongMaterial ||
-				material.isMeshStandardMaterial || material.isShadowMaterial ||
-				( material.isShaderMaterial && material.lights === true );
 
 		}
 
 		//
 		this.setFramebuffer = function ( value ) {
 
-			if ( _framebuffer !== value && _currentRenderTarget === null ) _gl.bindFramebuffer( 36160, value );
+			if ( _framebuffer !== value ) _gl.bindFramebuffer( 36160, value );
 
 			_framebuffer = value;
 
@@ -26096,7 +25487,7 @@ var Spacekit = (function (exports) {
 
 				var __webglFramebuffer = properties.get( renderTarget ).__webglFramebuffer;
 
-				if ( renderTarget.isWebGLCubeRenderTarget ) {
+				if ( renderTarget.isWebGLRenderTargetCube ) {
 
 					framebuffer = __webglFramebuffer[ activeCubeFace || 0 ];
 					isCube = true;
@@ -26154,7 +25545,7 @@ var Spacekit = (function (exports) {
 
 			var framebuffer = properties.get( renderTarget ).__webglFramebuffer;
 
-			if ( renderTarget.isWebGLCubeRenderTarget && activeCubeFaceIndex !== undefined ) {
+			if ( renderTarget.isWebGLRenderTargetCube && activeCubeFaceIndex !== undefined ) {
 
 				framebuffer = framebuffer[ activeCubeFaceIndex ];
 
@@ -26226,24 +25617,17 @@ var Spacekit = (function (exports) {
 
 		this.copyFramebufferToTexture = function ( position, texture, level ) {
 
-			if ( level === undefined ) level = 0;
-
-			var levelScale = Math.pow( 2, - level );
-			var width = Math.floor( texture.image.width * levelScale );
-			var height = Math.floor( texture.image.height * levelScale );
+			var width = texture.image.width;
+			var height = texture.image.height;
 			var glFormat = utils.convert( texture.format );
 
 			textures.setTexture2D( texture, 0 );
 
-			_gl.copyTexImage2D( 3553, level, glFormat, position.x, position.y, width, height, 0 );
-
-			state.unbindTexture();
+			_gl.copyTexImage2D( 3553, level || 0, glFormat, position.x, position.y, width, height, 0 );
 
 		};
 
 		this.copyTextureToTexture = function ( position, srcTexture, dstTexture, level ) {
-
-			if ( level === undefined ) level = 0;
 
 			var width = srcTexture.image.width;
 			var height = srcTexture.image.height;
@@ -26254,34 +25638,13 @@ var Spacekit = (function (exports) {
 
 			if ( srcTexture.isDataTexture ) {
 
-				_gl.texSubImage2D( 3553, level, position.x, position.y, width, height, glFormat, glType, srcTexture.image.data );
+				_gl.texSubImage2D( 3553, level || 0, position.x, position.y, width, height, glFormat, glType, srcTexture.image.data );
 
 			} else {
 
-				if ( srcTexture.isCompressedTexture ) {
-
-					_gl.compressedTexSubImage2D( 3553, level, position.x, position.y, srcTexture.mipmaps[ 0 ].width, srcTexture.mipmaps[ 0 ].height, glFormat, srcTexture.mipmaps[ 0 ].data );
-
-				} else {
-
-					_gl.texSubImage2D( 3553, level, position.x, position.y, glFormat, glType, srcTexture.image );
-
-				}
+				_gl.texSubImage2D( 3553, level || 0, position.x, position.y, glFormat, glType, srcTexture.image );
 
 			}
-
-			// Generate mipmaps only when copying level 0
-			if ( level === 0 && dstTexture.generateMipmaps ) _gl.generateMipmap( 3553 );
-
-			state.unbindTexture();
-
-		};
-
-		this.initTexture = function ( texture ) {
-
-			textures.setTexture2D( texture, 0 );
-
-			state.unbindTexture();
 
 		};
 
@@ -26378,7 +25741,7 @@ var Spacekit = (function (exports) {
 		this.stride = stride;
 		this.count = array !== undefined ? array.length / stride : 0;
 
-		this.usage = StaticDrawUsage;
+		this.dynamic = false;
 		this.updateRange = { offset: 0, count: - 1 };
 
 		this.version = 0;
@@ -26401,9 +25764,24 @@ var Spacekit = (function (exports) {
 
 		onUploadCallback: function () {},
 
-		setUsage: function ( value ) {
+		setArray: function ( array ) {
 
-			this.usage = value;
+			if ( Array.isArray( array ) ) {
+
+				throw new TypeError( 'THREE.BufferAttribute: array should be a Typed Array.' );
+
+			}
+
+			this.count = array !== undefined ? array.length / this.stride : 0;
+			this.array = array;
+
+			return this;
+
+		},
+
+		setDynamic: function ( value ) {
+
+			this.dynamic = value;
 
 			return this;
 
@@ -26414,7 +25792,7 @@ var Spacekit = (function (exports) {
 			this.array = new source.array.constructor( source.array );
 			this.count = source.count;
 			this.stride = source.stride;
-			this.usage = source.usage;
+			this.dynamic = source.dynamic;
 
 			return this;
 
@@ -26465,8 +25843,6 @@ var Spacekit = (function (exports) {
 	 * @author benaadams / https://twitter.com/ben_a_adams
 	 */
 
-	var _vector$6 = new Vector3();
-
 	function InterleavedBufferAttribute( interleavedBuffer, itemSize, offset, normalized ) {
 
 		this.data = interleavedBuffer;
@@ -26504,24 +25880,6 @@ var Spacekit = (function (exports) {
 	Object.assign( InterleavedBufferAttribute.prototype, {
 
 		isInterleavedBufferAttribute: true,
-
-		applyMatrix4: function ( m ) {
-
-			for ( var i = 0, l = this.data.count; i < l; i ++ ) {
-
-				_vector$6.x = this.getX( i );
-				_vector$6.y = this.getY( i );
-				_vector$6.z = this.getZ( i );
-
-				_vector$6.applyMatrix4( m );
-
-				this.setXYZ( i, _vector$6.x, _vector$6.y, _vector$6.z );
-
-			}
-
-			return this;
-
-		},
 
 		setX: function ( index, x ) {
 
@@ -26623,7 +25981,6 @@ var Spacekit = (function (exports) {
 	 * parameters = {
 	 *  color: <hex>,
 	 *  map: new THREE.Texture( <Image> ),
-	 *  alphaMap: new THREE.Texture( <Image> ),
 	 *  rotation: <float>,
 	 *  sizeAttenuation: <bool>
 	 * }
@@ -26636,15 +25993,13 @@ var Spacekit = (function (exports) {
 		this.type = 'SpriteMaterial';
 
 		this.color = new Color( 0xffffff );
-
 		this.map = null;
-
-		this.alphaMap = null;
 
 		this.rotation = 0;
 
 		this.sizeAttenuation = true;
 
+		this.lights = false;
 		this.transparent = true;
 
 		this.setValues( parameters );
@@ -26660,10 +26015,7 @@ var Spacekit = (function (exports) {
 		Material.prototype.copy.call( this, source );
 
 		this.color.copy( source.color );
-
 		this.map = source.map;
-
-		this.alphaMap = source.alphaMap;
 
 		this.rotation = source.rotation;
 
@@ -26678,23 +26030,7 @@ var Spacekit = (function (exports) {
 	 * @author alteredq / http://alteredqualia.com/
 	 */
 
-	var _geometry;
-
-	var _intersectPoint = new Vector3();
-	var _worldScale = new Vector3();
-	var _mvPosition = new Vector3();
-
-	var _alignedPosition = new Vector2();
-	var _rotatedPosition = new Vector2();
-	var _viewWorldMatrix = new Matrix4();
-
-	var _vA$1 = new Vector3();
-	var _vB$1 = new Vector3();
-	var _vC$1 = new Vector3();
-
-	var _uvA$1 = new Vector2();
-	var _uvB$1 = new Vector2();
-	var _uvC$1 = new Vector2();
+	var geometry;
 
 	function Sprite( material ) {
 
@@ -26702,9 +26038,9 @@ var Spacekit = (function (exports) {
 
 		this.type = 'Sprite';
 
-		if ( _geometry === undefined ) {
+		if ( geometry === undefined ) {
 
-			_geometry = new BufferGeometry();
+			geometry = new BufferGeometry();
 
 			var float32Array = new Float32Array( [
 				- 0.5, - 0.5, 0, 0, 0,
@@ -26715,13 +26051,13 @@ var Spacekit = (function (exports) {
 
 			var interleavedBuffer = new InterleavedBuffer( float32Array, 5 );
 
-			_geometry.setIndex( [ 0, 1, 2,	0, 2, 3 ] );
-			_geometry.setAttribute( 'position', new InterleavedBufferAttribute( interleavedBuffer, 3, 0, false ) );
-			_geometry.setAttribute( 'uv', new InterleavedBufferAttribute( interleavedBuffer, 2, 3, false ) );
+			geometry.setIndex( [ 0, 1, 2,	0, 2, 3 ] );
+			geometry.addAttribute( 'position', new InterleavedBufferAttribute( interleavedBuffer, 3, 0, false ) );
+			geometry.addAttribute( 'uv', new InterleavedBufferAttribute( interleavedBuffer, 2, 3, false ) );
 
 		}
 
-		this.geometry = _geometry;
+		this.geometry = geometry;
 		this.material = ( material !== undefined ) ? material : new SpriteMaterial();
 
 		this.center = new Vector2( 0.5, 0.5 );
@@ -26734,79 +26070,120 @@ var Spacekit = (function (exports) {
 
 		isSprite: true,
 
-		raycast: function ( raycaster, intersects ) {
+		raycast: ( function () {
 
-			if ( raycaster.camera === null ) {
+			var intersectPoint = new Vector3();
+			var worldScale = new Vector3();
+			var mvPosition = new Vector3();
 
-				console.error( 'THREE.Sprite: "Raycaster.camera" needs to be set in order to raycast against sprites.' );
+			var alignedPosition = new Vector2();
+			var rotatedPosition = new Vector2();
+			var viewWorldMatrix = new Matrix4();
 
-			}
+			var vA = new Vector3();
+			var vB = new Vector3();
+			var vC = new Vector3();
 
-			_worldScale.setFromMatrixScale( this.matrixWorld );
+			var uvA = new Vector2();
+			var uvB = new Vector2();
+			var uvC = new Vector2();
 
-			_viewWorldMatrix.copy( raycaster.camera.matrixWorld );
-			this.modelViewMatrix.multiplyMatrices( raycaster.camera.matrixWorldInverse, this.matrixWorld );
+			function transformVertex( vertexPosition, mvPosition, center, scale, sin, cos ) {
 
-			_mvPosition.setFromMatrixPosition( this.modelViewMatrix );
+				// compute position in camera space
+				alignedPosition.subVectors( vertexPosition, center ).addScalar( 0.5 ).multiply( scale );
 
-			if ( raycaster.camera.isPerspectiveCamera && this.material.sizeAttenuation === false ) {
+				// to check if rotation is not zero
+				if ( sin !== undefined ) {
 
-				_worldScale.multiplyScalar( - _mvPosition.z );
+					rotatedPosition.x = ( cos * alignedPosition.x ) - ( sin * alignedPosition.y );
+					rotatedPosition.y = ( sin * alignedPosition.x ) + ( cos * alignedPosition.y );
 
-			}
+				} else {
 
-			var rotation = this.material.rotation;
-			var sin, cos;
-			if ( rotation !== 0 ) {
-
-				cos = Math.cos( rotation );
-				sin = Math.sin( rotation );
-
-			}
-
-			var center = this.center;
-
-			transformVertex( _vA$1.set( - 0.5, - 0.5, 0 ), _mvPosition, center, _worldScale, sin, cos );
-			transformVertex( _vB$1.set( 0.5, - 0.5, 0 ), _mvPosition, center, _worldScale, sin, cos );
-			transformVertex( _vC$1.set( 0.5, 0.5, 0 ), _mvPosition, center, _worldScale, sin, cos );
-
-			_uvA$1.set( 0, 0 );
-			_uvB$1.set( 1, 0 );
-			_uvC$1.set( 1, 1 );
-
-			// check first triangle
-			var intersect = raycaster.ray.intersectTriangle( _vA$1, _vB$1, _vC$1, false, _intersectPoint );
-
-			if ( intersect === null ) {
-
-				// check second triangle
-				transformVertex( _vB$1.set( - 0.5, 0.5, 0 ), _mvPosition, center, _worldScale, sin, cos );
-				_uvB$1.set( 0, 1 );
-
-				intersect = raycaster.ray.intersectTriangle( _vA$1, _vC$1, _vB$1, false, _intersectPoint );
-				if ( intersect === null ) {
-
-					return;
+					rotatedPosition.copy( alignedPosition );
 
 				}
 
+
+				vertexPosition.copy( mvPosition );
+				vertexPosition.x += rotatedPosition.x;
+				vertexPosition.y += rotatedPosition.y;
+
+				// transform to world space
+				vertexPosition.applyMatrix4( viewWorldMatrix );
+
 			}
 
-			var distance = raycaster.ray.origin.distanceTo( _intersectPoint );
+			return function raycast( raycaster, intersects ) {
 
-			if ( distance < raycaster.near || distance > raycaster.far ) return;
+				worldScale.setFromMatrixScale( this.matrixWorld );
 
-			intersects.push( {
+				viewWorldMatrix.copy( raycaster._camera.matrixWorld );
+				this.modelViewMatrix.multiplyMatrices( raycaster._camera.matrixWorldInverse, this.matrixWorld );
 
-				distance: distance,
-				point: _intersectPoint.clone(),
-				uv: Triangle.getUV( _intersectPoint, _vA$1, _vB$1, _vC$1, _uvA$1, _uvB$1, _uvC$1, new Vector2() ),
-				face: null,
-				object: this
+				mvPosition.setFromMatrixPosition( this.modelViewMatrix );
 
-			} );
+				if ( raycaster._camera.isPerspectiveCamera && this.material.sizeAttenuation === false ) {
 
-		},
+					worldScale.multiplyScalar( - mvPosition.z );
+
+				}
+
+				var rotation = this.material.rotation;
+				var sin, cos;
+				if ( rotation !== 0 ) {
+
+					cos = Math.cos( rotation );
+					sin = Math.sin( rotation );
+
+				}
+
+				var center = this.center;
+
+				transformVertex( vA.set( - 0.5, - 0.5, 0 ), mvPosition, center, worldScale, sin, cos );
+				transformVertex( vB.set( 0.5, - 0.5, 0 ), mvPosition, center, worldScale, sin, cos );
+				transformVertex( vC.set( 0.5, 0.5, 0 ), mvPosition, center, worldScale, sin, cos );
+
+				uvA.set( 0, 0 );
+				uvB.set( 1, 0 );
+				uvC.set( 1, 1 );
+
+				// check first triangle
+				var intersect = raycaster.ray.intersectTriangle( vA, vB, vC, false, intersectPoint );
+
+				if ( intersect === null ) {
+
+					// check second triangle
+					transformVertex( vB.set( - 0.5, 0.5, 0 ), mvPosition, center, worldScale, sin, cos );
+					uvB.set( 0, 1 );
+
+					intersect = raycaster.ray.intersectTriangle( vA, vC, vB, false, intersectPoint );
+					if ( intersect === null ) {
+
+						return;
+
+					}
+
+				}
+
+				var distance = raycaster.ray.origin.distanceTo( intersectPoint );
+
+				if ( distance < raycaster.near || distance > raycaster.far ) return;
+
+				intersects.push( {
+
+					distance: distance,
+					point: intersectPoint.clone(),
+					uv: Triangle.getUV( intersectPoint, vA, vB, vC, uvA, uvB, uvC, new Vector2() ),
+					face: null,
+					object: this
+
+				} );
+
+			};
+
+		}() ),
 
 		clone: function () {
 
@@ -26827,47 +26204,15 @@ var Spacekit = (function (exports) {
 
 	} );
 
-	function transformVertex( vertexPosition, mvPosition, center, scale, sin, cos ) {
-
-		// compute position in camera space
-		_alignedPosition.subVectors( vertexPosition, center ).addScalar( 0.5 ).multiply( scale );
-
-		// to check if rotation is not zero
-		if ( sin !== undefined ) {
-
-			_rotatedPosition.x = ( cos * _alignedPosition.x ) - ( sin * _alignedPosition.y );
-			_rotatedPosition.y = ( sin * _alignedPosition.x ) + ( cos * _alignedPosition.y );
-
-		} else {
-
-			_rotatedPosition.copy( _alignedPosition );
-
-		}
-
-
-		vertexPosition.copy( mvPosition );
-		vertexPosition.x += _rotatedPosition.x;
-		vertexPosition.y += _rotatedPosition.y;
-
-		// transform to world space
-		vertexPosition.applyMatrix4( _viewWorldMatrix );
-
-	}
-
 	/**
 	 * @author mikael emtinger / http://gomo.se/
 	 * @author alteredq / http://alteredqualia.com/
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-	var _v1$4 = new Vector3();
-	var _v2$2 = new Vector3();
-
 	function LOD() {
 
 		Object3D.call( this );
-
-		this._currentLevel = 0;
 
 		this.type = 'LOD';
 
@@ -26902,8 +26247,6 @@ var Spacekit = (function (exports) {
 
 			}
 
-			this.autoUpdate = source.autoUpdate;
-
 			return this;
 
 		},
@@ -26934,97 +26277,88 @@ var Spacekit = (function (exports) {
 
 		},
 
-		getCurrentLevel: function () {
-
-			return this._currentLevel;
-
-		},
-
 		getObjectForDistance: function ( distance ) {
 
 			var levels = this.levels;
 
-			if ( levels.length > 0 ) {
+			for ( var i = 1, l = levels.length; i < l; i ++ ) {
 
-				for ( var i = 1, l = levels.length; i < l; i ++ ) {
+				if ( distance < levels[ i ].distance ) {
 
-					if ( distance < levels[ i ].distance ) {
-
-						break;
-
-					}
+					break;
 
 				}
 
-				return levels[ i - 1 ].object;
-
 			}
 
-			return null;
+			return levels[ i - 1 ].object;
 
 		},
 
-		raycast: function ( raycaster, intersects ) {
+		raycast: ( function () {
 
-			var levels = this.levels;
+			var matrixPosition = new Vector3();
 
-			if ( levels.length > 0 ) {
+			return function raycast( raycaster, intersects ) {
 
-				_v1$4.setFromMatrixPosition( this.matrixWorld );
+				matrixPosition.setFromMatrixPosition( this.matrixWorld );
 
-				var distance = raycaster.ray.origin.distanceTo( _v1$4 );
+				var distance = raycaster.ray.origin.distanceTo( matrixPosition );
 
 				this.getObjectForDistance( distance ).raycast( raycaster, intersects );
 
-			}
+			};
 
-		},
+		}() ),
 
-		update: function ( camera ) {
+		update: function () {
 
-			var levels = this.levels;
+			var v1 = new Vector3();
+			var v2 = new Vector3();
 
-			if ( levels.length > 1 ) {
+			return function update( camera ) {
 
-				_v1$4.setFromMatrixPosition( camera.matrixWorld );
-				_v2$2.setFromMatrixPosition( this.matrixWorld );
+				var levels = this.levels;
 
-				var distance = _v1$4.distanceTo( _v2$2 ) / camera.zoom;
+				if ( levels.length > 1 ) {
 
-				levels[ 0 ].object.visible = true;
+					v1.setFromMatrixPosition( camera.matrixWorld );
+					v2.setFromMatrixPosition( this.matrixWorld );
 
-				for ( var i = 1, l = levels.length; i < l; i ++ ) {
+					var distance = v1.distanceTo( v2 );
 
-					if ( distance >= levels[ i ].distance ) {
+					levels[ 0 ].object.visible = true;
 
-						levels[ i - 1 ].object.visible = false;
-						levels[ i ].object.visible = true;
+					for ( var i = 1, l = levels.length; i < l; i ++ ) {
 
-					} else {
+						if ( distance >= levels[ i ].distance ) {
 
-						break;
+							levels[ i - 1 ].object.visible = false;
+							levels[ i ].object.visible = true;
+
+						} else {
+
+							break;
+
+						}
+
+					}
+
+					for ( ; i < l; i ++ ) {
+
+						levels[ i ].object.visible = false;
 
 					}
 
 				}
 
-				this._currentLevel = i - 1;
+			};
 
-				for ( ; i < l; i ++ ) {
-
-					levels[ i ].object.visible = false;
-
-				}
-
-			}
-
-		},
+		}(),
 
 		toJSON: function ( meta ) {
 
 			var data = Object3D.prototype.toJSON.call( this, meta );
-
-			if ( this.autoUpdate === false ) data.object.autoUpdate = false;
 
 			data.object.levels = [];
 
@@ -27157,51 +26491,7 @@ var Spacekit = (function (exports) {
 
 			return new this.constructor( this.geometry, this.material ).copy( this );
 
-		},
-
-		boneTransform: ( function () {
-
-			var basePosition = new Vector3();
-
-			var skinIndex = new Vector4();
-			var skinWeight = new Vector4();
-
-			var vector = new Vector3();
-			var matrix = new Matrix4();
-
-			return function ( index, target ) {
-
-				var skeleton = this.skeleton;
-				var geometry = this.geometry;
-
-				skinIndex.fromBufferAttribute( geometry.attributes.skinIndex, index );
-				skinWeight.fromBufferAttribute( geometry.attributes.skinWeight, index );
-
-				basePosition.fromBufferAttribute( geometry.attributes.position, index ).applyMatrix4( this.bindMatrix );
-
-				target.set( 0, 0, 0 );
-
-				for ( var i = 0; i < 4; i ++ ) {
-
-					var weight = skinWeight.getComponent( i );
-
-					if ( weight !== 0 ) {
-
-						var boneIndex = skinIndex.getComponent( i );
-
-						matrix.multiplyMatrices( skeleton.bones[ boneIndex ].matrixWorld, skeleton.boneInverses[ boneIndex ] );
-
-						target.addScaledVector( vector.copy( basePosition ).applyMatrix4( matrix ), weight );
-
-					}
-
-				}
-
-				return target.applyMatrix4( this.bindMatrixInverse );
-
-			};
-
-		}() )
+		}
 
 	} );
 
@@ -27212,9 +26502,6 @@ var Spacekit = (function (exports) {
 	 * @author ikerr / http://verold.com
 	 */
 
-	var _offsetMatrix = new Matrix4();
-	var _identityMatrix = new Matrix4();
-
 	function Skeleton( bones, boneInverses ) {
 
 		// copy the bone array
@@ -27223,8 +26510,6 @@ var Spacekit = (function (exports) {
 
 		this.bones = bones.slice( 0 );
 		this.boneMatrices = new Float32Array( this.bones.length * 16 );
-
-		this.frame = - 1;
 
 		// use the supplied bone inverses or calculate the inverses
 
@@ -27323,33 +26608,40 @@ var Spacekit = (function (exports) {
 
 		},
 
-		update: function () {
+		update: ( function () {
 
-			var bones = this.bones;
-			var boneInverses = this.boneInverses;
-			var boneMatrices = this.boneMatrices;
-			var boneTexture = this.boneTexture;
+			var offsetMatrix = new Matrix4();
+			var identityMatrix = new Matrix4();
 
-			// flatten bone matrices to array
+			return function update() {
 
-			for ( var i = 0, il = bones.length; i < il; i ++ ) {
+				var bones = this.bones;
+				var boneInverses = this.boneInverses;
+				var boneMatrices = this.boneMatrices;
+				var boneTexture = this.boneTexture;
 
-				// compute the offset between the current and the original transform
+				// flatten bone matrices to array
 
-				var matrix = bones[ i ] ? bones[ i ].matrixWorld : _identityMatrix;
+				for ( var i = 0, il = bones.length; i < il; i ++ ) {
 
-				_offsetMatrix.multiplyMatrices( matrix, boneInverses[ i ] );
-				_offsetMatrix.toArray( boneMatrices, i * 16 );
+					// compute the offset between the current and the original transform
 
-			}
+					var matrix = bones[ i ] ? bones[ i ].matrixWorld : identityMatrix;
 
-			if ( boneTexture !== undefined ) {
+					offsetMatrix.multiplyMatrices( matrix, boneInverses[ i ] );
+					offsetMatrix.toArray( boneMatrices, i * 16 );
 
-				boneTexture.needsUpdate = true;
+				}
 
-			}
+				if ( boneTexture !== undefined ) {
 
-		},
+					boneTexture.needsUpdate = true;
+
+				}
+
+			};
+
+		} )(),
 
 		clone: function () {
 
@@ -27372,18 +26664,6 @@ var Spacekit = (function (exports) {
 			}
 
 			return undefined;
-
-		},
-
-		dispose: function ( ) {
-
-			if ( this.boneTexture ) {
-
-				this.boneTexture.dispose();
-
-				this.boneTexture = undefined;
-
-			}
 
 		}
 
@@ -27413,94 +26693,6 @@ var Spacekit = (function (exports) {
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
-	 */
-
-	var _instanceLocalMatrix = new Matrix4();
-	var _instanceWorldMatrix = new Matrix4();
-
-	var _instanceIntersects = [];
-
-	var _mesh = new Mesh();
-
-	function InstancedMesh( geometry, material, count ) {
-
-		Mesh.call( this, geometry, material );
-
-		this.instanceMatrix = new BufferAttribute( new Float32Array( count * 16 ), 16 );
-
-		this.count = count;
-
-		this.frustumCulled = false;
-
-	}
-
-	InstancedMesh.prototype = Object.assign( Object.create( Mesh.prototype ), {
-
-		constructor: InstancedMesh,
-
-		isInstancedMesh: true,
-
-		getMatrixAt: function ( index, matrix ) {
-
-			matrix.fromArray( this.instanceMatrix.array, index * 16 );
-
-		},
-
-		raycast: function ( raycaster, intersects ) {
-
-			var matrixWorld = this.matrixWorld;
-			var raycastTimes = this.count;
-
-			_mesh.geometry = this.geometry;
-			_mesh.material = this.material;
-
-			if ( _mesh.material === undefined ) return;
-
-			for ( var instanceId = 0; instanceId < raycastTimes; instanceId ++ ) {
-
-				// calculate the world matrix for each instance
-
-				this.getMatrixAt( instanceId, _instanceLocalMatrix );
-
-				_instanceWorldMatrix.multiplyMatrices( matrixWorld, _instanceLocalMatrix );
-
-				// the mesh represents this single instance
-
-				_mesh.matrixWorld = _instanceWorldMatrix;
-
-				_mesh.raycast( raycaster, _instanceIntersects );
-
-				// process the result of raycast
-
-				for ( var i = 0, l = _instanceIntersects.length; i < l; i ++ ) {
-
-					var intersect = _instanceIntersects[ i ];
-					intersect.instanceId = instanceId;
-					intersect.object = this;
-					intersects.push( intersect );
-
-				}
-
-				_instanceIntersects.length = 0;
-
-			}
-
-		},
-
-		setMatrixAt: function ( index, matrix ) {
-
-			matrix.toArray( this.instanceMatrix.array, index * 16 );
-
-		},
-
-		updateMorphTargets: function () {
-
-		}
-
-	} );
-
-	/**
-	 * @author mrdoob / http://mrdoob.com/
 	 * @author alteredq / http://alteredqualia.com/
 	 *
 	 * parameters = {
@@ -27524,6 +26716,8 @@ var Spacekit = (function (exports) {
 		this.linewidth = 1;
 		this.linecap = 'round';
 		this.linejoin = 'round';
+
+		this.lights = false;
 
 		this.setValues( parameters );
 
@@ -27552,12 +26746,6 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-	var _start = new Vector3();
-	var _end = new Vector3();
-	var _inverseMatrix$1 = new Matrix4();
-	var _ray$1 = new Ray();
-	var _sphere$2 = new Sphere();
-
 	function Line( geometry, material, mode ) {
 
 		if ( mode === 1 ) {
@@ -27571,7 +26759,7 @@ var Spacekit = (function (exports) {
 		this.type = 'Line';
 
 		this.geometry = geometry !== undefined ? geometry : new BufferGeometry();
-		this.material = material !== undefined ? material : new LineBasicMaterial();
+		this.material = material !== undefined ? material : new LineBasicMaterial( { color: Math.random() * 0xffffff } );
 
 	}
 
@@ -27581,108 +26769,188 @@ var Spacekit = (function (exports) {
 
 		isLine: true,
 
-		computeLineDistances: function () {
+		computeLineDistances: ( function () {
 
-			var geometry = this.geometry;
+			var start = new Vector3();
+			var end = new Vector3();
 
-			if ( geometry.isBufferGeometry ) {
+			return function computeLineDistances() {
 
-				// we assume non-indexed geometry
+				var geometry = this.geometry;
 
-				if ( geometry.index === null ) {
+				if ( geometry.isBufferGeometry ) {
 
-					var positionAttribute = geometry.attributes.position;
-					var lineDistances = [ 0 ];
+					// we assume non-indexed geometry
 
-					for ( var i = 1, l = positionAttribute.count; i < l; i ++ ) {
+					if ( geometry.index === null ) {
 
-						_start.fromBufferAttribute( positionAttribute, i - 1 );
-						_end.fromBufferAttribute( positionAttribute, i );
+						var positionAttribute = geometry.attributes.position;
+						var lineDistances = [ 0 ];
+
+						for ( var i = 1, l = positionAttribute.count; i < l; i ++ ) {
+
+							start.fromBufferAttribute( positionAttribute, i - 1 );
+							end.fromBufferAttribute( positionAttribute, i );
+
+							lineDistances[ i ] = lineDistances[ i - 1 ];
+							lineDistances[ i ] += start.distanceTo( end );
+
+						}
+
+						geometry.addAttribute( 'lineDistance', new Float32BufferAttribute( lineDistances, 1 ) );
+
+					} else {
+
+						console.warn( 'THREE.Line.computeLineDistances(): Computation only possible with non-indexed BufferGeometry.' );
+
+					}
+
+				} else if ( geometry.isGeometry ) {
+
+					var vertices = geometry.vertices;
+					var lineDistances = geometry.lineDistances;
+
+					lineDistances[ 0 ] = 0;
+
+					for ( var i = 1, l = vertices.length; i < l; i ++ ) {
 
 						lineDistances[ i ] = lineDistances[ i - 1 ];
-						lineDistances[ i ] += _start.distanceTo( _end );
+						lineDistances[ i ] += vertices[ i - 1 ].distanceTo( vertices[ i ] );
 
 					}
 
-					geometry.setAttribute( 'lineDistance', new Float32BufferAttribute( lineDistances, 1 ) );
-
-				} else {
-
-					console.warn( 'THREE.Line.computeLineDistances(): Computation only possible with non-indexed BufferGeometry.' );
-
 				}
 
-			} else if ( geometry.isGeometry ) {
+				return this;
 
-				var vertices = geometry.vertices;
-				var lineDistances = geometry.lineDistances;
+			};
 
-				lineDistances[ 0 ] = 0;
+		}() ),
 
-				for ( var i = 1, l = vertices.length; i < l; i ++ ) {
+		raycast: ( function () {
 
-					lineDistances[ i ] = lineDistances[ i - 1 ];
-					lineDistances[ i ] += vertices[ i - 1 ].distanceTo( vertices[ i ] );
+			var inverseMatrix = new Matrix4();
+			var ray = new Ray();
+			var sphere = new Sphere();
 
-				}
+			return function raycast( raycaster, intersects ) {
 
-			}
+				var precision = raycaster.linePrecision;
 
-			return this;
+				var geometry = this.geometry;
+				var matrixWorld = this.matrixWorld;
 
-		},
+				// Checking boundingSphere distance to ray
 
-		raycast: function ( raycaster, intersects ) {
+				if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
 
-			var geometry = this.geometry;
-			var matrixWorld = this.matrixWorld;
-			var threshold = raycaster.params.Line.threshold;
+				sphere.copy( geometry.boundingSphere );
+				sphere.applyMatrix4( matrixWorld );
+				sphere.radius += precision;
 
-			// Checking boundingSphere distance to ray
+				if ( raycaster.ray.intersectsSphere( sphere ) === false ) return;
 
-			if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
+				//
 
-			_sphere$2.copy( geometry.boundingSphere );
-			_sphere$2.applyMatrix4( matrixWorld );
-			_sphere$2.radius += threshold;
+				inverseMatrix.getInverse( matrixWorld );
+				ray.copy( raycaster.ray ).applyMatrix4( inverseMatrix );
 
-			if ( raycaster.ray.intersectsSphere( _sphere$2 ) === false ) return;
+				var localPrecision = precision / ( ( this.scale.x + this.scale.y + this.scale.z ) / 3 );
+				var localPrecisionSq = localPrecision * localPrecision;
 
-			//
+				var vStart = new Vector3();
+				var vEnd = new Vector3();
+				var interSegment = new Vector3();
+				var interRay = new Vector3();
+				var step = ( this && this.isLineSegments ) ? 2 : 1;
 
-			_inverseMatrix$1.getInverse( matrixWorld );
-			_ray$1.copy( raycaster.ray ).applyMatrix4( _inverseMatrix$1 );
+				if ( geometry.isBufferGeometry ) {
 
-			var localThreshold = threshold / ( ( this.scale.x + this.scale.y + this.scale.z ) / 3 );
-			var localThresholdSq = localThreshold * localThreshold;
+					var index = geometry.index;
+					var attributes = geometry.attributes;
+					var positions = attributes.position.array;
 
-			var vStart = new Vector3();
-			var vEnd = new Vector3();
-			var interSegment = new Vector3();
-			var interRay = new Vector3();
-			var step = ( this && this.isLineSegments ) ? 2 : 1;
+					if ( index !== null ) {
 
-			if ( geometry.isBufferGeometry ) {
+						var indices = index.array;
 
-				var index = geometry.index;
-				var attributes = geometry.attributes;
-				var positions = attributes.position.array;
+						for ( var i = 0, l = indices.length - 1; i < l; i += step ) {
 
-				if ( index !== null ) {
+							var a = indices[ i ];
+							var b = indices[ i + 1 ];
 
-					var indices = index.array;
+							vStart.fromArray( positions, a * 3 );
+							vEnd.fromArray( positions, b * 3 );
 
-					for ( var i = 0, l = indices.length - 1; i < l; i += step ) {
+							var distSq = ray.distanceSqToSegment( vStart, vEnd, interRay, interSegment );
 
-						var a = indices[ i ];
-						var b = indices[ i + 1 ];
+							if ( distSq > localPrecisionSq ) continue;
 
-						vStart.fromArray( positions, a * 3 );
-						vEnd.fromArray( positions, b * 3 );
+							interRay.applyMatrix4( this.matrixWorld ); //Move back to world space for distance calculation
 
-						var distSq = _ray$1.distanceSqToSegment( vStart, vEnd, interRay, interSegment );
+							var distance = raycaster.ray.origin.distanceTo( interRay );
 
-						if ( distSq > localThresholdSq ) continue;
+							if ( distance < raycaster.near || distance > raycaster.far ) continue;
+
+							intersects.push( {
+
+								distance: distance,
+								// What do we want? intersection point on the ray or on the segment??
+								// point: raycaster.ray.at( distance ),
+								point: interSegment.clone().applyMatrix4( this.matrixWorld ),
+								index: i,
+								face: null,
+								faceIndex: null,
+								object: this
+
+							} );
+
+						}
+
+					} else {
+
+						for ( var i = 0, l = positions.length / 3 - 1; i < l; i += step ) {
+
+							vStart.fromArray( positions, 3 * i );
+							vEnd.fromArray( positions, 3 * i + 3 );
+
+							var distSq = ray.distanceSqToSegment( vStart, vEnd, interRay, interSegment );
+
+							if ( distSq > localPrecisionSq ) continue;
+
+							interRay.applyMatrix4( this.matrixWorld ); //Move back to world space for distance calculation
+
+							var distance = raycaster.ray.origin.distanceTo( interRay );
+
+							if ( distance < raycaster.near || distance > raycaster.far ) continue;
+
+							intersects.push( {
+
+								distance: distance,
+								// What do we want? intersection point on the ray or on the segment??
+								// point: raycaster.ray.at( distance ),
+								point: interSegment.clone().applyMatrix4( this.matrixWorld ),
+								index: i,
+								face: null,
+								faceIndex: null,
+								object: this
+
+							} );
+
+						}
+
+					}
+
+				} else if ( geometry.isGeometry ) {
+
+					var vertices = geometry.vertices;
+					var nbVertices = vertices.length;
+
+					for ( var i = 0; i < nbVertices - 1; i += step ) {
+
+						var distSq = ray.distanceSqToSegment( vertices[ i ], vertices[ i + 1 ], interRay, interSegment );
+
+						if ( distSq > localPrecisionSq ) continue;
 
 						interRay.applyMatrix4( this.matrixWorld ); //Move back to world space for distance calculation
 
@@ -27705,75 +26973,11 @@ var Spacekit = (function (exports) {
 
 					}
 
-				} else {
-
-					for ( var i = 0, l = positions.length / 3 - 1; i < l; i += step ) {
-
-						vStart.fromArray( positions, 3 * i );
-						vEnd.fromArray( positions, 3 * i + 3 );
-
-						var distSq = _ray$1.distanceSqToSegment( vStart, vEnd, interRay, interSegment );
-
-						if ( distSq > localThresholdSq ) continue;
-
-						interRay.applyMatrix4( this.matrixWorld ); //Move back to world space for distance calculation
-
-						var distance = raycaster.ray.origin.distanceTo( interRay );
-
-						if ( distance < raycaster.near || distance > raycaster.far ) continue;
-
-						intersects.push( {
-
-							distance: distance,
-							// What do we want? intersection point on the ray or on the segment??
-							// point: raycaster.ray.at( distance ),
-							point: interSegment.clone().applyMatrix4( this.matrixWorld ),
-							index: i,
-							face: null,
-							faceIndex: null,
-							object: this
-
-						} );
-
-					}
-
 				}
 
-			} else if ( geometry.isGeometry ) {
+			};
 
-				var vertices = geometry.vertices;
-				var nbVertices = vertices.length;
-
-				for ( var i = 0; i < nbVertices - 1; i += step ) {
-
-					var distSq = _ray$1.distanceSqToSegment( vertices[ i ], vertices[ i + 1 ], interRay, interSegment );
-
-					if ( distSq > localThresholdSq ) continue;
-
-					interRay.applyMatrix4( this.matrixWorld ); //Move back to world space for distance calculation
-
-					var distance = raycaster.ray.origin.distanceTo( interRay );
-
-					if ( distance < raycaster.near || distance > raycaster.far ) continue;
-
-					intersects.push( {
-
-						distance: distance,
-						// What do we want? intersection point on the ray or on the segment??
-						// point: raycaster.ray.at( distance ),
-						point: interSegment.clone().applyMatrix4( this.matrixWorld ),
-						index: i,
-						face: null,
-						faceIndex: null,
-						object: this
-
-					} );
-
-				}
-
-			}
-
-		},
+		}() ),
 
 		clone: function () {
 
@@ -27786,9 +26990,6 @@ var Spacekit = (function (exports) {
 	/**
 	 * @author mrdoob / http://mrdoob.com/
 	 */
-
-	var _start$1 = new Vector3();
-	var _end$1 = new Vector3();
 
 	function LineSegments( geometry, material ) {
 
@@ -27804,57 +27005,64 @@ var Spacekit = (function (exports) {
 
 		isLineSegments: true,
 
-		computeLineDistances: function () {
+		computeLineDistances: ( function () {
 
-			var geometry = this.geometry;
+			var start = new Vector3();
+			var end = new Vector3();
 
-			if ( geometry.isBufferGeometry ) {
+			return function computeLineDistances() {
 
-				// we assume non-indexed geometry
+				var geometry = this.geometry;
 
-				if ( geometry.index === null ) {
+				if ( geometry.isBufferGeometry ) {
 
-					var positionAttribute = geometry.attributes.position;
-					var lineDistances = [];
+					// we assume non-indexed geometry
 
-					for ( var i = 0, l = positionAttribute.count; i < l; i += 2 ) {
+					if ( geometry.index === null ) {
 
-						_start$1.fromBufferAttribute( positionAttribute, i );
-						_end$1.fromBufferAttribute( positionAttribute, i + 1 );
+						var positionAttribute = geometry.attributes.position;
+						var lineDistances = [];
 
-						lineDistances[ i ] = ( i === 0 ) ? 0 : lineDistances[ i - 1 ];
-						lineDistances[ i + 1 ] = lineDistances[ i ] + _start$1.distanceTo( _end$1 );
+						for ( var i = 0, l = positionAttribute.count; i < l; i += 2 ) {
+
+							start.fromBufferAttribute( positionAttribute, i );
+							end.fromBufferAttribute( positionAttribute, i + 1 );
+
+							lineDistances[ i ] = ( i === 0 ) ? 0 : lineDistances[ i - 1 ];
+							lineDistances[ i + 1 ] = lineDistances[ i ] + start.distanceTo( end );
+
+						}
+
+						geometry.addAttribute( 'lineDistance', new Float32BufferAttribute( lineDistances, 1 ) );
+
+					} else {
+
+						console.warn( 'THREE.LineSegments.computeLineDistances(): Computation only possible with non-indexed BufferGeometry.' );
 
 					}
 
-					geometry.setAttribute( 'lineDistance', new Float32BufferAttribute( lineDistances, 1 ) );
+				} else if ( geometry.isGeometry ) {
 
-				} else {
+					var vertices = geometry.vertices;
+					var lineDistances = geometry.lineDistances;
 
-					console.warn( 'THREE.LineSegments.computeLineDistances(): Computation only possible with non-indexed BufferGeometry.' );
+					for ( var i = 0, l = vertices.length; i < l; i += 2 ) {
 
-				}
+						start.copy( vertices[ i ] );
+						end.copy( vertices[ i + 1 ] );
 
-			} else if ( geometry.isGeometry ) {
+						lineDistances[ i ] = ( i === 0 ) ? 0 : lineDistances[ i - 1 ];
+						lineDistances[ i + 1 ] = lineDistances[ i ] + start.distanceTo( end );
 
-				var vertices = geometry.vertices;
-				var lineDistances = geometry.lineDistances;
-
-				for ( var i = 0, l = vertices.length; i < l; i += 2 ) {
-
-					_start$1.copy( vertices[ i ] );
-					_end$1.copy( vertices[ i + 1 ] );
-
-					lineDistances[ i ] = ( i === 0 ) ? 0 : lineDistances[ i - 1 ];
-					lineDistances[ i + 1 ] = lineDistances[ i ] + _start$1.distanceTo( _end$1 );
+					}
 
 				}
 
-			}
+				return this;
 
-			return this;
+			};
 
-		}
+		}() )
 
 	} );
 
@@ -27886,7 +27094,6 @@ var Spacekit = (function (exports) {
 	 *  color: <hex>,
 	 *  opacity: <float>,
 	 *  map: new THREE.Texture( <Image> ),
-	 *  alphaMap: new THREE.Texture( <Image> ),
 	 *
 	 *  size: <float>,
 	 *  sizeAttenuation: <bool>
@@ -27905,12 +27112,12 @@ var Spacekit = (function (exports) {
 
 		this.map = null;
 
-		this.alphaMap = null;
-
 		this.size = 1;
 		this.sizeAttenuation = true;
 
 		this.morphTargets = false;
+
+		this.lights = false;
 
 		this.setValues( parameters );
 
@@ -27929,8 +27136,6 @@ var Spacekit = (function (exports) {
 
 		this.map = source.map;
 
-		this.alphaMap = source.alphaMap;
-
 		this.size = source.size;
 		this.sizeAttenuation = source.sizeAttenuation;
 
@@ -27944,11 +27149,6 @@ var Spacekit = (function (exports) {
 	 * @author alteredq / http://alteredqualia.com/
 	 */
 
-	var _inverseMatrix$2 = new Matrix4();
-	var _ray$2 = new Ray();
-	var _sphere$3 = new Sphere();
-	var _position$1 = new Vector3();
-
 	function Points( geometry, material ) {
 
 		Object3D.call( this );
@@ -27956,7 +27156,7 @@ var Spacekit = (function (exports) {
 		this.type = 'Points';
 
 		this.geometry = geometry !== undefined ? geometry : new BufferGeometry();
-		this.material = material !== undefined ? material : new PointsMaterial();
+		this.material = material !== undefined ? material : new PointsMaterial( { color: Math.random() * 0xffffff } );
 
 		this.updateMorphTargets();
 
@@ -27968,75 +27168,114 @@ var Spacekit = (function (exports) {
 
 		isPoints: true,
 
-		raycast: function ( raycaster, intersects ) {
+		raycast: ( function () {
 
-			var geometry = this.geometry;
-			var matrixWorld = this.matrixWorld;
-			var threshold = raycaster.params.Points.threshold;
+			var inverseMatrix = new Matrix4();
+			var ray = new Ray();
+			var sphere = new Sphere();
 
-			// Checking boundingSphere distance to ray
+			return function raycast( raycaster, intersects ) {
 
-			if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
+				var object = this;
+				var geometry = this.geometry;
+				var matrixWorld = this.matrixWorld;
+				var threshold = raycaster.params.Points.threshold;
 
-			_sphere$3.copy( geometry.boundingSphere );
-			_sphere$3.applyMatrix4( matrixWorld );
-			_sphere$3.radius += threshold;
+				// Checking boundingSphere distance to ray
 
-			if ( raycaster.ray.intersectsSphere( _sphere$3 ) === false ) return;
+				if ( geometry.boundingSphere === null ) geometry.computeBoundingSphere();
 
-			//
+				sphere.copy( geometry.boundingSphere );
+				sphere.applyMatrix4( matrixWorld );
+				sphere.radius += threshold;
 
-			_inverseMatrix$2.getInverse( matrixWorld );
-			_ray$2.copy( raycaster.ray ).applyMatrix4( _inverseMatrix$2 );
+				if ( raycaster.ray.intersectsSphere( sphere ) === false ) return;
 
-			var localThreshold = threshold / ( ( this.scale.x + this.scale.y + this.scale.z ) / 3 );
-			var localThresholdSq = localThreshold * localThreshold;
+				//
 
-			if ( geometry.isBufferGeometry ) {
+				inverseMatrix.getInverse( matrixWorld );
+				ray.copy( raycaster.ray ).applyMatrix4( inverseMatrix );
 
-				var index = geometry.index;
-				var attributes = geometry.attributes;
-				var positions = attributes.position.array;
+				var localThreshold = threshold / ( ( this.scale.x + this.scale.y + this.scale.z ) / 3 );
+				var localThresholdSq = localThreshold * localThreshold;
+				var position = new Vector3();
+				var intersectPoint = new Vector3();
 
-				if ( index !== null ) {
+				function testPoint( point, index ) {
 
-					var indices = index.array;
+					var rayPointDistanceSq = ray.distanceSqToPoint( point );
 
-					for ( var i = 0, il = indices.length; i < il; i ++ ) {
+					if ( rayPointDistanceSq < localThresholdSq ) {
 
-						var a = indices[ i ];
+						ray.closestPointToPoint( point, intersectPoint );
+						intersectPoint.applyMatrix4( matrixWorld );
 
-						_position$1.fromArray( positions, a * 3 );
+						var distance = raycaster.ray.origin.distanceTo( intersectPoint );
 
-						testPoint( _position$1, a, localThresholdSq, matrixWorld, raycaster, intersects, this );
+						if ( distance < raycaster.near || distance > raycaster.far ) return;
+
+						intersects.push( {
+
+							distance: distance,
+							distanceToRay: Math.sqrt( rayPointDistanceSq ),
+							point: intersectPoint.clone(),
+							index: index,
+							face: null,
+							object: object
+
+						} );
+
+					}
+
+				}
+
+				if ( geometry.isBufferGeometry ) {
+
+					var index = geometry.index;
+					var attributes = geometry.attributes;
+					var positions = attributes.position.array;
+
+					if ( index !== null ) {
+
+						var indices = index.array;
+
+						for ( var i = 0, il = indices.length; i < il; i ++ ) {
+
+							var a = indices[ i ];
+
+							position.fromArray( positions, a * 3 );
+
+							testPoint( position, a );
+
+						}
+
+					} else {
+
+						for ( var i = 0, l = positions.length / 3; i < l; i ++ ) {
+
+							position.fromArray( positions, i * 3 );
+
+							testPoint( position, i );
+
+						}
 
 					}
 
 				} else {
 
-					for ( var i = 0, l = positions.length / 3; i < l; i ++ ) {
+					var vertices = geometry.vertices;
 
-						_position$1.fromArray( positions, i * 3 );
+					for ( var i = 0, l = vertices.length; i < l; i ++ ) {
 
-						testPoint( _position$1, i, localThresholdSq, matrixWorld, raycaster, intersects, this );
+						testPoint( vertices[ i ], i );
 
 					}
 
 				}
 
-			} else {
+			};
 
-				var vertices = geometry.vertices;
-
-				for ( var i = 0, l = vertices.length; i < l; i ++ ) {
-
-					testPoint( vertices[ i ], i, localThresholdSq, matrixWorld, raycaster, intersects, this );
-
-				}
-
-			}
-
-		},
+		}() ),
 
 		updateMorphTargets: function () {
 
@@ -28091,36 +27330,6 @@ var Spacekit = (function (exports) {
 		}
 
 	} );
-
-	function testPoint( point, index, localThresholdSq, matrixWorld, raycaster, intersects, object ) {
-
-		var rayPointDistanceSq = _ray$2.distanceSqToPoint( point );
-
-		if ( rayPointDistanceSq < localThresholdSq ) {
-
-			var intersectPoint = new Vector3();
-
-			_ray$2.closestPointToPoint( point, intersectPoint );
-			intersectPoint.applyMatrix4( matrixWorld );
-
-			var distance = raycaster.ray.origin.distanceTo( intersectPoint );
-
-			if ( distance < raycaster.near || distance > raycaster.far ) return;
-
-			intersects.push( {
-
-				distance: distance,
-				distanceToRay: Math.sqrt( rayPointDistanceSq ),
-				point: intersectPoint,
-				index: index,
-				face: null,
-				object: object
-
-			} );
-
-		}
-
-	}
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -28403,7 +27612,7 @@ var Spacekit = (function (exports) {
 
 		// build geometry
 
-		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
 
 	}
 
@@ -28415,7 +27624,7 @@ var Spacekit = (function (exports) {
 	 * @author Mugen87 / https://github.com/Mugen87
 	 *
 	 * Parametric Surfaces Geometry
-	 * based on the brilliant article by @prideout https://prideout.net/blog/old/blog/index.html@p=44.html
+	 * based on the brilliant article by @prideout http://prideout.net/blog/?p=44
 	 */
 
 	// ParametricGeometry
@@ -28557,9 +27766,9 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	}
 
@@ -28633,9 +27842,9 @@ var Spacekit = (function (exports) {
 
 		// build non-indexed geometry
 
-		this.setAttribute( 'position', new Float32BufferAttribute( vertexBuffer, 3 ) );
-		this.setAttribute( 'normal', new Float32BufferAttribute( vertexBuffer.slice(), 3 ) );
-		this.setAttribute( 'uv', new Float32BufferAttribute( uvBuffer, 2 ) );
+		this.addAttribute( 'position', new Float32BufferAttribute( vertexBuffer, 3 ) );
+		this.addAttribute( 'normal', new Float32BufferAttribute( vertexBuffer.slice(), 3 ) );
+		this.addAttribute( 'uv', new Float32BufferAttribute( uvBuffer, 2 ) );
 
 		if ( detail === 0 ) {
 
@@ -29246,9 +28455,9 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 		// functions
 
@@ -29536,9 +28745,9 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 		// this function calculates the current position on the torus curve
 
@@ -29686,9 +28895,9 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	}
 
@@ -29697,7 +28906,7 @@ var Spacekit = (function (exports) {
 
 	/**
 	 * @author Mugen87 / https://github.com/Mugen87
-	 * Port from https://github.com/mapbox/earcut (v2.2.2)
+	 * Port from https://github.com/mapbox/earcut (v2.1.5)
 	 */
 
 	var Earcut = {
@@ -29853,7 +29062,7 @@ var Spacekit = (function (exports) {
 
 				} else if ( pass === 1 ) {
 
-					ear = cureLocalIntersections( filterPoints( ear ), triangles, dim );
+					ear = cureLocalIntersections( ear, triangles, dim );
 					earcutLinked( ear, triangles, dim, minX, minY, invSize, 2 );
 
 					// as a last resort, try splitting the remaining polygon into two
@@ -29983,7 +29192,7 @@ var Spacekit = (function (exports) {
 
 		} while ( p !== start );
 
-		return filterPoints( p );
+		return p;
 
 	}
 
@@ -30066,9 +29275,6 @@ var Spacekit = (function (exports) {
 		if ( outerNode ) {
 
 			var b = splitPolygon( outerNode, hole );
-
-			// filter collinear points around the cuts
-			filterPoints( outerNode, outerNode.next );
 			filterPoints( b, b.next );
 
 		}
@@ -30113,7 +29319,7 @@ var Spacekit = (function (exports) {
 
 		if ( ! m ) return null;
 
-		if ( hx === qx ) return m; // hole touches outer segment; pick leftmost endpoint
+		if ( hx === qx ) return m.prev; // hole touches outer segment; pick lower endpoint
 
 		// look for points inside the triangle of hole point, segment intersection and endpoint;
 		// if there are no points found, we have a valid connection;
@@ -30125,16 +29331,16 @@ var Spacekit = (function (exports) {
 			tanMin = Infinity,
 			tan;
 
-		p = m;
+		p = m.next;
 
-		do {
+		while ( p !== stop ) {
 
 			if ( hx >= p.x && p.x >= mx && hx !== p.x &&
 					pointInTriangle( hy < my ? hx : qx, hy, mx, my, hy < my ? qx : hx, hy, p.x, p.y ) ) {
 
 				tan = Math.abs( hy - p.y ) / ( hx - p.x ); // tangential
 
-				if ( locallyInside( p, hole ) && ( tan < tanMin || ( tan === tanMin && ( p.x > m.x || ( p.x === m.x && sectorContainsSector( m, p ) ) ) ) ) ) {
+				if ( ( tan < tanMin || ( tan === tanMin && p.x > m.x ) ) && locallyInside( p, hole ) ) {
 
 					m = p;
 					tanMin = tan;
@@ -30145,16 +29351,9 @@ var Spacekit = (function (exports) {
 
 			p = p.next;
 
-		} while ( p !== stop );
+		}
 
 		return m;
-
-	}
-
-	// whether sector in vertex m contains sector in vertex p in the same coordinates
-	function sectorContainsSector( m, p ) {
-
-		return area( m.prev, m, p.prev ) < 0 && area( p.next, m, m.next ) < 0;
 
 	}
 
@@ -30285,18 +29484,16 @@ var Spacekit = (function (exports) {
 	function pointInTriangle( ax, ay, bx, by, cx, cy, px, py ) {
 
 		return ( cx - px ) * ( ay - py ) - ( ax - px ) * ( cy - py ) >= 0 &&
-				( ax - px ) * ( by - py ) - ( bx - px ) * ( ay - py ) >= 0 &&
-				( bx - px ) * ( cy - py ) - ( cx - px ) * ( by - py ) >= 0;
+			   ( ax - px ) * ( by - py ) - ( bx - px ) * ( ay - py ) >= 0 &&
+			   ( bx - px ) * ( cy - py ) - ( cx - px ) * ( by - py ) >= 0;
 
 	}
 
 	// check if a diagonal between two polygon nodes is valid (lies in polygon interior)
 	function isValidDiagonal( a, b ) {
 
-		return a.next.i !== b.i && a.prev.i !== b.i && ! intersectsPolygon( a, b ) && // dones't intersect other edges
-			( locallyInside( a, b ) && locallyInside( b, a ) && middleInside( a, b ) && // locally visible
-			( area( a.prev, a, b.prev ) || area( a, b.prev, b ) ) || // does not create opposite-facing sectors
-			equals( a, b ) && area( a.prev, a, a.next ) > 0 && area( b.prev, b, b.next ) > 0 ); // special zero-length case
+		return a.next.i !== b.i && a.prev.i !== b.i && ! intersectsPolygon( a, b ) &&
+			   locallyInside( a, b ) && locallyInside( b, a ) && middleInside( a, b );
 
 	}
 
@@ -30317,32 +29514,10 @@ var Spacekit = (function (exports) {
 	// check if two segments intersect
 	function intersects( p1, q1, p2, q2 ) {
 
-		var o1 = sign( area( p1, q1, p2 ) );
-		var o2 = sign( area( p1, q1, q2 ) );
-		var o3 = sign( area( p2, q2, p1 ) );
-		var o4 = sign( area( p2, q2, q1 ) );
-
-		if ( o1 !== o2 && o3 !== o4 ) return true; // general case
-
-		if ( o1 === 0 && onSegment( p1, p2, q1 ) ) return true; // p1, q1 and p2 are collinear and p2 lies on p1q1
-		if ( o2 === 0 && onSegment( p1, q2, q1 ) ) return true; // p1, q1 and q2 are collinear and q2 lies on p1q1
-		if ( o3 === 0 && onSegment( p2, p1, q2 ) ) return true; // p2, q2 and p1 are collinear and p1 lies on p2q2
-		if ( o4 === 0 && onSegment( p2, q1, q2 ) ) return true; // p2, q2 and q1 are collinear and q1 lies on p2q2
-
-		return false;
-
-	}
-
-	// for collinear points p, q, r, check if point q lies on segment pr
-	function onSegment( p, q, r ) {
-
-		return q.x <= Math.max( p.x, r.x ) && q.x >= Math.min( p.x, r.x ) && q.y <= Math.max( p.y, r.y ) && q.y >= Math.min( p.y, r.y );
-
-	}
-
-	function sign( num ) {
-
-		return num > 0 ? 1 : num < 0 ? - 1 : 0;
+		if ( ( equals( p1, p2 ) && equals( q1, q2 ) ) ||
+			( equals( p1, q2 ) && equals( p2, q1 ) ) ) return true;
+		return area( p1, q1, p2 ) > 0 !== area( p1, q1, q2 ) > 0 &&
+			   area( p2, q2, p1 ) > 0 !== area( p2, q2, q1 ) > 0;
 
 	}
 
@@ -30666,8 +29841,8 @@ var Spacekit = (function (exports) {
 
 		// build geometry
 
-		this.setAttribute( 'position', new Float32BufferAttribute( verticesArray, 3 ) );
-		this.setAttribute( 'uv', new Float32BufferAttribute( uvArray, 2 ) );
+		this.addAttribute( 'position', new Float32BufferAttribute( verticesArray, 3 ) );
+		this.addAttribute( 'uv', new Float32BufferAttribute( uvArray, 2 ) );
 
 		this.computeVertexNormals();
 
@@ -31634,9 +30809,9 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	}
 
@@ -31778,9 +30953,9 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	}
 
@@ -31837,7 +31012,7 @@ var Spacekit = (function (exports) {
 
 		// clamp phiLength so it's in range of [ 0, 2PI ]
 
-		phiLength = MathUtils.clamp( phiLength, 0, Math.PI * 2 );
+		phiLength = _Math.clamp( phiLength, 0, Math.PI * 2 );
 
 
 		// buffers
@@ -31910,8 +31085,8 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 		// generate normals
 
@@ -32059,9 +31234,9 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 
 		// helper functions
@@ -32200,7 +31375,7 @@ var Spacekit = (function (exports) {
 
 		// helper variables
 
-		var thresholdDot = Math.cos( MathUtils.DEG2RAD * thresholdAngle );
+		var thresholdDot = Math.cos( _Math.DEG2RAD * thresholdAngle );
 		var edge = [ 0, 0 ], edges = {}, edge1, edge2;
 		var key, keys = [ 'a', 'b', 'c' ];
 
@@ -32276,7 +31451,7 @@ var Spacekit = (function (exports) {
 
 		// build geometry
 
-		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
 
 	}
 
@@ -32375,9 +31550,9 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 		function generateTorso() {
 
@@ -32745,17 +31920,18 @@ var Spacekit = (function (exports) {
 		// build geometry
 
 		this.setIndex( indices );
-		this.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		this.setAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
-		this.setAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
+		this.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		this.addAttribute( 'normal', new Float32BufferAttribute( normals, 3 ) );
+		this.addAttribute( 'uv', new Float32BufferAttribute( uvs, 2 ) );
 
 	}
 
 	CircleBufferGeometry.prototype = Object.create( BufferGeometry.prototype );
 	CircleBufferGeometry.prototype.constructor = CircleBufferGeometry;
 
+
+
 	var Geometries = /*#__PURE__*/Object.freeze({
-		__proto__: null,
 		WireframeGeometry: WireframeGeometry,
 		ParametricGeometry: ParametricGeometry,
 		ParametricBufferGeometry: ParametricBufferGeometry,
@@ -32914,8 +32090,8 @@ var Spacekit = (function (exports) {
 		this.type = 'MeshStandardMaterial';
 
 		this.color = new Color( 0xffffff ); // diffuse
-		this.roughness = 1.0;
-		this.metalness = 0.0;
+		this.roughness = 0.5;
+		this.metalness = 0.5;
 
 		this.map = null;
 
@@ -32959,8 +32135,6 @@ var Spacekit = (function (exports) {
 		this.skinning = false;
 		this.morphTargets = false;
 		this.morphNormals = false;
-
-		this.vertexTangents = false;
 
 		this.setValues( parameters );
 
@@ -33024,8 +32198,6 @@ var Spacekit = (function (exports) {
 		this.morphTargets = source.morphTargets;
 		this.morphNormals = source.morphNormals;
 
-		this.vertexTangents = source.vertexTangents;
-
 		return this;
 
 	};
@@ -33034,18 +32206,9 @@ var Spacekit = (function (exports) {
 	 * @author WestLangley / http://github.com/WestLangley
 	 *
 	 * parameters = {
-	 *  clearcoat: <float>,
-	 *  clearcoatMap: new THREE.Texture( <Image> ),
-	 *  clearcoatRoughness: <float>,
-	 *  clearcoatRoughnessMap: new THREE.Texture( <Image> ),
-	 *  clearcoatNormalScale: <Vector2>,
-	 *  clearcoatNormalMap: new THREE.Texture( <Image> ),
-	 *
-	 *  reflectivity: <float>,
-	 *
-	 *  sheen: <Color>,
-	 *
-	 *  transparency: <float>
+	 *  reflectivity: <float>
+	 *  clearCoat: <float>
+	 *  clearCoatRoughness: <float>
 	 * }
 	 */
 
@@ -33053,27 +32216,14 @@ var Spacekit = (function (exports) {
 
 		MeshStandardMaterial.call( this );
 
-		this.defines = {
-
-			'STANDARD': '',
-			'PHYSICAL': ''
-
-		};
+		this.defines = { 'PHYSICAL': '' };
 
 		this.type = 'MeshPhysicalMaterial';
 
-		this.clearcoat = 0.0;
-		this.clearcoatMap = null;
-		this.clearcoatRoughness = 0.0;
-		this.clearcoatRoughnessMap = null;
-		this.clearcoatNormalScale = new Vector2( 1, 1 );
-		this.clearcoatNormalMap = null;
-
 		this.reflectivity = 0.5; // maps to F0 = 0.04
 
-		this.sheen = null; // null will disable sheen bsdf
-
-		this.transparency = 0.0;
+		this.clearCoat = 0.0;
+		this.clearCoatRoughness = 0.0;
 
 		this.setValues( parameters );
 
@@ -33088,33 +32238,12 @@ var Spacekit = (function (exports) {
 
 		MeshStandardMaterial.prototype.copy.call( this, source );
 
-		this.defines = {
-
-			'STANDARD': '',
-			'PHYSICAL': ''
-
-		};
-
-		this.clearcoat = source.clearcoat;
-		this.clearcoatMap = source.clearcoatMap;
-		this.clearcoatRoughness = source.clearcoatRoughness;
-		this.clearcoatRoughnessMap = source.clearcoatRoughnessMap;
-		this.clearcoatNormalMap = source.clearcoatNormalMap;
-		this.clearcoatNormalScale.copy( source.clearcoatNormalScale );
+		this.defines = { 'PHYSICAL': '' };
 
 		this.reflectivity = source.reflectivity;
 
-		if ( source.sheen ) {
-
-			this.sheen = ( this.sheen || new Color() ).copy( source.sheen );
-
-		} else {
-
-			this.sheen = null;
-
-		}
-
-		this.transparency = source.transparency;
+		this.clearCoat = source.clearCoat;
+		this.clearCoatRoughness = source.clearCoatRoughness;
 
 		return this;
 
@@ -33158,7 +32287,7 @@ var Spacekit = (function (exports) {
 	 *  alphaMap: new THREE.Texture( <Image> ),
 	 *
 	 *  envMap: new THREE.CubeTexture( [posx, negx, posy, negy, posz, negz] ),
-	 *  combine: THREE.MultiplyOperation,
+	 *  combine: THREE.Multiply,
 	 *  reflectivity: <float>,
 	 *  refractionRatio: <float>,
 	 *
@@ -33288,149 +32417,34 @@ var Spacekit = (function (exports) {
 	 * @author takahirox / http://github.com/takahirox
 	 *
 	 * parameters = {
-	 *  color: <hex>,
-	 *  specular: <hex>,
-	 *  shininess: <float>,
-	 *
-	 *  map: new THREE.Texture( <Image> ),
-	 *  gradientMap: new THREE.Texture( <Image> ),
-	 *
-	 *  lightMap: new THREE.Texture( <Image> ),
-	 *  lightMapIntensity: <float>
-	 *
-	 *  aoMap: new THREE.Texture( <Image> ),
-	 *  aoMapIntensity: <float>
-	 *
-	 *  emissive: <hex>,
-	 *  emissiveIntensity: <float>
-	 *  emissiveMap: new THREE.Texture( <Image> ),
-	 *
-	 *  bumpMap: new THREE.Texture( <Image> ),
-	 *  bumpScale: <float>,
-	 *
-	 *  normalMap: new THREE.Texture( <Image> ),
-	 *  normalMapType: THREE.TangentSpaceNormalMap,
-	 *  normalScale: <Vector2>,
-	 *
-	 *  displacementMap: new THREE.Texture( <Image> ),
-	 *  displacementScale: <float>,
-	 *  displacementBias: <float>,
-	 *
-	 *  specularMap: new THREE.Texture( <Image> ),
-	 *
-	 *  alphaMap: new THREE.Texture( <Image> ),
-	 *
-	 *  wireframe: <boolean>,
-	 *  wireframeLinewidth: <float>,
-	 *
-	 *  skinning: <bool>,
-	 *  morphTargets: <bool>,
-	 *  morphNormals: <bool>
+	 *  gradientMap: new THREE.Texture( <Image> )
 	 * }
 	 */
 
 	function MeshToonMaterial( parameters ) {
 
-		Material.call( this );
+		MeshPhongMaterial.call( this );
 
 		this.defines = { 'TOON': '' };
 
 		this.type = 'MeshToonMaterial';
 
-		this.color = new Color( 0xffffff );
-		this.specular = new Color( 0x111111 );
-		this.shininess = 30;
-
-		this.map = null;
 		this.gradientMap = null;
-
-		this.lightMap = null;
-		this.lightMapIntensity = 1.0;
-
-		this.aoMap = null;
-		this.aoMapIntensity = 1.0;
-
-		this.emissive = new Color( 0x000000 );
-		this.emissiveIntensity = 1.0;
-		this.emissiveMap = null;
-
-		this.bumpMap = null;
-		this.bumpScale = 1;
-
-		this.normalMap = null;
-		this.normalMapType = TangentSpaceNormalMap;
-		this.normalScale = new Vector2( 1, 1 );
-
-		this.displacementMap = null;
-		this.displacementScale = 1;
-		this.displacementBias = 0;
-
-		this.specularMap = null;
-
-		this.alphaMap = null;
-
-		this.wireframe = false;
-		this.wireframeLinewidth = 1;
-		this.wireframeLinecap = 'round';
-		this.wireframeLinejoin = 'round';
-
-		this.skinning = false;
-		this.morphTargets = false;
-		this.morphNormals = false;
 
 		this.setValues( parameters );
 
 	}
 
-	MeshToonMaterial.prototype = Object.create( Material.prototype );
+	MeshToonMaterial.prototype = Object.create( MeshPhongMaterial.prototype );
 	MeshToonMaterial.prototype.constructor = MeshToonMaterial;
 
 	MeshToonMaterial.prototype.isMeshToonMaterial = true;
 
 	MeshToonMaterial.prototype.copy = function ( source ) {
 
-		Material.prototype.copy.call( this, source );
+		MeshPhongMaterial.prototype.copy.call( this, source );
 
-		this.color.copy( source.color );
-		this.specular.copy( source.specular );
-		this.shininess = source.shininess;
-
-		this.map = source.map;
 		this.gradientMap = source.gradientMap;
-
-		this.lightMap = source.lightMap;
-		this.lightMapIntensity = source.lightMapIntensity;
-
-		this.aoMap = source.aoMap;
-		this.aoMapIntensity = source.aoMapIntensity;
-
-		this.emissive.copy( source.emissive );
-		this.emissiveMap = source.emissiveMap;
-		this.emissiveIntensity = source.emissiveIntensity;
-
-		this.bumpMap = source.bumpMap;
-		this.bumpScale = source.bumpScale;
-
-		this.normalMap = source.normalMap;
-		this.normalMapType = source.normalMapType;
-		this.normalScale.copy( source.normalScale );
-
-		this.displacementMap = source.displacementMap;
-		this.displacementScale = source.displacementScale;
-		this.displacementBias = source.displacementBias;
-
-		this.specularMap = source.specularMap;
-
-		this.alphaMap = source.alphaMap;
-
-		this.wireframe = source.wireframe;
-		this.wireframeLinewidth = source.wireframeLinewidth;
-		this.wireframeLinecap = source.wireframeLinecap;
-		this.wireframeLinejoin = source.wireframeLinejoin;
-
-		this.skinning = source.skinning;
-		this.morphTargets = source.morphTargets;
-		this.morphNormals = source.morphNormals;
 
 		return this;
 
@@ -33484,6 +32498,7 @@ var Spacekit = (function (exports) {
 		this.wireframeLinewidth = 1;
 
 		this.fog = false;
+		this.lights = false;
 
 		this.skinning = false;
 		this.morphTargets = false;
@@ -33710,6 +32725,8 @@ var Spacekit = (function (exports) {
 		this.morphTargets = false;
 		this.morphNormals = false;
 
+		this.lights = false;
+
 		this.setValues( parameters );
 
 	}
@@ -33798,8 +32815,9 @@ var Spacekit = (function (exports) {
 
 	};
 
+
+
 	var Materials = /*#__PURE__*/Object.freeze({
-		__proto__: null,
 		ShadowMaterial: ShadowMaterial,
 		SpriteMaterial: SpriteMaterial,
 		RawShaderMaterial: RawShaderMaterial,
@@ -33979,185 +32997,6 @@ var Spacekit = (function (exports) {
 				} while ( key !== undefined );
 
 			}
-
-		},
-
-		subclip: function ( sourceClip, name, startFrame, endFrame, fps ) {
-
-			fps = fps || 30;
-
-			var clip = sourceClip.clone();
-
-			clip.name = name;
-
-			var tracks = [];
-
-			for ( var i = 0; i < clip.tracks.length; ++ i ) {
-
-				var track = clip.tracks[ i ];
-				var valueSize = track.getValueSize();
-
-				var times = [];
-				var values = [];
-
-				for ( var j = 0; j < track.times.length; ++ j ) {
-
-					var frame = track.times[ j ] * fps;
-
-					if ( frame < startFrame || frame >= endFrame ) continue;
-
-					times.push( track.times[ j ] );
-
-					for ( var k = 0; k < valueSize; ++ k ) {
-
-						values.push( track.values[ j * valueSize + k ] );
-
-					}
-
-				}
-
-				if ( times.length === 0 ) continue;
-
-				track.times = AnimationUtils.convertArray( times, track.times.constructor );
-				track.values = AnimationUtils.convertArray( values, track.values.constructor );
-
-				tracks.push( track );
-
-			}
-
-			clip.tracks = tracks;
-
-			// find minimum .times value across all tracks in the trimmed clip
-
-			var minStartTime = Infinity;
-
-			for ( var i = 0; i < clip.tracks.length; ++ i ) {
-
-				if ( minStartTime > clip.tracks[ i ].times[ 0 ] ) {
-
-					minStartTime = clip.tracks[ i ].times[ 0 ];
-
-				}
-
-			}
-
-			// shift all tracks such that clip begins at t=0
-
-			for ( var i = 0; i < clip.tracks.length; ++ i ) {
-
-				clip.tracks[ i ].shift( - 1 * minStartTime );
-
-			}
-
-			clip.resetDuration();
-
-			return clip;
-
-		},
-
-		makeClipAdditive: function ( targetClip, referenceFrame, referenceClip, fps ) {
-
-			if ( referenceFrame === undefined ) referenceFrame = 0;
-			if ( referenceClip === undefined ) referenceClip = targetClip;
-			if ( fps === undefined || fps <= 0 ) fps = 30;
-
-			var numTracks = targetClip.tracks.length;
-			var referenceTime = referenceFrame / fps;
-
-			// Make each track's values relative to the values at the reference frame
-			for ( var i = 0; i < numTracks; ++ i ) {
-
-				var referenceTrack = referenceClip.tracks[ i ];
-				var referenceTrackType = referenceTrack.ValueTypeName;
-
-				// Skip this track if it's non-numeric
-				if ( referenceTrackType === 'bool' || referenceTrackType === 'string' ) continue;
-
-				// Find the track in the target clip whose name and type matches the reference track
-				var targetTrack = targetClip.tracks.find( function ( track ) {
-
-					return track.name === referenceTrack.name
-					&& track.ValueTypeName === referenceTrackType;
-
-				} );
-
-				if ( targetTrack === undefined ) continue;
-
-				var valueSize = referenceTrack.getValueSize();
-				var lastIndex = referenceTrack.times.length - 1;
-				var referenceValue;
-
-				// Find the value to subtract out of the track
-				if ( referenceTime <= referenceTrack.times[ 0 ] ) {
-
-					// Reference frame is earlier than the first keyframe, so just use the first keyframe
-					referenceValue = AnimationUtils.arraySlice( referenceTrack.values, 0, referenceTrack.valueSize );
-
-				} else if ( referenceTime >= referenceTrack.times[ lastIndex ] ) {
-
-					// Reference frame is after the last keyframe, so just use the last keyframe
-					var startIndex = lastIndex * valueSize;
-					referenceValue = AnimationUtils.arraySlice( referenceTrack.values, startIndex );
-
-				} else {
-
-					// Interpolate to the reference value
-					var interpolant = referenceTrack.createInterpolant();
-					interpolant.evaluate( referenceTime );
-					referenceValue = interpolant.resultBuffer;
-
-				}
-
-				// Conjugate the quaternion
-				if ( referenceTrackType === 'quaternion' ) {
-
-					var referenceQuat = new Quaternion(
-						referenceValue[ 0 ],
-						referenceValue[ 1 ],
-						referenceValue[ 2 ],
-						referenceValue[ 3 ]
-					).normalize().conjugate();
-					referenceQuat.toArray( referenceValue );
-
-				}
-
-				// Subtract the reference value from all of the track values
-
-				var numTimes = targetTrack.times.length;
-				for ( var j = 0; j < numTimes; ++ j ) {
-
-					var valueStart = j * valueSize;
-
-					if ( referenceTrackType === 'quaternion' ) {
-
-						// Multiply the conjugate for quaternion track types
-						Quaternion.multiplyQuaternionsFlat(
-							targetTrack.values,
-							valueStart,
-							referenceValue,
-							0,
-							targetTrack.values,
-							valueStart
-						);
-
-					} else {
-
-						// Subtract each value for all other numeric track types
-						for ( var k = 0; k < valueSize; ++ k ) {
-
-							targetTrack.values[ valueStart + k ] -= referenceValue[ k ];
-
-						}
-
-					}
-
-				}
-
-			}
-
-			targetClip.blendMode = AdditiveAnimationBlendMode;
-
-			return targetClip;
 
 		}
 
@@ -34409,7 +33248,7 @@ var Spacekit = (function (exports) {
 
 	} );
 
-	// DECLARE ALIAS AFTER assign prototype
+	//!\ DECLARE ALIAS AFTER assign prototype !
 	Object.assign( Interpolant.prototype, {
 
 		//( 0, t, t0 ), returns this.resultBuffer
@@ -34882,12 +33721,7 @@ var Spacekit = (function (exports) {
 			if ( from !== 0 || to !== nKeys ) {
 
 				// empty tracks are forbidden, so keep at least one keyframe
-				if ( from >= to ) {
-
-					to = Math.max( to, 1 );
-					from = to - 1;
-
-				}
+				if ( from >= to ) to = Math.max( to, 1 ), from = to - 1;
 
 				var stride = this.getValueSize();
 				this.times = AnimationUtils.arraySlice( times, from, to );
@@ -34980,9 +33814,8 @@ var Spacekit = (function (exports) {
 		// (0,0,0,0,1,1,1,0,0,0,0,0,0,0) --> (0,0,1,1,0,0)
 		optimize: function () {
 
-			// times or values may be shared with other tracks, so overwriting is unsafe
-			var times = AnimationUtils.arraySlice( this.times ),
-				values = AnimationUtils.arraySlice( this.values ),
+			var times = this.times,
+				values = this.values,
 				stride = this.getValueSize(),
 
 				smoothInterpolation = this.getInterpolation() === InterpolateSmooth,
@@ -35076,11 +33909,6 @@ var Spacekit = (function (exports) {
 
 				this.times = AnimationUtils.arraySlice( times, 0, writeIndex );
 				this.values = AnimationUtils.arraySlice( values, 0, writeIndex * stride );
-
-			} else {
-
-				this.times = times;
-				this.values = values;
 
 			}
 
@@ -35337,14 +34165,13 @@ var Spacekit = (function (exports) {
 	 * @author David Sarno / http://lighthaus.us/
 	 */
 
-	function AnimationClip( name, duration, tracks, blendMode ) {
+	function AnimationClip( name, duration, tracks ) {
 
 		this.name = name;
 		this.tracks = tracks;
 		this.duration = ( duration !== undefined ) ? duration : - 1;
-		this.blendMode = ( blendMode !== undefined ) ? blendMode : NormalAnimationBlendMode;
 
-		this.uuid = MathUtils.generateUUID();
+		this.uuid = _Math.generateUUID();
 
 		// this means it should figure out its duration by scanning the tracks
 		if ( this.duration < 0 ) {
@@ -35446,7 +34273,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			return new AnimationClip( json.name, json.duration, tracks, json.blendMode );
+			return new AnimationClip( json.name, json.duration, tracks );
 
 		},
 
@@ -35460,8 +34287,7 @@ var Spacekit = (function (exports) {
 				'name': clip.name,
 				'duration': clip.duration,
 				'tracks': tracks,
-				'uuid': clip.uuid,
-				'blendMode': clip.blendMode
+				'uuid': clip.uuid
 
 			};
 
@@ -35623,7 +34449,6 @@ var Spacekit = (function (exports) {
 			// automatic length determination in AnimationClip.
 			var duration = animation.length || - 1;
 			var fps = animation.fps || 30;
-			var blendMode = animation.blendMode;
 
 			var hierarchyTracks = animation.hierarchy || [];
 
@@ -35705,7 +34530,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			var clip = new AnimationClip( clipName, duration, tracks, blendMode );
+			var clip = new AnimationClip( clipName, duration, tracks );
 
 			return clip;
 
@@ -35771,6 +34596,7 @@ var Spacekit = (function (exports) {
 
 		},
 
+
 		clone: function () {
 
 			var tracks = [];
@@ -35781,7 +34607,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			return new AnimationClip( this.name, this.duration, tracks, this.blendMode );
+			return new AnimationClip( this.name, this.duration, tracks );
 
 		}
 
@@ -35843,7 +34669,6 @@ var Spacekit = (function (exports) {
 		var itemsLoaded = 0;
 		var itemsTotal = 0;
 		var urlModifier = undefined;
-		var handlers = [];
 
 		// Refer to #5689 for the reason why we don't set .onStart
 		// in the constructor
@@ -35920,112 +34745,13 @@ var Spacekit = (function (exports) {
 		this.setURLModifier = function ( transform ) {
 
 			urlModifier = transform;
-
 			return this;
-
-		};
-
-		this.addHandler = function ( regex, loader ) {
-
-			handlers.push( regex, loader );
-
-			return this;
-
-		};
-
-		this.removeHandler = function ( regex ) {
-
-			var index = handlers.indexOf( regex );
-
-			if ( index !== - 1 ) {
-
-				handlers.splice( index, 2 );
-
-			}
-
-			return this;
-
-		};
-
-		this.getHandler = function ( file ) {
-
-			for ( var i = 0, l = handlers.length; i < l; i += 2 ) {
-
-				var regex = handlers[ i ];
-				var loader = handlers[ i + 1 ];
-
-				if ( regex.global ) regex.lastIndex = 0; // see #17920
-
-				if ( regex.test( file ) ) {
-
-					return loader;
-
-				}
-
-			}
-
-			return null;
 
 		};
 
 	}
 
 	var DefaultLoadingManager = new LoadingManager();
-
-	/**
-	 * @author alteredq / http://alteredqualia.com/
-	 */
-
-	function Loader( manager ) {
-
-		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
-
-		this.crossOrigin = 'anonymous';
-		this.path = '';
-		this.resourcePath = '';
-
-	}
-
-	Object.assign( Loader.prototype, {
-
-		load: function ( /* url, onLoad, onProgress, onError */ ) {},
-
-		loadAsync: function ( url, onProgress ) {
-
-			var scope = this;
-
-			return new Promise( function ( resolve, reject ) {
-
-				scope.load( url, resolve, onProgress, reject );
-
-			} );
-
-		},
-
-		parse: function ( /* data */ ) {},
-
-		setCrossOrigin: function ( crossOrigin ) {
-
-			this.crossOrigin = crossOrigin;
-			return this;
-
-		},
-
-		setPath: function ( path ) {
-
-			this.path = path;
-			return this;
-
-		},
-
-		setResourcePath: function ( resourcePath ) {
-
-			this.resourcePath = resourcePath;
-			return this;
-
-		}
-
-	} );
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -36035,13 +34761,11 @@ var Spacekit = (function (exports) {
 
 	function FileLoader( manager ) {
 
-		Loader.call( this, manager );
+		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
 
 	}
 
-	FileLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
-
-		constructor: FileLoader,
+	Object.assign( FileLoader.prototype, {
 
 		load: function ( url, onLoad, onProgress, onError ) {
 
@@ -36198,6 +34922,8 @@ var Spacekit = (function (exports) {
 
 					var response = this.response;
 
+					Cache.add( url, response );
+
 					var callbacks = loading[ url ];
 
 					delete loading[ url ];
@@ -36208,10 +34934,6 @@ var Spacekit = (function (exports) {
 						// e.g. 'file://' or 'data://'. Handle as success.
 
 						if ( this.status === 0 ) console.warn( 'THREE.FileLoader: HTTP Status 0 received.' );
-
-						// Add to cache only on HTTP success, so that we do not cache
-						// error response bodies as proper responses to requests.
-						Cache.add( url, response );
 
 						for ( var i = 0, il = callbacks.length; i < il; i ++ ) {
 
@@ -36308,6 +35030,13 @@ var Spacekit = (function (exports) {
 
 		},
 
+		setPath: function ( value ) {
+
+			this.path = value;
+			return this;
+
+		},
+
 		setResponseType: function ( value ) {
 
 			this.responseType = value;
@@ -36344,13 +35073,11 @@ var Spacekit = (function (exports) {
 
 	function AnimationLoader( manager ) {
 
-		Loader.call( this, manager );
+		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
 
 	}
 
-	AnimationLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
-
-		constructor: AnimationLoader,
+	Object.assign( AnimationLoader.prototype, {
 
 		load: function ( url, onLoad, onProgress, onError ) {
 
@@ -36380,6 +35107,13 @@ var Spacekit = (function (exports) {
 
 			return animations;
 
+		},
+
+		setPath: function ( value ) {
+
+			this.path = value;
+			return this;
+
 		}
 
 	} );
@@ -36388,19 +35122,18 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 *
 	 * Abstract Base class to block based textures loader (dds, pvr, ...)
-	 *
-	 * Sub classes have to implement the parse() method which will be used in load().
 	 */
 
 	function CompressedTextureLoader( manager ) {
 
-		Loader.call( this, manager );
+		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
+
+		// override in sub classes
+		this._parser = null;
 
 	}
 
-	CompressedTextureLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
-
-		constructor: CompressedTextureLoader,
+	Object.assign( CompressedTextureLoader.prototype, {
 
 		load: function ( url, onLoad, onProgress, onError ) {
 
@@ -36419,7 +35152,7 @@ var Spacekit = (function (exports) {
 
 				loader.load( url[ i ], function ( buffer ) {
 
-					var texDatas = scope.parse( buffer, true );
+					var texDatas = scope._parser( buffer, true );
 
 					images[ i ] = {
 						width: texDatas.width,
@@ -36462,7 +35195,7 @@ var Spacekit = (function (exports) {
 
 				loader.load( url, function ( buffer ) {
 
-					var texDatas = scope.parse( buffer, true );
+					var texDatas = scope._parser( buffer, true );
 
 					if ( texDatas.isCubemap ) {
 
@@ -36508,6 +35241,13 @@ var Spacekit = (function (exports) {
 
 			return texture;
 
+		},
+
+		setPath: function ( value ) {
+
+			this.path = value;
+			return this;
+
 		}
 
 	} );
@@ -36516,19 +35256,18 @@ var Spacekit = (function (exports) {
 	 * @author Nikos M. / https://github.com/foo123/
 	 *
 	 * Abstract Base class to load generic binary textures formats (rgbe, hdr, ...)
-	 *
-	 * Sub classes have to implement the parse() method which will be used in load().
 	 */
 
 	function DataTextureLoader( manager ) {
 
-		Loader.call( this, manager );
+		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
+
+		// override in sub classes
+		this._parser = null;
 
 	}
 
-	DataTextureLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
-
-		constructor: DataTextureLoader,
+	Object.assign( DataTextureLoader.prototype, {
 
 		load: function ( url, onLoad, onProgress, onError ) {
 
@@ -36541,7 +35280,7 @@ var Spacekit = (function (exports) {
 			loader.setPath( this.path );
 			loader.load( url, function ( buffer ) {
 
-				var texData = scope.parse( buffer );
+				var texData = scope._parser( buffer );
 
 				if ( ! texData ) return;
 
@@ -36561,7 +35300,7 @@ var Spacekit = (function (exports) {
 				texture.wrapT = texData.wrapT !== undefined ? texData.wrapT : ClampToEdgeWrapping;
 
 				texture.magFilter = texData.magFilter !== undefined ? texData.magFilter : LinearFilter;
-				texture.minFilter = texData.minFilter !== undefined ? texData.minFilter : LinearFilter;
+				texture.minFilter = texData.minFilter !== undefined ? texData.minFilter : LinearMipmapLinearFilter;
 
 				texture.anisotropy = texData.anisotropy !== undefined ? texData.anisotropy : 1;
 
@@ -36570,7 +35309,6 @@ var Spacekit = (function (exports) {
 					texture.format = texData.format;
 
 				}
-
 				if ( texData.type !== undefined ) {
 
 					texture.type = texData.type;
@@ -36580,7 +35318,6 @@ var Spacekit = (function (exports) {
 				if ( texData.mipmaps !== undefined ) {
 
 					texture.mipmaps = texData.mipmaps;
-					texture.minFilter = LinearMipmapLinearFilter; // presumably...
 
 				}
 
@@ -36599,6 +35336,13 @@ var Spacekit = (function (exports) {
 
 			return texture;
 
+		},
+
+		setPath: function ( value ) {
+
+			this.path = value;
+			return this;
+
 		}
 
 	} );
@@ -36607,17 +35351,20 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
+
 	function ImageLoader( manager ) {
 
-		Loader.call( this, manager );
+		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
 
 	}
 
-	ImageLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
+	Object.assign( ImageLoader.prototype, {
 
-		constructor: ImageLoader,
+		crossOrigin: 'anonymous',
 
 		load: function ( url, onLoad, onProgress, onError ) {
+
+			if ( url === undefined ) url = '';
 
 			if ( this.path !== undefined ) url = this.path + url;
 
@@ -36685,6 +35432,20 @@ var Spacekit = (function (exports) {
 
 			return image;
 
+		},
+
+		setCrossOrigin: function ( value ) {
+
+			this.crossOrigin = value;
+			return this;
+
+		},
+
+		setPath: function ( value ) {
+
+			this.path = value;
+			return this;
+
 		}
 
 	} );
@@ -36696,13 +35457,13 @@ var Spacekit = (function (exports) {
 
 	function CubeTextureLoader( manager ) {
 
-		Loader.call( this, manager );
+		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
 
 	}
 
-	CubeTextureLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
+	Object.assign( CubeTextureLoader.prototype, {
 
-		constructor: CubeTextureLoader,
+		crossOrigin: 'anonymous',
 
 		load: function ( urls, onLoad, onProgress, onError ) {
 
@@ -36742,6 +35503,20 @@ var Spacekit = (function (exports) {
 
 			return texture;
 
+		},
+
+		setCrossOrigin: function ( value ) {
+
+			this.crossOrigin = value;
+			return this;
+
+		},
+
+		setPath: function ( value ) {
+
+			this.path = value;
+			return this;
+
 		}
 
 	} );
@@ -36750,15 +35525,16 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
+
 	function TextureLoader( manager ) {
 
-		Loader.call( this, manager );
+		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
 
 	}
 
-	TextureLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
+	Object.assign( TextureLoader.prototype, {
 
-		constructor: TextureLoader,
+		crossOrigin: 'anonymous',
 
 		load: function ( url, onLoad, onProgress, onError ) {
 
@@ -36788,6 +35564,20 @@ var Spacekit = (function (exports) {
 
 			return texture;
 
+		},
+
+		setCrossOrigin: function ( value ) {
+
+			this.crossOrigin = value;
+			return this;
+
+		},
+
+		setPath: function ( value ) {
+
+			this.path = value;
+			return this;
+
 		}
 
 	} );
@@ -36797,8 +35587,8 @@ var Spacekit = (function (exports) {
 	 * Extensible curve object
 	 *
 	 * Some common of curve methods:
-	 * .getPoint( t, optionalTarget ), .getTangent( t, optionalTarget )
-	 * .getPointAt( u, optionalTarget ), .getTangentAt( u, optionalTarget )
+	 * .getPoint( t, optionalTarget ), .getTangent( t )
+	 * .getPointAt( u, optionalTarget ), .getTangentAt( u )
 	 * .getPoints(), .getSpacedPoints()
 	 * .getLength()
 	 * .updateArcLengths()
@@ -37027,7 +35817,7 @@ var Spacekit = (function (exports) {
 		// 2 points a small delta apart will be used to find its gradient
 		// which seems to give a reasonable approximation
 
-		getTangent: function ( t, optionalTarget ) {
+		getTangent: function ( t ) {
 
 			var delta = 0.0001;
 			var t1 = t - delta;
@@ -37041,18 +35831,15 @@ var Spacekit = (function (exports) {
 			var pt1 = this.getPoint( t1 );
 			var pt2 = this.getPoint( t2 );
 
-			var tangent = optionalTarget || ( ( pt1.isVector2 ) ? new Vector2() : new Vector3() );
-
-			tangent.copy( pt2 ).sub( pt1 ).normalize();
-
-			return tangent;
+			var vec = pt2.clone().sub( pt1 );
+			return vec.normalize();
 
 		},
 
-		getTangentAt: function ( u, optionalTarget ) {
+		getTangentAt: function ( u ) {
 
 			var t = this.getUtoTmapping( u );
-			return this.getTangent( t, optionalTarget );
+			return this.getTangent( t );
 
 		},
 
@@ -37077,7 +35864,7 @@ var Spacekit = (function (exports) {
 
 				u = i / segments;
 
-				tangents[ i ] = this.getTangentAt( u, new Vector3() );
+				tangents[ i ] = this.getTangentAt( u );
 				tangents[ i ].normalize();
 
 			}
@@ -37132,7 +35919,7 @@ var Spacekit = (function (exports) {
 
 					vec.normalize();
 
-					theta = Math.acos( MathUtils.clamp( tangents[ i - 1 ].dot( tangents[ i ] ), - 1, 1 ) ); // clamp for floating pt errors
+					theta = Math.acos( _Math.clamp( tangents[ i - 1 ].dot( tangents[ i ] ), - 1, 1 ) ); // clamp for floating pt errors
 
 					normals[ i ].applyMatrix4( mat.makeRotationAxis( vec, theta ) );
 
@@ -37146,7 +35933,7 @@ var Spacekit = (function (exports) {
 
 			if ( closed === true ) {
 
-				theta = Math.acos( MathUtils.clamp( normals[ 0 ].dot( normals[ segments ] ), - 1, 1 ) );
+				theta = Math.acos( _Math.clamp( normals[ 0 ].dot( normals[ segments ] ), - 1, 1 ) );
 				theta /= segments;
 
 				if ( tangents[ 0 ].dot( vec.crossVectors( normals[ 0 ], normals[ segments ] ) ) > 0 ) {
@@ -37897,13 +36684,11 @@ var Spacekit = (function (exports) {
 
 	};
 
-	LineCurve.prototype.getTangent = function ( t, optionalTarget ) {
+	LineCurve.prototype.getTangent = function ( /* t */ ) {
 
-		var tangent = optionalTarget || new Vector2();
+		var tangent = this.v2.clone().sub( this.v1 );
 
-		var tangent = tangent.copy( this.v2 ).sub( this.v1 ).normalize();
-
-		return tangent;
+		return tangent.normalize();
 
 	};
 
@@ -38244,8 +37029,9 @@ var Spacekit = (function (exports) {
 
 	};
 
+
+
 	var Curves = /*#__PURE__*/Object.freeze({
-		__proto__: null,
 		ArcCurve: ArcCurve,
 		CatmullRomCurve3: CatmullRomCurve3,
 		CubicBezierCurve: CubicBezierCurve,
@@ -38549,15 +37335,11 @@ var Spacekit = (function (exports) {
 
 			}
 
-			return this;
-
 		},
 
 		moveTo: function ( x, y ) {
 
 			this.currentPoint.set( x, y ); // TODO consider referencing vectors instead of copying?
-
-			return this;
 
 		},
 
@@ -38567,8 +37349,6 @@ var Spacekit = (function (exports) {
 			this.curves.push( curve );
 
 			this.currentPoint.set( x, y );
-
-			return this;
 
 		},
 
@@ -38583,8 +37363,6 @@ var Spacekit = (function (exports) {
 			this.curves.push( curve );
 
 			this.currentPoint.set( aX, aY );
-
-			return this;
 
 		},
 
@@ -38601,8 +37379,6 @@ var Spacekit = (function (exports) {
 
 			this.currentPoint.set( aX, aY );
 
-			return this;
-
 		},
 
 		splineThru: function ( pts /*Array of Vector*/ ) {
@@ -38614,8 +37390,6 @@ var Spacekit = (function (exports) {
 
 			this.currentPoint.copy( pts[ pts.length - 1 ] );
 
-			return this;
-
 		},
 
 		arc: function ( aX, aY, aRadius, aStartAngle, aEndAngle, aClockwise ) {
@@ -38626,15 +37400,11 @@ var Spacekit = (function (exports) {
 			this.absarc( aX + x0, aY + y0, aRadius,
 				aStartAngle, aEndAngle, aClockwise );
 
-			return this;
-
 		},
 
 		absarc: function ( aX, aY, aRadius, aStartAngle, aEndAngle, aClockwise ) {
 
 			this.absellipse( aX, aY, aRadius, aRadius, aStartAngle, aEndAngle, aClockwise );
-
-			return this;
 
 		},
 
@@ -38644,8 +37414,6 @@ var Spacekit = (function (exports) {
 			var y0 = this.currentPoint.y;
 
 			this.absellipse( aX + x0, aY + y0, xRadius, yRadius, aStartAngle, aEndAngle, aClockwise, aRotation );
-
-			return this;
 
 		},
 
@@ -38670,8 +37438,6 @@ var Spacekit = (function (exports) {
 
 			var lastPoint = curve.getPoint( 1 );
 			this.currentPoint.copy( lastPoint );
-
-			return this;
 
 		},
 
@@ -38722,7 +37488,7 @@ var Spacekit = (function (exports) {
 
 		Path.call( this, points );
 
-		this.uuid = MathUtils.generateUUID();
+		this.uuid = _Math.generateUUID();
 
 		this.type = 'Shape';
 
@@ -38925,83 +37691,11 @@ var Spacekit = (function (exports) {
 		this.mapSize = new Vector2( 512, 512 );
 
 		this.map = null;
-		this.mapPass = null;
 		this.matrix = new Matrix4();
-
-		this._frustum = new Frustum();
-		this._frameExtents = new Vector2( 1, 1 );
-
-		this._viewportCount = 1;
-
-		this._viewports = [
-
-			new Vector4( 0, 0, 1, 1 )
-
-		];
 
 	}
 
 	Object.assign( LightShadow.prototype, {
-
-		_projScreenMatrix: new Matrix4(),
-
-		_lightPositionWorld: new Vector3(),
-
-		_lookTarget: new Vector3(),
-
-		getViewportCount: function () {
-
-			return this._viewportCount;
-
-		},
-
-		getFrustum: function () {
-
-			return this._frustum;
-
-		},
-
-		updateMatrices: function ( light ) {
-
-			var shadowCamera = this.camera,
-				shadowMatrix = this.matrix,
-				projScreenMatrix = this._projScreenMatrix,
-				lookTarget = this._lookTarget,
-				lightPositionWorld = this._lightPositionWorld;
-
-			lightPositionWorld.setFromMatrixPosition( light.matrixWorld );
-			shadowCamera.position.copy( lightPositionWorld );
-
-			lookTarget.setFromMatrixPosition( light.target.matrixWorld );
-			shadowCamera.lookAt( lookTarget );
-			shadowCamera.updateMatrixWorld();
-
-			projScreenMatrix.multiplyMatrices( shadowCamera.projectionMatrix, shadowCamera.matrixWorldInverse );
-			this._frustum.setFromProjectionMatrix( projScreenMatrix );
-
-			shadowMatrix.set(
-				0.5, 0.0, 0.0, 0.5,
-				0.0, 0.5, 0.0, 0.5,
-				0.0, 0.0, 0.5, 0.5,
-				0.0, 0.0, 0.0, 1.0
-			);
-
-			shadowMatrix.multiply( shadowCamera.projectionMatrix );
-			shadowMatrix.multiply( shadowCamera.matrixWorldInverse );
-
-		},
-
-		getViewport: function ( viewportIndex ) {
-
-			return this._viewports[ viewportIndex ];
-
-		},
-
-		getFrameExtents: function () {
-
-			return this._frameExtents;
-
-		},
 
 		copy: function ( source ) {
 
@@ -39055,11 +37749,11 @@ var Spacekit = (function (exports) {
 
 		isSpotLightShadow: true,
 
-		updateMatrices: function ( light ) {
+		update: function ( light ) {
 
 			var camera = this.camera;
 
-			var fov = MathUtils.RAD2DEG * 2 * light.angle;
+			var fov = _Math.RAD2DEG * 2 * light.angle;
 			var aspect = this.mapSize.width / this.mapSize.height;
 			var far = light.distance || camera.far;
 
@@ -39071,8 +37765,6 @@ var Spacekit = (function (exports) {
 				camera.updateProjectionMatrix();
 
 			}
-
-			LightShadow.prototype.updateMatrices.call( this, light );
 
 		}
 
@@ -39144,88 +37836,6 @@ var Spacekit = (function (exports) {
 
 	} );
 
-	function PointLightShadow() {
-
-		LightShadow.call( this, new PerspectiveCamera( 90, 1, 0.5, 500 ) );
-
-		this._frameExtents = new Vector2( 4, 2 );
-
-		this._viewportCount = 6;
-
-		this._viewports = [
-			// These viewports map a cube-map onto a 2D texture with the
-			// following orientation:
-			//
-			//  xzXZ
-			//   y Y
-			//
-			// X - Positive x direction
-			// x - Negative x direction
-			// Y - Positive y direction
-			// y - Negative y direction
-			// Z - Positive z direction
-			// z - Negative z direction
-
-			// positive X
-			new Vector4( 2, 1, 1, 1 ),
-			// negative X
-			new Vector4( 0, 1, 1, 1 ),
-			// positive Z
-			new Vector4( 3, 1, 1, 1 ),
-			// negative Z
-			new Vector4( 1, 1, 1, 1 ),
-			// positive Y
-			new Vector4( 3, 0, 1, 1 ),
-			// negative Y
-			new Vector4( 1, 0, 1, 1 )
-		];
-
-		this._cubeDirections = [
-			new Vector3( 1, 0, 0 ), new Vector3( - 1, 0, 0 ), new Vector3( 0, 0, 1 ),
-			new Vector3( 0, 0, - 1 ), new Vector3( 0, 1, 0 ), new Vector3( 0, - 1, 0 )
-		];
-
-		this._cubeUps = [
-			new Vector3( 0, 1, 0 ), new Vector3( 0, 1, 0 ), new Vector3( 0, 1, 0 ),
-			new Vector3( 0, 1, 0 ), new Vector3( 0, 0, 1 ),	new Vector3( 0, 0, - 1 )
-		];
-
-	}
-
-	PointLightShadow.prototype = Object.assign( Object.create( LightShadow.prototype ), {
-
-		constructor: PointLightShadow,
-
-		isPointLightShadow: true,
-
-		updateMatrices: function ( light, viewportIndex ) {
-
-			if ( viewportIndex === undefined ) viewportIndex = 0;
-
-			var camera = this.camera,
-				shadowMatrix = this.matrix,
-				lightPositionWorld = this._lightPositionWorld,
-				lookTarget = this._lookTarget,
-				projScreenMatrix = this._projScreenMatrix;
-
-			lightPositionWorld.setFromMatrixPosition( light.matrixWorld );
-			camera.position.copy( lightPositionWorld );
-
-			lookTarget.copy( camera.position );
-			lookTarget.add( this._cubeDirections[ viewportIndex ] );
-			camera.up.copy( this._cubeUps[ viewportIndex ] );
-			camera.lookAt( lookTarget );
-			camera.updateMatrixWorld();
-
-			shadowMatrix.makeTranslation( - lightPositionWorld.x, - lightPositionWorld.y, - lightPositionWorld.z );
-
-			projScreenMatrix.multiplyMatrices( camera.projectionMatrix, camera.matrixWorldInverse );
-			this._frustum.setFromProjectionMatrix( projScreenMatrix );
-
-		}
-
-	} );
-
 	/**
 	 * @author mrdoob / http://mrdoob.com/
 	 */
@@ -39257,7 +37867,7 @@ var Spacekit = (function (exports) {
 		this.distance = ( distance !== undefined ) ? distance : 0;
 		this.decay = ( decay !== undefined ) ? decay : 1;	// for physically correct lights, should be 2.
 
-		this.shadow = new PointLightShadow();
+		this.shadow = new LightShadow( new PerspectiveCamera( 90, 1, 0.5, 500 ) );
 
 	}
 
@@ -39386,13 +37996,15 @@ var Spacekit = (function (exports) {
 
 			if ( this.view !== null && this.view.enabled ) {
 
-				var scaleW = ( this.right - this.left ) / this.view.fullWidth / this.zoom;
-				var scaleH = ( this.top - this.bottom ) / this.view.fullHeight / this.zoom;
+				var zoomW = this.zoom / ( this.view.width / this.view.fullWidth );
+				var zoomH = this.zoom / ( this.view.height / this.view.fullHeight );
+				var scaleW = ( this.right - this.left ) / this.view.width;
+				var scaleH = ( this.top - this.bottom ) / this.view.height;
 
-				left += scaleW * this.view.offsetX;
-				right = left + scaleW * this.view.width;
-				top -= scaleH * this.view.offsetY;
-				bottom = top - scaleH * this.view.height;
+				left += scaleW * ( this.view.offsetX / zoomW );
+				right = left + scaleW * ( this.view.width / zoomW );
+				top -= scaleH * ( this.view.offsetY / zoomH );
+				bottom = top - scaleH * ( this.view.height / zoomH );
 
 			}
 
@@ -39426,7 +38038,7 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-	function DirectionalLightShadow() {
+	function DirectionalLightShadow( ) {
 
 		LightShadow.call( this, new OrthographicCamera( - 5, 5, 5, - 5, 0.5, 500 ) );
 
@@ -39434,15 +38046,7 @@ var Spacekit = (function (exports) {
 
 	DirectionalLightShadow.prototype = Object.assign( Object.create( LightShadow.prototype ), {
 
-		constructor: DirectionalLightShadow,
-
-		isDirectionalLightShadow: true,
-
-		updateMatrices: function ( light ) {
-
-			LightShadow.prototype.updateMatrices.call( this, light );
-
-		}
+		constructor: DirectionalLightShadow
 
 	} );
 
@@ -39554,325 +38158,17 @@ var Spacekit = (function (exports) {
 	} );
 
 	/**
-	 * @author bhouston / http://clara.io
-	 * @author WestLangley / http://github.com/WestLangley
-	 *
-	 * Primary reference:
-	 *   https://graphics.stanford.edu/papers/envmap/envmap.pdf
-	 *
-	 * Secondary reference:
-	 *   https://www.ppsloan.org/publications/StupidSH36.pdf
-	 */
-
-	// 3-band SH defined by 9 coefficients
-
-	function SphericalHarmonics3() {
-
-		this.coefficients = [];
-
-		for ( var i = 0; i < 9; i ++ ) {
-
-			this.coefficients.push( new Vector3() );
-
-		}
-
-	}
-
-	Object.assign( SphericalHarmonics3.prototype, {
-
-		isSphericalHarmonics3: true,
-
-		set: function ( coefficients ) {
-
-			for ( var i = 0; i < 9; i ++ ) {
-
-				this.coefficients[ i ].copy( coefficients[ i ] );
-
-			}
-
-			return this;
-
-		},
-
-		zero: function () {
-
-			for ( var i = 0; i < 9; i ++ ) {
-
-				this.coefficients[ i ].set( 0, 0, 0 );
-
-			}
-
-			return this;
-
-		},
-
-		// get the radiance in the direction of the normal
-		// target is a Vector3
-		getAt: function ( normal, target ) {
-
-			// normal is assumed to be unit length
-
-			var x = normal.x, y = normal.y, z = normal.z;
-
-			var coeff = this.coefficients;
-
-			// band 0
-			target.copy( coeff[ 0 ] ).multiplyScalar( 0.282095 );
-
-			// band 1
-			target.addScaledVector( coeff[ 1 ], 0.488603 * y );
-			target.addScaledVector( coeff[ 2 ], 0.488603 * z );
-			target.addScaledVector( coeff[ 3 ], 0.488603 * x );
-
-			// band 2
-			target.addScaledVector( coeff[ 4 ], 1.092548 * ( x * y ) );
-			target.addScaledVector( coeff[ 5 ], 1.092548 * ( y * z ) );
-			target.addScaledVector( coeff[ 6 ], 0.315392 * ( 3.0 * z * z - 1.0 ) );
-			target.addScaledVector( coeff[ 7 ], 1.092548 * ( x * z ) );
-			target.addScaledVector( coeff[ 8 ], 0.546274 * ( x * x - y * y ) );
-
-			return target;
-
-		},
-
-		// get the irradiance (radiance convolved with cosine lobe) in the direction of the normal
-		// target is a Vector3
-		// https://graphics.stanford.edu/papers/envmap/envmap.pdf
-		getIrradianceAt: function ( normal, target ) {
-
-			// normal is assumed to be unit length
-
-			var x = normal.x, y = normal.y, z = normal.z;
-
-			var coeff = this.coefficients;
-
-			// band 0
-			target.copy( coeff[ 0 ] ).multiplyScalar( 0.886227 ); // π * 0.282095
-
-			// band 1
-			target.addScaledVector( coeff[ 1 ], 2.0 * 0.511664 * y ); // ( 2 * π / 3 ) * 0.488603
-			target.addScaledVector( coeff[ 2 ], 2.0 * 0.511664 * z );
-			target.addScaledVector( coeff[ 3 ], 2.0 * 0.511664 * x );
-
-			// band 2
-			target.addScaledVector( coeff[ 4 ], 2.0 * 0.429043 * x * y ); // ( π / 4 ) * 1.092548
-			target.addScaledVector( coeff[ 5 ], 2.0 * 0.429043 * y * z );
-			target.addScaledVector( coeff[ 6 ], 0.743125 * z * z - 0.247708 ); // ( π / 4 ) * 0.315392 * 3
-			target.addScaledVector( coeff[ 7 ], 2.0 * 0.429043 * x * z );
-			target.addScaledVector( coeff[ 8 ], 0.429043 * ( x * x - y * y ) ); // ( π / 4 ) * 0.546274
-
-			return target;
-
-		},
-
-		add: function ( sh ) {
-
-			for ( var i = 0; i < 9; i ++ ) {
-
-				this.coefficients[ i ].add( sh.coefficients[ i ] );
-
-			}
-
-			return this;
-
-		},
-
-		addScaledSH: function ( sh, s ) {
-
-			for ( var i = 0; i < 9; i ++ ) {
-
-				this.coefficients[ i ].addScaledVector( sh.coefficients[ i ], s );
-
-			}
-
-			return this;
-
-		},
-
-		scale: function ( s ) {
-
-			for ( var i = 0; i < 9; i ++ ) {
-
-				this.coefficients[ i ].multiplyScalar( s );
-
-			}
-
-			return this;
-
-		},
-
-		lerp: function ( sh, alpha ) {
-
-			for ( var i = 0; i < 9; i ++ ) {
-
-				this.coefficients[ i ].lerp( sh.coefficients[ i ], alpha );
-
-			}
-
-			return this;
-
-		},
-
-		equals: function ( sh ) {
-
-			for ( var i = 0; i < 9; i ++ ) {
-
-				if ( ! this.coefficients[ i ].equals( sh.coefficients[ i ] ) ) {
-
-					return false;
-
-				}
-
-			}
-
-			return true;
-
-		},
-
-		copy: function ( sh ) {
-
-			return this.set( sh.coefficients );
-
-		},
-
-		clone: function () {
-
-			return new this.constructor().copy( this );
-
-		},
-
-		fromArray: function ( array, offset ) {
-
-			if ( offset === undefined ) offset = 0;
-
-			var coefficients = this.coefficients;
-
-			for ( var i = 0; i < 9; i ++ ) {
-
-				coefficients[ i ].fromArray( array, offset + ( i * 3 ) );
-
-			}
-
-			return this;
-
-		},
-
-		toArray: function ( array, offset ) {
-
-			if ( array === undefined ) array = [];
-			if ( offset === undefined ) offset = 0;
-
-			var coefficients = this.coefficients;
-
-			for ( var i = 0; i < 9; i ++ ) {
-
-				coefficients[ i ].toArray( array, offset + ( i * 3 ) );
-
-			}
-
-			return array;
-
-		}
-
-	} );
-
-	Object.assign( SphericalHarmonics3, {
-
-		// evaluate the basis functions
-		// shBasis is an Array[ 9 ]
-		getBasisAt: function ( normal, shBasis ) {
-
-			// normal is assumed to be unit length
-
-			var x = normal.x, y = normal.y, z = normal.z;
-
-			// band 0
-			shBasis[ 0 ] = 0.282095;
-
-			// band 1
-			shBasis[ 1 ] = 0.488603 * y;
-			shBasis[ 2 ] = 0.488603 * z;
-			shBasis[ 3 ] = 0.488603 * x;
-
-			// band 2
-			shBasis[ 4 ] = 1.092548 * x * y;
-			shBasis[ 5 ] = 1.092548 * y * z;
-			shBasis[ 6 ] = 0.315392 * ( 3 * z * z - 1 );
-			shBasis[ 7 ] = 1.092548 * x * z;
-			shBasis[ 8 ] = 0.546274 * ( x * x - y * y );
-
-		}
-
-	} );
-
-	/**
-	 * @author WestLangley / http://github.com/WestLangley
-	 *
-	 * A LightProbe is a source of indirect-diffuse light
-	 */
-
-	function LightProbe( sh, intensity ) {
-
-		Light.call( this, undefined, intensity );
-
-		this.type = 'LightProbe';
-
-		this.sh = ( sh !== undefined ) ? sh : new SphericalHarmonics3();
-
-	}
-
-	LightProbe.prototype = Object.assign( Object.create( Light.prototype ), {
-
-		constructor: LightProbe,
-
-		isLightProbe: true,
-
-		copy: function ( source ) {
-
-			Light.prototype.copy.call( this, source );
-
-			this.sh.copy( source.sh );
-
-			return this;
-
-		},
-
-		fromJSON: function ( json ) {
-
-			this.intensity = json.intensity; // TODO: Move this bit to Light.fromJSON();
-			this.sh.fromArray( json.sh );
-
-			return this;
-
-		},
-
-		toJSON: function ( meta ) {
-
-			var data = Light.prototype.toJSON.call( this, meta );
-
-			data.object.sh = this.sh.toArray();
-
-			return data;
-
-		}
-
-	} );
-
-	/**
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
 	function MaterialLoader( manager ) {
 
-		Loader.call( this, manager );
-
+		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
 		this.textures = {};
 
 	}
 
-	MaterialLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
-
-		constructor: MaterialLoader,
+	Object.assign( MaterialLoader.prototype, {
 
 		load: function ( url, onLoad, onProgress, onError ) {
 
@@ -39911,12 +38207,12 @@ var Spacekit = (function (exports) {
 			if ( json.color !== undefined ) material.color.setHex( json.color );
 			if ( json.roughness !== undefined ) material.roughness = json.roughness;
 			if ( json.metalness !== undefined ) material.metalness = json.metalness;
-			if ( json.sheen !== undefined ) material.sheen = new Color().setHex( json.sheen );
 			if ( json.emissive !== undefined ) material.emissive.setHex( json.emissive );
 			if ( json.specular !== undefined ) material.specular.setHex( json.specular );
 			if ( json.shininess !== undefined ) material.shininess = json.shininess;
-			if ( json.clearcoat !== undefined ) material.clearcoat = json.clearcoat;
-			if ( json.clearcoatRoughness !== undefined ) material.clearcoatRoughness = json.clearcoatRoughness;
+			if ( json.clearCoat !== undefined ) material.clearCoat = json.clearCoat;
+			if ( json.clearCoatRoughness !== undefined ) material.clearCoatRoughness = json.clearCoatRoughness;
+			if ( json.vertexColors !== undefined ) material.vertexColors = json.vertexColors;
 			if ( json.fog !== undefined ) material.fog = json.fog;
 			if ( json.flatShading !== undefined ) material.flatShading = json.flatShading;
 			if ( json.blending !== undefined ) material.blending = json.blending;
@@ -39928,16 +38224,6 @@ var Spacekit = (function (exports) {
 			if ( json.depthTest !== undefined ) material.depthTest = json.depthTest;
 			if ( json.depthWrite !== undefined ) material.depthWrite = json.depthWrite;
 			if ( json.colorWrite !== undefined ) material.colorWrite = json.colorWrite;
-
-			if ( json.stencilWrite !== undefined ) material.stencilWrite = json.stencilWrite;
-			if ( json.stencilWriteMask !== undefined ) material.stencilWriteMask = json.stencilWriteMask;
-			if ( json.stencilFunc !== undefined ) material.stencilFunc = json.stencilFunc;
-			if ( json.stencilRef !== undefined ) material.stencilRef = json.stencilRef;
-			if ( json.stencilFuncMask !== undefined ) material.stencilFuncMask = json.stencilFuncMask;
-			if ( json.stencilFail !== undefined ) material.stencilFail = json.stencilFail;
-			if ( json.stencilZFail !== undefined ) material.stencilZFail = json.stencilZFail;
-			if ( json.stencilZPass !== undefined ) material.stencilZPass = json.stencilZPass;
-
 			if ( json.wireframe !== undefined ) material.wireframe = json.wireframe;
 			if ( json.wireframeLinewidth !== undefined ) material.wireframeLinewidth = json.wireframeLinewidth;
 			if ( json.wireframeLinecap !== undefined ) material.wireframeLinecap = json.wireframeLinecap;
@@ -39959,27 +38245,8 @@ var Spacekit = (function (exports) {
 			if ( json.morphNormals !== undefined ) material.morphNormals = json.morphNormals;
 			if ( json.dithering !== undefined ) material.dithering = json.dithering;
 
-			if ( json.vertexTangents !== undefined ) material.vertexTangents = json.vertexTangents;
-
 			if ( json.visible !== undefined ) material.visible = json.visible;
-
-			if ( json.toneMapped !== undefined ) material.toneMapped = json.toneMapped;
-
 			if ( json.userData !== undefined ) material.userData = json.userData;
-
-			if ( json.vertexColors !== undefined ) {
-
-				if ( typeof json.vertexColors === 'number' ) {
-
-					material.vertexColors = ( json.vertexColors > 0 ) ? true : false;
-
-				} else {
-
-					material.vertexColors = json.vertexColors;
-
-				}
-
-			}
 
 			// Shader Material
 
@@ -40057,7 +38324,12 @@ var Spacekit = (function (exports) {
 			if ( json.map !== undefined ) material.map = getTexture( json.map );
 			if ( json.matcap !== undefined ) material.matcap = getTexture( json.matcap );
 
-			if ( json.alphaMap !== undefined ) material.alphaMap = getTexture( json.alphaMap );
+			if ( json.alphaMap !== undefined ) {
+
+				material.alphaMap = getTexture( json.alphaMap );
+				material.transparent = true;
+
+			}
 
 			if ( json.bumpMap !== undefined ) material.bumpMap = getTexture( json.bumpMap );
 			if ( json.bumpScale !== undefined ) material.bumpScale = json.bumpScale;
@@ -40106,12 +38378,14 @@ var Spacekit = (function (exports) {
 
 			if ( json.gradientMap !== undefined ) material.gradientMap = getTexture( json.gradientMap );
 
-			if ( json.clearcoatMap !== undefined ) material.clearcoatMap = getTexture( json.clearcoatMap );
-			if ( json.clearcoatRoughnessMap !== undefined ) material.clearcoatRoughnessMap = getTexture( json.clearcoatRoughnessMap );
-			if ( json.clearcoatNormalMap !== undefined ) material.clearcoatNormalMap = getTexture( json.clearcoatNormalMap );
-			if ( json.clearcoatNormalScale !== undefined ) material.clearcoatNormalScale = new Vector2().fromArray( json.clearcoatNormalScale );
-
 			return material;
+
+		},
+
+		setPath: function ( value ) {
+
+			this.path = value;
+			return this;
 
 		},
 
@@ -40283,13 +38557,11 @@ var Spacekit = (function (exports) {
 
 	function BufferGeometryLoader( manager ) {
 
-		Loader.call( this, manager );
+		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
 
 	}
 
-	BufferGeometryLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
-
-		constructor: BufferGeometryLoader,
+	Object.assign( BufferGeometryLoader.prototype, {
 
 		load: function ( url, onLoad, onProgress, onError ) {
 
@@ -40327,7 +38599,7 @@ var Spacekit = (function (exports) {
 				var bufferAttributeConstr = attribute.isInstancedBufferAttribute ? InstancedBufferAttribute : BufferAttribute;
 				var bufferAttribute = new bufferAttributeConstr( typedArray, attribute.itemSize, attribute.normalized );
 				if ( attribute.name !== undefined ) bufferAttribute.name = attribute.name;
-				geometry.setAttribute( key, bufferAttribute );
+				geometry.addAttribute( key, bufferAttribute );
 
 			}
 
@@ -40355,14 +38627,6 @@ var Spacekit = (function (exports) {
 					geometry.morphAttributes[ key ] = array;
 
 				}
-
-			}
-
-			var morphTargetsRelative = json.data.morphTargetsRelative;
-
-			if ( morphTargetsRelative ) {
-
-				geometry.morphTargetsRelative = true;
 
 			}
 
@@ -40401,6 +38665,13 @@ var Spacekit = (function (exports) {
 
 			return geometry;
 
+		},
+
+		setPath: function ( value ) {
+
+			this.path = value;
+			return this;
+
 		}
 
 	} );
@@ -40424,19 +38695,20 @@ var Spacekit = (function (exports) {
 
 	function ObjectLoader( manager ) {
 
-		Loader.call( this, manager );
+		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
+		this.resourcePath = '';
 
 	}
 
-	ObjectLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
+	Object.assign( ObjectLoader.prototype, {
 
-		constructor: ObjectLoader,
+		crossOrigin: 'anonymous',
 
 		load: function ( url, onLoad, onProgress, onError ) {
 
 			var scope = this;
 
-			var path = ( this.path === '' ) ? LoaderUtils.extractUrlBase( url ) : this.path;
+			var path = ( this.path === undefined ) ? LoaderUtils.extractUrlBase( url ) : this.path;
 			this.resourcePath = this.resourcePath || path;
 
 			var loader = new FileLoader( scope.manager );
@@ -40471,6 +38743,27 @@ var Spacekit = (function (exports) {
 				scope.parse( json, onLoad );
 
 			}, onProgress, onError );
+
+		},
+
+		setPath: function ( value ) {
+
+			this.path = value;
+			return this;
+
+		},
+
+		setResourcePath: function ( value ) {
+
+			this.resourcePath = value;
+			return this;
+
+		},
+
+		setCrossOrigin: function ( value ) {
+
+			this.crossOrigin = value;
+			return this;
 
 		},
 
@@ -40780,7 +39073,17 @@ var Spacekit = (function (exports) {
 
 						case 'Geometry':
 
-							console.error( 'THREE.ObjectLoader: Loading "Geometry" is not supported anymore.' );
+							if ( 'THREE' in window && 'LegacyJSONLoader' in THREE ) {
+
+								var geometryLoader = new THREE.LegacyJSONLoader();
+								geometry = geometryLoader.parse( data, this.resourcePath ).geometry;
+
+
+							} else {
+
+								console.error( 'THREE.ObjectLoader: You have to import LegacyJSONLoader in order load geometry data of type "Geometry".' );
+
+							}
 
 							break;
 
@@ -41179,12 +39482,6 @@ var Spacekit = (function (exports) {
 
 					break;
 
-				case 'LightProbe':
-
-					object = new LightProbe().fromJSON( data );
-
-					break;
-
 				case 'SkinnedMesh':
 
 					console.warn( 'THREE.ObjectLoader.parseObject() does not support SkinnedMesh yet.' );
@@ -41194,19 +39491,17 @@ var Spacekit = (function (exports) {
 					var geometry = getGeometry( data.geometry );
 					var material = getMaterial( data.material );
 
-					object = new Mesh( geometry, material );
+					if ( geometry.bones && geometry.bones.length > 0 ) {
 
-					break;
+						object = new SkinnedMesh( geometry, material );
 
-				case 'InstancedMesh':
+					} else {
 
-					var geometry = getGeometry( data.geometry );
-					var material = getMaterial( data.material );
-					var count = data.count;
-					var instanceMatrix = data.instanceMatrix;
+						object = new Mesh( geometry, material );
 
-					object = new InstancedMesh( geometry, material, count );
-					object.instanceMatrix = new BufferAttribute( new Float32Array( instanceMatrix.array ), 16 );
+					}
+
+					if ( data.drawMode !== undefined ) object.setDrawMode( data.drawMode );
 
 					break;
 
@@ -41311,8 +39606,6 @@ var Spacekit = (function (exports) {
 
 			if ( data.type === 'LOD' ) {
 
-				if ( data.autoUpdate !== undefined ) object.autoUpdate = data.autoUpdate;
-
 				var levels = data.levels;
 
 				for ( var l = 0; l < levels.length; l ++ ) {
@@ -41381,13 +39674,12 @@ var Spacekit = (function (exports) {
 
 		}
 
-		Loader.call( this, manager );
-
+		this.manager = manager !== undefined ? manager : DefaultLoadingManager;
 		this.options = undefined;
 
 	}
 
-	ImageBitmapLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
+	ImageBitmapLoader.prototype = {
 
 		constructor: ImageBitmapLoader,
 
@@ -41463,9 +39755,22 @@ var Spacekit = (function (exports) {
 
 			scope.manager.itemStart( url );
 
+		},
+
+		setCrossOrigin: function ( /* value */ ) {
+
+			return this;
+
+		},
+
+		setPath: function ( value ) {
+
+			this.path = value;
+			return this;
+
 		}
 
-	} );
+	};
 
 	/**
 	 * @author zz85 / http://www.lab4games.net/zz85/blog
@@ -41491,15 +39796,11 @@ var Spacekit = (function (exports) {
 			this.subPaths.push( this.currentPath );
 			this.currentPath.moveTo( x, y );
 
-			return this;
-
 		},
 
 		lineTo: function ( x, y ) {
 
 			this.currentPath.lineTo( x, y );
-
-			return this;
 
 		},
 
@@ -41507,23 +39808,17 @@ var Spacekit = (function (exports) {
 
 			this.currentPath.quadraticCurveTo( aCPx, aCPy, aX, aY );
 
-			return this;
-
 		},
 
 		bezierCurveTo: function ( aCP1x, aCP1y, aCP2x, aCP2y, aX, aY ) {
 
 			this.currentPath.bezierCurveTo( aCP1x, aCP1y, aCP2x, aCP2y, aX, aY );
 
-			return this;
-
 		},
 
 		splineThru: function ( pts ) {
 
 			this.currentPath.splineThru( pts );
-
-			return this;
 
 		},
 
@@ -41574,7 +39869,6 @@ var Spacekit = (function (exports) {
 							edgeHighPt = inPolygon[ p ]; edgeDy = - edgeDy;
 
 						}
-
 						if ( ( inPt.y < edgeLowPt.y ) || ( inPt.y > edgeHighPt.y ) ) 		continue;
 
 						if ( inPt.y === edgeLowPt.y ) {
@@ -41714,7 +40008,6 @@ var Spacekit = (function (exports) {
 							}
 
 						}
-
 						if ( hole_unassigned ) {
 
 							betterShapeHoles[ sIdx ].push( ho );
@@ -41725,7 +40018,6 @@ var Spacekit = (function (exports) {
 
 				}
 				// console.log("ambiguous: ", ambiguous);
-
 				if ( toChange.length > 0 ) {
 
 					// console.log("to change: ", toChange);
@@ -41798,7 +40090,7 @@ var Spacekit = (function (exports) {
 
 	function createPaths( text, size, data ) {
 
-		var chars = Array.from ? Array.from( text ) : String( text ).split( '' ); // workaround for IE11, see #13988
+		var chars = Array.from ? Array.from( text ) : String( text ).split( '' ); // see #13988
 		var scale = size / data.resolution;
 		var line_height = ( data.boundingBox.yMax - data.boundingBox.yMin + data.underlineThickness ) * scale;
 
@@ -41913,13 +40205,11 @@ var Spacekit = (function (exports) {
 
 	function FontLoader( manager ) {
 
-		Loader.call( this, manager );
+		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
 
 	}
 
-	FontLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
-
-		constructor: FontLoader,
+	Object.assign( FontLoader.prototype, {
 
 		load: function ( url, onLoad, onProgress, onError ) {
 
@@ -41954,7 +40244,333 @@ var Spacekit = (function (exports) {
 
 			return new Font( json );
 
+		},
+
+		setPath: function ( value ) {
+
+			this.path = value;
+			return this;
+
 		}
+
+	} );
+
+	/**
+	 * @author alteredq / http://alteredqualia.com/
+	 */
+
+	function Loader() {}
+
+	Loader.Handlers = {
+
+		handlers: [],
+
+		add: function ( regex, loader ) {
+
+			this.handlers.push( regex, loader );
+
+		},
+
+		get: function ( file ) {
+
+			var handlers = this.handlers;
+
+			for ( var i = 0, l = handlers.length; i < l; i += 2 ) {
+
+				var regex = handlers[ i ];
+				var loader = handlers[ i + 1 ];
+
+				if ( regex.test( file ) ) {
+
+					return loader;
+
+				}
+
+			}
+
+			return null;
+
+		}
+
+	};
+
+	Object.assign( Loader.prototype, {
+
+		crossOrigin: 'anonymous',
+
+		onLoadStart: function () {},
+
+		onLoadProgress: function () {},
+
+		onLoadComplete: function () {},
+
+		initMaterials: function ( materials, texturePath, crossOrigin ) {
+
+			var array = [];
+
+			for ( var i = 0; i < materials.length; ++ i ) {
+
+				array[ i ] = this.createMaterial( materials[ i ], texturePath, crossOrigin );
+
+			}
+
+			return array;
+
+		},
+
+		createMaterial: ( function () {
+
+			var BlendingMode = {
+				NoBlending: NoBlending,
+				NormalBlending: NormalBlending,
+				AdditiveBlending: AdditiveBlending,
+				SubtractiveBlending: SubtractiveBlending,
+				MultiplyBlending: MultiplyBlending,
+				CustomBlending: CustomBlending
+			};
+
+			var color = new Color();
+			var textureLoader = new TextureLoader();
+			var materialLoader = new MaterialLoader();
+
+			return function createMaterial( m, texturePath, crossOrigin ) {
+
+				// convert from old material format
+
+				var textures = {};
+
+				function loadTexture( path, repeat, offset, wrap, anisotropy ) {
+
+					var fullPath = texturePath + path;
+					var loader = Loader.Handlers.get( fullPath );
+
+					var texture;
+
+					if ( loader !== null ) {
+
+						texture = loader.load( fullPath );
+
+					} else {
+
+						textureLoader.setCrossOrigin( crossOrigin );
+						texture = textureLoader.load( fullPath );
+
+					}
+
+					if ( repeat !== undefined ) {
+
+						texture.repeat.fromArray( repeat );
+
+						if ( repeat[ 0 ] !== 1 ) texture.wrapS = RepeatWrapping;
+						if ( repeat[ 1 ] !== 1 ) texture.wrapT = RepeatWrapping;
+
+					}
+
+					if ( offset !== undefined ) {
+
+						texture.offset.fromArray( offset );
+
+					}
+
+					if ( wrap !== undefined ) {
+
+						if ( wrap[ 0 ] === 'repeat' ) texture.wrapS = RepeatWrapping;
+						if ( wrap[ 0 ] === 'mirror' ) texture.wrapS = MirroredRepeatWrapping;
+
+						if ( wrap[ 1 ] === 'repeat' ) texture.wrapT = RepeatWrapping;
+						if ( wrap[ 1 ] === 'mirror' ) texture.wrapT = MirroredRepeatWrapping;
+
+					}
+
+					if ( anisotropy !== undefined ) {
+
+						texture.anisotropy = anisotropy;
+
+					}
+
+					var uuid = _Math.generateUUID();
+
+					textures[ uuid ] = texture;
+
+					return uuid;
+
+				}
+
+				//
+
+				var json = {
+					uuid: _Math.generateUUID(),
+					type: 'MeshLambertMaterial'
+				};
+
+				for ( var name in m ) {
+
+					var value = m[ name ];
+
+					switch ( name ) {
+
+						case 'DbgColor':
+						case 'DbgIndex':
+						case 'opticalDensity':
+						case 'illumination':
+							break;
+						case 'DbgName':
+							json.name = value;
+							break;
+						case 'blending':
+							json.blending = BlendingMode[ value ];
+							break;
+						case 'colorAmbient':
+						case 'mapAmbient':
+							console.warn( 'THREE.Loader.createMaterial:', name, 'is no longer supported.' );
+							break;
+						case 'colorDiffuse':
+							json.color = color.fromArray( value ).getHex();
+							break;
+						case 'colorSpecular':
+							json.specular = color.fromArray( value ).getHex();
+							break;
+						case 'colorEmissive':
+							json.emissive = color.fromArray( value ).getHex();
+							break;
+						case 'specularCoef':
+							json.shininess = value;
+							break;
+						case 'shading':
+							if ( value.toLowerCase() === 'basic' ) json.type = 'MeshBasicMaterial';
+							if ( value.toLowerCase() === 'phong' ) json.type = 'MeshPhongMaterial';
+							if ( value.toLowerCase() === 'standard' ) json.type = 'MeshStandardMaterial';
+							break;
+						case 'mapDiffuse':
+							json.map = loadTexture( value, m.mapDiffuseRepeat, m.mapDiffuseOffset, m.mapDiffuseWrap, m.mapDiffuseAnisotropy );
+							break;
+						case 'mapDiffuseRepeat':
+						case 'mapDiffuseOffset':
+						case 'mapDiffuseWrap':
+						case 'mapDiffuseAnisotropy':
+							break;
+						case 'mapEmissive':
+							json.emissiveMap = loadTexture( value, m.mapEmissiveRepeat, m.mapEmissiveOffset, m.mapEmissiveWrap, m.mapEmissiveAnisotropy );
+							break;
+						case 'mapEmissiveRepeat':
+						case 'mapEmissiveOffset':
+						case 'mapEmissiveWrap':
+						case 'mapEmissiveAnisotropy':
+							break;
+						case 'mapLight':
+							json.lightMap = loadTexture( value, m.mapLightRepeat, m.mapLightOffset, m.mapLightWrap, m.mapLightAnisotropy );
+							break;
+						case 'mapLightRepeat':
+						case 'mapLightOffset':
+						case 'mapLightWrap':
+						case 'mapLightAnisotropy':
+							break;
+						case 'mapAO':
+							json.aoMap = loadTexture( value, m.mapAORepeat, m.mapAOOffset, m.mapAOWrap, m.mapAOAnisotropy );
+							break;
+						case 'mapAORepeat':
+						case 'mapAOOffset':
+						case 'mapAOWrap':
+						case 'mapAOAnisotropy':
+							break;
+						case 'mapBump':
+							json.bumpMap = loadTexture( value, m.mapBumpRepeat, m.mapBumpOffset, m.mapBumpWrap, m.mapBumpAnisotropy );
+							break;
+						case 'mapBumpScale':
+							json.bumpScale = value;
+							break;
+						case 'mapBumpRepeat':
+						case 'mapBumpOffset':
+						case 'mapBumpWrap':
+						case 'mapBumpAnisotropy':
+							break;
+						case 'mapNormal':
+							json.normalMap = loadTexture( value, m.mapNormalRepeat, m.mapNormalOffset, m.mapNormalWrap, m.mapNormalAnisotropy );
+							break;
+						case 'mapNormalFactor':
+							json.normalScale = value;
+							break;
+						case 'mapNormalRepeat':
+						case 'mapNormalOffset':
+						case 'mapNormalWrap':
+						case 'mapNormalAnisotropy':
+							break;
+						case 'mapSpecular':
+							json.specularMap = loadTexture( value, m.mapSpecularRepeat, m.mapSpecularOffset, m.mapSpecularWrap, m.mapSpecularAnisotropy );
+							break;
+						case 'mapSpecularRepeat':
+						case 'mapSpecularOffset':
+						case 'mapSpecularWrap':
+						case 'mapSpecularAnisotropy':
+							break;
+						case 'mapMetalness':
+							json.metalnessMap = loadTexture( value, m.mapMetalnessRepeat, m.mapMetalnessOffset, m.mapMetalnessWrap, m.mapMetalnessAnisotropy );
+							break;
+						case 'mapMetalnessRepeat':
+						case 'mapMetalnessOffset':
+						case 'mapMetalnessWrap':
+						case 'mapMetalnessAnisotropy':
+							break;
+						case 'mapRoughness':
+							json.roughnessMap = loadTexture( value, m.mapRoughnessRepeat, m.mapRoughnessOffset, m.mapRoughnessWrap, m.mapRoughnessAnisotropy );
+							break;
+						case 'mapRoughnessRepeat':
+						case 'mapRoughnessOffset':
+						case 'mapRoughnessWrap':
+						case 'mapRoughnessAnisotropy':
+							break;
+						case 'mapAlpha':
+							json.alphaMap = loadTexture( value, m.mapAlphaRepeat, m.mapAlphaOffset, m.mapAlphaWrap, m.mapAlphaAnisotropy );
+							break;
+						case 'mapAlphaRepeat':
+						case 'mapAlphaOffset':
+						case 'mapAlphaWrap':
+						case 'mapAlphaAnisotropy':
+							break;
+						case 'flipSided':
+							json.side = BackSide;
+							break;
+						case 'doubleSided':
+							json.side = DoubleSide;
+							break;
+						case 'transparency':
+							console.warn( 'THREE.Loader.createMaterial: transparency has been renamed to opacity' );
+							json.opacity = value;
+							break;
+						case 'depthTest':
+						case 'depthWrite':
+						case 'colorWrite':
+						case 'opacity':
+						case 'reflectivity':
+						case 'transparent':
+						case 'visible':
+						case 'wireframe':
+							json[ name ] = value;
+							break;
+						case 'vertexColors':
+							if ( value === true ) json.vertexColors = VertexColors;
+							if ( value === 'face' ) json.vertexColors = FaceColors;
+							break;
+						default:
+							console.error( 'THREE.Loader.createMaterial: Unsupported', name, value );
+							break;
+
+					}
+
+				}
+
+				if ( json.type === 'MeshBasicMaterial' ) delete json.emissive;
+				if ( json.type !== 'MeshPhongMaterial' ) delete json.specular;
+
+				if ( json.opacity < 1 ) json.transparent = true;
+
+				materialLoader.setTextures( textures );
+
+				return materialLoader.parse( json );
+
+			};
+
+		} )()
 
 	} );
 
@@ -41962,25 +40578,25 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-	var _context;
+	var context;
 
 	var AudioContext = {
 
 		getContext: function () {
 
-			if ( _context === undefined ) {
+			if ( context === undefined ) {
 
-				_context = new ( window.AudioContext || window.webkitAudioContext )();
+				context = new ( window.AudioContext || window.webkitAudioContext )();
 
 			}
 
-			return _context;
+			return context;
 
 		},
 
 		setContext: function ( value ) {
 
-			_context = value;
+			context = value;
 
 		}
 
@@ -41992,13 +40608,11 @@ var Spacekit = (function (exports) {
 
 	function AudioLoader( manager ) {
 
-		Loader.call( this, manager );
+		this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
 
 	}
 
-	AudioLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
-
-		constructor: AudioLoader,
+	Object.assign( AudioLoader.prototype, {
 
 		load: function ( url, onLoad, onProgress, onError ) {
 
@@ -42019,6 +40633,293 @@ var Spacekit = (function (exports) {
 				} );
 
 			}, onProgress, onError );
+
+		},
+
+		setPath: function ( value ) {
+
+			this.path = value;
+			return this;
+
+		}
+
+	} );
+
+	/**
+	 * @author bhouston / http://clara.io
+	 * @author WestLangley / http://github.com/WestLangley
+	 *
+	 * Primary reference:
+	 *   https://graphics.stanford.edu/papers/envmap/envmap.pdf
+	 *
+	 * Secondary reference:
+	 *   https://www.ppsloan.org/publications/StupidSH36.pdf
+	 */
+
+	// 3-band SH defined by 9 coefficients
+
+	function SphericalHarmonics3() {
+
+		this.coefficients = [];
+
+		for ( var i = 0; i < 9; i ++ ) {
+
+			this.coefficients.push( new Vector3() );
+
+		}
+
+	}
+
+	Object.assign( SphericalHarmonics3.prototype, {
+
+		isSphericalHarmonics3: true,
+
+		set: function ( coefficients ) {
+
+			for ( var i = 0; i < 9; i ++ ) {
+
+				this.coefficients[ i ].copy( coefficients[ i ] );
+
+			}
+
+			return this;
+
+		},
+
+		zero: function () {
+
+			for ( var i = 0; i < 9; i ++ ) {
+
+				this.coefficients[ i ].set( 0, 0, 0 );
+
+			}
+
+			return this;
+
+		},
+
+		// get the radiance in the direction of the normal
+		// target is a Vector3
+		getAt: function ( normal, target ) {
+
+			// normal is assumed to be unit length
+
+			var x = normal.x, y = normal.y, z = normal.z;
+
+			var coeff = this.coefficients;
+
+			// band 0
+			target.copy( coeff[ 0 ] ).multiplyScalar( 0.282095 );
+
+			// band 1
+			target.addScale( coeff[ 1 ], 0.488603 * y );
+			target.addScale( coeff[ 2 ], 0.488603 * z );
+			target.addScale( coeff[ 3 ], 0.488603 * x );
+
+			// band 2
+			target.addScale( coeff[ 4 ], 1.092548 * ( x * y ) );
+			target.addScale( coeff[ 5 ], 1.092548 * ( y * z ) );
+			target.addScale( coeff[ 6 ], 0.315392 * ( 3.0 * z * z - 1.0 ) );
+			target.addScale( coeff[ 7 ], 1.092548 * ( x * z ) );
+			target.addScale( coeff[ 8 ], 0.546274 * ( x * x - y * y ) );
+
+			return target;
+
+		},
+
+		// get the irradiance (radiance convolved with cosine lobe) in the direction of the normal
+		// target is a Vector3
+		// https://graphics.stanford.edu/papers/envmap/envmap.pdf
+		getIrradianceAt: function ( normal, target ) {
+
+			// normal is assumed to be unit length
+
+			var x = normal.x, y = normal.y, z = normal.z;
+
+			var coeff = this.coefficients;
+
+			// band 0
+			target.copy( coeff[ 0 ] ).multiplyScalar( 0.886227 ); // π * 0.282095
+
+			// band 1
+			target.addScale( coeff[ 1 ], 2.0 * 0.511664 * y ); // ( 2 * π / 3 ) * 0.488603
+			target.addScale( coeff[ 2 ], 2.0 * 0.511664 * z );
+			target.addScale( coeff[ 3 ], 2.0 * 0.511664 * x );
+
+			// band 2
+			target.addScale( coeff[ 4 ], 2.0 * 0.429043 * x * y ); // ( π / 4 ) * 1.092548
+			target.addScale( coeff[ 5 ], 2.0 * 0.429043 * y * z );
+			target.addScale( coeff[ 6 ], 0.743125 * z * z - 0.247708 ); // ( π / 4 ) * 0.315392 * 3
+			target.addScale( coeff[ 7 ], 2.0 * 0.429043 * x * z );
+			target.addScale( coeff[ 8 ], 0.429043 * ( x * x - y * y ) ); // ( π / 4 ) * 0.546274
+
+			return target;
+
+		},
+
+		add: function ( sh ) {
+
+			for ( var i = 0; i < 9; i ++ ) {
+
+				this.coefficients[ i ].add( sh.coefficients[ i ] );
+
+			}
+
+			return this;
+
+		},
+
+
+		scale: function ( s ) {
+
+			for ( var i = 0; i < 9; i ++ ) {
+
+				this.coefficients[ i ].multiplyScalar( s );
+
+			}
+
+			return this;
+
+		},
+
+		lerp: function ( sh, alpha ) {
+
+			for ( var i = 0; i < 9; i ++ ) {
+
+				this.coefficients[ i ].lerp( sh.coefficients[ i ], alpha );
+
+			}
+
+			return this;
+
+		},
+
+		equals: function ( sh ) {
+
+			for ( var i = 0; i < 9; i ++ ) {
+
+				if ( ! this.coefficients[ i ].equals( sh.coefficients[ i ] ) ) {
+
+					return false;
+
+				}
+
+			}
+
+			return true;
+
+		},
+
+		copy: function ( sh ) {
+
+			return this.set( sh.coefficients );
+
+		},
+
+		clone: function () {
+
+			return new this.constructor().copy( this );
+
+		},
+
+		fromArray: function ( array ) {
+
+			var coefficients = this.coefficients;
+
+			for ( var i = 0; i < 9; i ++ ) {
+
+				coefficients[ i ].fromArray( array, i * 3 );
+
+			}
+
+			return this;
+
+		},
+
+		toArray: function () {
+
+			var array = [];
+			var coefficients = this.coefficients;
+
+			for ( var i = 0; i < 9; i ++ ) {
+
+				coefficients[ i ].toArray( array, i * 3 );
+
+			}
+
+			return array;
+
+		}
+
+	} );
+
+	Object.assign( SphericalHarmonics3, {
+
+		// evaluate the basis functions
+		// shBasis is an Array[ 9 ]
+		getBasisAt: function ( normal, shBasis ) {
+
+			// normal is assumed to be unit length
+
+			var x = normal.x, y = normal.y, z = normal.z;
+
+			// band 0
+			shBasis[ 0 ] = 0.282095;
+
+			// band 1
+			shBasis[ 1 ] = 0.488603 * y;
+			shBasis[ 2 ] = 0.488603 * z;
+			shBasis[ 3 ] = 0.488603 * x;
+
+			// band 2
+			shBasis[ 4 ] = 1.092548 * x * y;
+			shBasis[ 5 ] = 1.092548 * y * z;
+			shBasis[ 6 ] = 0.315392 * ( 3 * z * z - 1 );
+			shBasis[ 7 ] = 1.092548 * x * z;
+			shBasis[ 8 ] = 0.546274 * ( x * x - y * y );
+
+		}
+
+	} );
+
+	/**
+	 * @author WestLangley / http://github.com/WestLangley
+	 *
+	 * A LightProbe is a source of indirect-diffuse light
+	 */
+
+	function LightProbe( sh, intensity ) {
+
+		Light.call( this, undefined, intensity );
+
+		this.sh = ( sh !== undefined ) ? sh : new SphericalHarmonics3();
+
+	}
+
+	LightProbe.prototype = Object.assign( Object.create( Light.prototype ), {
+
+		constructor: LightProbe,
+
+		isLightProbe: true,
+
+		copy: function ( source ) {
+
+			Light.prototype.copy.call( this, source );
+
+			this.sh.copy( source.sh );
+			this.intensity = source.intensity;
+
+			return this;
+
+		},
+
+		toJSON: function ( meta ) {
+
+			var data = Light.prototype.toJSON.call( this, meta );
+
+			// data.sh = this.sh.toArray(); // todo
+
+			return data;
 
 		}
 
@@ -42114,9 +41015,6 @@ var Spacekit = (function (exports) {
 
 	} );
 
-	var _eyeRight = new Matrix4();
-	var _eyeLeft = new Matrix4();
-
 	/**
 	 * @author mrdoob / http://mrdoob.com/
 	 */
@@ -42137,78 +41035,75 @@ var Spacekit = (function (exports) {
 		this.cameraR.layers.enable( 2 );
 		this.cameraR.matrixAutoUpdate = false;
 
-		this._cache = {
-			focus: null,
-			fov: null,
-			aspect: null,
-			near: null,
-			far: null,
-			zoom: null,
-			eyeSep: null
-		};
-
 	}
 
 	Object.assign( StereoCamera.prototype, {
 
-		update: function ( camera ) {
+		update: ( function () {
 
-			var cache = this._cache;
+			var instance, focus, fov, aspect, near, far, zoom, eyeSep;
 
-			var needsUpdate = cache.focus !== camera.focus || cache.fov !== camera.fov ||
-				cache.aspect !== camera.aspect * this.aspect || cache.near !== camera.near ||
-				cache.far !== camera.far || cache.zoom !== camera.zoom || cache.eyeSep !== this.eyeSep;
+			var eyeRight = new Matrix4();
+			var eyeLeft = new Matrix4();
 
-			if ( needsUpdate ) {
+			return function update( camera ) {
 
-				cache.focus = camera.focus;
-				cache.fov = camera.fov;
-				cache.aspect = camera.aspect * this.aspect;
-				cache.near = camera.near;
-				cache.far = camera.far;
-				cache.zoom = camera.zoom;
-				cache.eyeSep = this.eyeSep;
+				var needsUpdate = instance !== this || focus !== camera.focus || fov !== camera.fov ||
+													aspect !== camera.aspect * this.aspect || near !== camera.near ||
+													far !== camera.far || zoom !== camera.zoom || eyeSep !== this.eyeSep;
 
-				// Off-axis stereoscopic effect based on
-				// http://paulbourke.net/stereographics/stereorender/
+				if ( needsUpdate ) {
 
-				var projectionMatrix = camera.projectionMatrix.clone();
-				var eyeSepHalf = cache.eyeSep / 2;
-				var eyeSepOnProjection = eyeSepHalf * cache.near / cache.focus;
-				var ymax = ( cache.near * Math.tan( MathUtils.DEG2RAD * cache.fov * 0.5 ) ) / cache.zoom;
-				var xmin, xmax;
+					instance = this;
+					focus = camera.focus;
+					fov = camera.fov;
+					aspect = camera.aspect * this.aspect;
+					near = camera.near;
+					far = camera.far;
+					zoom = camera.zoom;
 
-				// translate xOffset
+					// Off-axis stereoscopic effect based on
+					// http://paulbourke.net/stereographics/stereorender/
 
-				_eyeLeft.elements[ 12 ] = - eyeSepHalf;
-				_eyeRight.elements[ 12 ] = eyeSepHalf;
+					var projectionMatrix = camera.projectionMatrix.clone();
+					eyeSep = this.eyeSep / 2;
+					var eyeSepOnProjection = eyeSep * near / focus;
+					var ymax = ( near * Math.tan( _Math.DEG2RAD * fov * 0.5 ) ) / zoom;
+					var xmin, xmax;
 
-				// for left eye
+					// translate xOffset
 
-				xmin = - ymax * cache.aspect + eyeSepOnProjection;
-				xmax = ymax * cache.aspect + eyeSepOnProjection;
+					eyeLeft.elements[ 12 ] = - eyeSep;
+					eyeRight.elements[ 12 ] = eyeSep;
 
-				projectionMatrix.elements[ 0 ] = 2 * cache.near / ( xmax - xmin );
-				projectionMatrix.elements[ 8 ] = ( xmax + xmin ) / ( xmax - xmin );
+					// for left eye
 
-				this.cameraL.projectionMatrix.copy( projectionMatrix );
+					xmin = - ymax * aspect + eyeSepOnProjection;
+					xmax = ymax * aspect + eyeSepOnProjection;
 
-				// for right eye
+					projectionMatrix.elements[ 0 ] = 2 * near / ( xmax - xmin );
+					projectionMatrix.elements[ 8 ] = ( xmax + xmin ) / ( xmax - xmin );
 
-				xmin = - ymax * cache.aspect - eyeSepOnProjection;
-				xmax = ymax * cache.aspect - eyeSepOnProjection;
+					this.cameraL.projectionMatrix.copy( projectionMatrix );
 
-				projectionMatrix.elements[ 0 ] = 2 * cache.near / ( xmax - xmin );
-				projectionMatrix.elements[ 8 ] = ( xmax + xmin ) / ( xmax - xmin );
+					// for right eye
 
-				this.cameraR.projectionMatrix.copy( projectionMatrix );
+					xmin = - ymax * aspect - eyeSepOnProjection;
+					xmax = ymax * aspect - eyeSepOnProjection;
 
-			}
+					projectionMatrix.elements[ 0 ] = 2 * near / ( xmax - xmin );
+					projectionMatrix.elements[ 8 ] = ( xmax + xmin ) / ( xmax - xmin );
 
-			this.cameraL.matrixWorld.copy( camera.matrixWorld ).multiply( _eyeLeft );
-			this.cameraR.matrixWorld.copy( camera.matrixWorld ).multiply( _eyeRight );
+					this.cameraR.projectionMatrix.copy( projectionMatrix );
 
-		}
+				}
+
+				this.cameraL.matrixWorld.copy( camera.matrixWorld ).multiply( eyeLeft );
+				this.cameraR.matrixWorld.copy( camera.matrixWorld ).multiply( eyeRight );
+
+			};
+
+		} )()
 
 	} );
 
@@ -42287,11 +41182,6 @@ var Spacekit = (function (exports) {
 	 * @author mrdoob / http://mrdoob.com/
 	 */
 
-	var _position$2 = new Vector3();
-	var _quaternion$3 = new Quaternion();
-	var _scale$1 = new Vector3();
-	var _orientation = new Vector3();
-
 	function AudioListener() {
 
 		Object3D.call( this );
@@ -42306,10 +41196,6 @@ var Spacekit = (function (exports) {
 		this.filter = null;
 
 		this.timeDelta = 0;
-
-		// private
-
-		this._clock = new Clock();
 
 	}
 
@@ -42379,43 +41265,54 @@ var Spacekit = (function (exports) {
 
 		},
 
-		updateMatrixWorld: function ( force ) {
+		updateMatrixWorld: ( function () {
 
-			Object3D.prototype.updateMatrixWorld.call( this, force );
+			var position = new Vector3();
+			var quaternion = new Quaternion();
+			var scale = new Vector3();
 
-			var listener = this.context.listener;
-			var up = this.up;
+			var orientation = new Vector3();
+			var clock = new Clock();
 
-			this.timeDelta = this._clock.getDelta();
+			return function updateMatrixWorld( force ) {
 
-			this.matrixWorld.decompose( _position$2, _quaternion$3, _scale$1 );
+				Object3D.prototype.updateMatrixWorld.call( this, force );
 
-			_orientation.set( 0, 0, - 1 ).applyQuaternion( _quaternion$3 );
+				var listener = this.context.listener;
+				var up = this.up;
 
-			if ( listener.positionX ) {
+				this.timeDelta = clock.getDelta();
 
-				// code path for Chrome (see #14393)
+				this.matrixWorld.decompose( position, quaternion, scale );
 
-				var endTime = this.context.currentTime + this.timeDelta;
+				orientation.set( 0, 0, - 1 ).applyQuaternion( quaternion );
 
-				listener.positionX.linearRampToValueAtTime( _position$2.x, endTime );
-				listener.positionY.linearRampToValueAtTime( _position$2.y, endTime );
-				listener.positionZ.linearRampToValueAtTime( _position$2.z, endTime );
-				listener.forwardX.linearRampToValueAtTime( _orientation.x, endTime );
-				listener.forwardY.linearRampToValueAtTime( _orientation.y, endTime );
-				listener.forwardZ.linearRampToValueAtTime( _orientation.z, endTime );
-				listener.upX.linearRampToValueAtTime( up.x, endTime );
-				listener.upY.linearRampToValueAtTime( up.y, endTime );
-				listener.upZ.linearRampToValueAtTime( up.z, endTime );
+				if ( listener.positionX ) {
 
-			} else {
+					// code path for Chrome (see #14393)
 
-				listener.setPosition( _position$2.x, _position$2.y, _position$2.z );
-				listener.setOrientation( _orientation.x, _orientation.y, _orientation.z, up.x, up.y, up.z );
+					var endTime = this.context.currentTime + this.timeDelta;
 
-			}
+					listener.positionX.linearRampToValueAtTime( position.x, endTime );
+					listener.positionY.linearRampToValueAtTime( position.y, endTime );
+					listener.positionZ.linearRampToValueAtTime( position.z, endTime );
+					listener.forwardX.linearRampToValueAtTime( orientation.x, endTime );
+					listener.forwardY.linearRampToValueAtTime( orientation.y, endTime );
+					listener.forwardZ.linearRampToValueAtTime( orientation.z, endTime );
+					listener.upX.linearRampToValueAtTime( up.x, endTime );
+					listener.upY.linearRampToValueAtTime( up.y, endTime );
+					listener.upZ.linearRampToValueAtTime( up.z, endTime );
 
-		}
+				} else {
+
+					listener.setPosition( position.x, position.y, position.z );
+					listener.setOrientation( orientation.x, orientation.y, orientation.z, up.x, up.y, up.z );
+
+				}
+
+			};
+
+		} )()
 
 	} );
 
@@ -42441,17 +41338,12 @@ var Spacekit = (function (exports) {
 		this.buffer = null;
 		this.detune = 0;
 		this.loop = false;
-		this.loopStart = 0;
-		this.loopEnd = 0;
+		this.startTime = 0;
 		this.offset = 0;
-		this.duration = undefined;
 		this.playbackRate = 1;
 		this.isPlaying = false;
 		this.hasPlaybackControl = true;
 		this.sourceType = 'empty';
-
-		this._startedAt = 0;
-		this._progress = 0;
 
 		this.filters = [];
 
@@ -42489,17 +41381,6 @@ var Spacekit = (function (exports) {
 
 		},
 
-		setMediaStreamSource: function ( mediaStream ) {
-
-			this.hasPlaybackControl = false;
-			this.sourceType = 'mediaStreamNode';
-			this.source = this.context.createMediaStreamSource( mediaStream );
-			this.connect();
-
-			return this;
-
-		},
-
 		setBuffer: function ( audioBuffer ) {
 
 			this.buffer = audioBuffer;
@@ -42511,9 +41392,7 @@ var Spacekit = (function (exports) {
 
 		},
 
-		play: function ( delay ) {
-
-			if ( delay === undefined ) delay = 0;
+		play: function () {
 
 			if ( this.isPlaying === true ) {
 
@@ -42529,15 +41408,13 @@ var Spacekit = (function (exports) {
 
 			}
 
-			this._startedAt = this.context.currentTime + delay;
-
 			var source = this.context.createBufferSource();
+
 			source.buffer = this.buffer;
 			source.loop = this.loop;
-			source.loopStart = this.loopStart;
-			source.loopEnd = this.loopEnd;
 			source.onended = this.onEnded.bind( this );
-			source.start( this._startedAt, this._progress + this.offset, this.duration );
+			this.startTime = this.context.currentTime;
+			source.start( this.startTime, this.offset );
 
 			this.isPlaying = true;
 
@@ -42561,21 +41438,9 @@ var Spacekit = (function (exports) {
 
 			if ( this.isPlaying === true ) {
 
-				// update current progress
-
-				this._progress += Math.max( this.context.currentTime - this._startedAt, 0 ) * this.playbackRate;
-
-				if ( this.loop === true ) {
-
-					// ensure _progress does not exceed duration with looped audios
-
-					this._progress = this._progress % ( this.duration || this.buffer.duration );
-
-				}
-
 				this.source.stop();
 				this.source.onended = null;
-
+				this.offset += ( this.context.currentTime - this.startTime ) * this.playbackRate;
 				this.isPlaying = false;
 
 			}
@@ -42593,10 +41458,9 @@ var Spacekit = (function (exports) {
 
 			}
 
-			this._progress = 0;
-
 			this.source.stop();
 			this.source.onended = null;
+			this.offset = 0;
 			this.isPlaying = false;
 
 			return this;
@@ -42778,22 +41642,6 @@ var Spacekit = (function (exports) {
 
 		},
 
-		setLoopStart: function ( value ) {
-
-			this.loopStart = value;
-
-			return this;
-
-		},
-
-		setLoopEnd: function ( value ) {
-
-			this.loopEnd = value;
-
-			return this;
-
-		},
-
 		getVolume: function () {
 
 			return this.gain.gain.value;
@@ -42813,11 +41661,6 @@ var Spacekit = (function (exports) {
 	/**
 	 * @author mrdoob / http://mrdoob.com/
 	 */
-
-	var _position$3 = new Vector3();
-	var _quaternion$4 = new Quaternion();
-	var _scale$2 = new Vector3();
-	var _orientation$1 = new Vector3();
 
 	function PositionalAudio( listener ) {
 
@@ -42905,39 +41748,50 @@ var Spacekit = (function (exports) {
 
 		},
 
-		updateMatrixWorld: function ( force ) {
+		updateMatrixWorld: ( function () {
 
-			Object3D.prototype.updateMatrixWorld.call( this, force );
+			var position = new Vector3();
+			var quaternion = new Quaternion();
+			var scale = new Vector3();
 
-			if ( this.hasPlaybackControl === true && this.isPlaying === false ) return;
+			var orientation = new Vector3();
 
-			this.matrixWorld.decompose( _position$3, _quaternion$4, _scale$2 );
+			return function updateMatrixWorld( force ) {
 
-			_orientation$1.set( 0, 0, 1 ).applyQuaternion( _quaternion$4 );
+				Object3D.prototype.updateMatrixWorld.call( this, force );
 
-			var panner = this.panner;
+				if ( this.hasPlaybackControl === true && this.isPlaying === false ) return;
 
-			if ( panner.positionX ) {
+				this.matrixWorld.decompose( position, quaternion, scale );
 
-				// code path for Chrome and Firefox (see #14393)
+				orientation.set( 0, 0, 1 ).applyQuaternion( quaternion );
 
-				var endTime = this.context.currentTime + this.listener.timeDelta;
+				var panner = this.panner;
 
-				panner.positionX.linearRampToValueAtTime( _position$3.x, endTime );
-				panner.positionY.linearRampToValueAtTime( _position$3.y, endTime );
-				panner.positionZ.linearRampToValueAtTime( _position$3.z, endTime );
-				panner.orientationX.linearRampToValueAtTime( _orientation$1.x, endTime );
-				panner.orientationY.linearRampToValueAtTime( _orientation$1.y, endTime );
-				panner.orientationZ.linearRampToValueAtTime( _orientation$1.z, endTime );
+				if ( panner.positionX ) {
 
-			} else {
+					// code path for Chrome and Firefox (see #14393)
 
-				panner.setPosition( _position$3.x, _position$3.y, _position$3.z );
-				panner.setOrientation( _orientation$1.x, _orientation$1.y, _orientation$1.z );
+					var endTime = this.context.currentTime + this.listener.timeDelta;
 
-			}
+					panner.positionX.linearRampToValueAtTime( position.x, endTime );
+					panner.positionY.linearRampToValueAtTime( position.y, endTime );
+					panner.positionZ.linearRampToValueAtTime( position.z, endTime );
+					panner.orientationX.linearRampToValueAtTime( orientation.x, endTime );
+					panner.orientationY.linearRampToValueAtTime( orientation.y, endTime );
+					panner.orientationZ.linearRampToValueAtTime( orientation.z, endTime );
 
-		}
+				} else {
+
+					panner.setPosition( position.x, position.y, position.z );
+					panner.setOrientation( orientation.x, orientation.y, orientation.z );
+
+				}
+
+			};
+
+		} )()
+
 
 	} );
 
@@ -42997,11 +41851,28 @@ var Spacekit = (function (exports) {
 		this.binding = binding;
 		this.valueSize = valueSize;
 
-		var mixFunction,
-			mixFunctionAdditive,
-			setIdentity;
+		var bufferType = Float64Array,
+			mixFunction;
 
-		// buffer layout: [ incoming | accu0 | accu1 | orig | addAccu | (optional work) ]
+		switch ( typeName ) {
+
+			case 'quaternion':
+				mixFunction = this._slerp;
+				break;
+
+			case 'string':
+			case 'bool':
+				bufferType = Array;
+				mixFunction = this._select;
+				break;
+
+			default:
+				mixFunction = this._lerp;
+
+		}
+
+		this.buffer = new bufferType( valueSize * 4 );
+		// layout: [ incoming | accu0 | accu1 | orig ]
 		//
 		// interpolators can use .buffer as their .result
 		// the data then goes to 'incoming'
@@ -43011,53 +41882,10 @@ var Spacekit = (function (exports) {
 		// changes
 		//
 		// 'orig' stores the original state of the property
-		//
-		// 'add' is used for additive cumulative results
-		//
-		// 'work' is optional and is only present for quaternion types. It is used
-		// to store intermediate quaternion multiplication results
-
-		switch ( typeName ) {
-
-			case 'quaternion':
-				mixFunction = this._slerp;
-				mixFunctionAdditive = this._slerpAdditive;
-				setIdentity = this._setAdditiveIdentityQuaternion;
-
-				this.buffer = new Float64Array( valueSize * 6 );
-				this._workIndex = 5;
-				break;
-
-			case 'string':
-			case 'bool':
-				mixFunction = this._select;
-
-				// Use the regular mix function and for additive on these types,
-				// additive is not relevant for non-numeric types
-				mixFunctionAdditive = this._select;
-
-				setIdentity = this._setAdditiveIdentityOther;
-
-				this.buffer = new Array( valueSize * 5 );
-				break;
-
-			default:
-				mixFunction = this._lerp;
-				mixFunctionAdditive = this._lerpAdditive;
-				setIdentity = this._setAdditiveIdentityNumeric;
-
-				this.buffer = new Float64Array( valueSize * 5 );
-
-		}
 
 		this._mixBufferRegion = mixFunction;
-		this._mixBufferRegionAdditive = mixFunctionAdditive;
-		this._setIdentity = setIdentity;
-		this._origIndex = 3;
-		this._addIndex = 4;
 
 		this.cumulativeWeight = 0;
-		this.cumulativeWeightAdditive = 0;
 
 		this.useCount = 0;
 		this.referenceCount = 0;
@@ -43104,28 +41932,6 @@ var Spacekit = (function (exports) {
 
 		},
 
-		// accumulate data in the 'incoming' region into 'add'
-		accumulateAdditive: function ( weight ) {
-
-			var buffer = this.buffer,
-				stride = this.valueSize,
-				offset = stride * this._addIndex;
-
-			if ( this.cumulativeWeightAdditive === 0 ) {
-
-				// add = identity
-
-				this._setIdentity();
-
-			}
-
-			// add := add + incoming * weight
-
-			this._mixBufferRegionAdditive( buffer, offset, 0, weight, stride );
-			this.cumulativeWeightAdditive += weight;
-
-		},
-
 		// apply the state of 'accu<i>' to the binding when accus differ
 		apply: function ( accuIndex ) {
 
@@ -43134,29 +41940,19 @@ var Spacekit = (function (exports) {
 				offset = accuIndex * stride + stride,
 
 				weight = this.cumulativeWeight,
-				weightAdditive = this.cumulativeWeightAdditive,
 
 				binding = this.binding;
 
 			this.cumulativeWeight = 0;
-			this.cumulativeWeightAdditive = 0;
 
 			if ( weight < 1 ) {
 
 				// accuN := accuN + original * ( 1 - cumulativeWeight )
 
-				var originalValueOffset = stride * this._origIndex;
+				var originalValueOffset = stride * 3;
 
 				this._mixBufferRegion(
 					buffer, offset, originalValueOffset, 1 - weight, stride );
-
-			}
-
-			if ( weightAdditive > 0 ) {
-
-				// accuN := accuN + additive accuN
-
-				this._mixBufferRegionAdditive( buffer, offset, this._addIndex * stride, 1, stride );
 
 			}
 
@@ -43183,7 +41979,7 @@ var Spacekit = (function (exports) {
 			var buffer = this.buffer,
 				stride = this.valueSize,
 
-				originalValueOffset = stride * this._origIndex;
+				originalValueOffset = stride * 3;
 
 			binding.getValue( buffer, originalValueOffset );
 
@@ -43194,11 +41990,7 @@ var Spacekit = (function (exports) {
 
 			}
 
-			// Add to identity for additive
-			this._setIdentity();
-
 			this.cumulativeWeight = 0;
-			this.cumulativeWeightAdditive = 0;
 
 		},
 
@@ -43207,30 +41999,6 @@ var Spacekit = (function (exports) {
 
 			var originalValueOffset = this.valueSize * 3;
 			this.binding.setValue( this.buffer, originalValueOffset );
-
-		},
-
-		_setAdditiveIdentityNumeric: function () {
-
-			var startIndex = this._addIndex * this.valueSize;
-
-			this.buffer.fill( 0, startIndex, startIndex + this.valueSize );
-
-		},
-
-		_setAdditiveIdentityQuaternion: function () {
-
-			this._setAdditiveIdentityNumeric();
-			this.buffer[ this._addIndex * 4 + 3 ] = 1;
-
-		},
-
-		_setAdditiveIdentityOther: function () {
-
-			var startIndex = this._origIndex * this.valueSize;
-			var targetIndex = this._addIndex * this.valueSize;
-
-			this.buffer.copyWithin( targetIndex, startIndex, this.valueSize );
 
 		},
 
@@ -43257,18 +42025,6 @@ var Spacekit = (function (exports) {
 
 		},
 
-		_slerpAdditive: function ( buffer, dstOffset, srcOffset, t, stride ) {
-
-			var workOffset = this._workIndex * stride;
-
-			// Store result in intermediate buffer offset
-			Quaternion.multiplyQuaternionsFlat( buffer, workOffset, buffer, dstOffset, buffer, srcOffset );
-
-			// Slerp to the intermediate result
-			Quaternion.slerpFlat( buffer, dstOffset, buffer, dstOffset, buffer, workOffset, t );
-
-		},
-
 		_lerp: function ( buffer, dstOffset, srcOffset, t, stride ) {
 
 			var s = 1 - t;
@@ -43278,18 +42034,6 @@ var Spacekit = (function (exports) {
 				var j = dstOffset + i;
 
 				buffer[ j ] = buffer[ j ] * s + buffer[ srcOffset + i ] * t;
-
-			}
-
-		},
-
-		_lerpAdditive: function ( buffer, dstOffset, srcOffset, t, stride ) {
-
-			for ( var i = 0; i !== stride; ++ i ) {
-
-				var j = dstOffset + i;
-
-				buffer[ j ] = buffer[ j ] + buffer[ srcOffset + i ] * t;
 
 			}
 
@@ -43308,40 +42052,7 @@ var Spacekit = (function (exports) {
 	 */
 
 	// Characters [].:/ are reserved for track binding syntax.
-	var _RESERVED_CHARS_RE = '\\[\\]\\.:\\/';
-	var _reservedRe = new RegExp( '[' + _RESERVED_CHARS_RE + ']', 'g' );
-
-	// Attempts to allow node names from any language. ES5's `\w` regexp matches
-	// only latin characters, and the unicode \p{L} is not yet supported. So
-	// instead, we exclude reserved characters and match everything else.
-	var _wordChar = '[^' + _RESERVED_CHARS_RE + ']';
-	var _wordCharOrDot = '[^' + _RESERVED_CHARS_RE.replace( '\\.', '' ) + ']';
-
-	// Parent directories, delimited by '/' or ':'. Currently unused, but must
-	// be matched to parse the rest of the track name.
-	var _directoryRe = /((?:WC+[\/:])*)/.source.replace( 'WC', _wordChar );
-
-	// Target node. May contain word characters (a-zA-Z0-9_) and '.' or '-'.
-	var _nodeRe = /(WCOD+)?/.source.replace( 'WCOD', _wordCharOrDot );
-
-	// Object on target node, and accessor. May not contain reserved
-	// characters. Accessor may contain any character except closing bracket.
-	var _objectRe = /(?:\.(WC+)(?:\[(.+)\])?)?/.source.replace( 'WC', _wordChar );
-
-	// Property and accessor. May not contain reserved characters. Accessor may
-	// contain any non-bracket characters.
-	var _propertyRe = /\.(WC+)(?:\[(.+)\])?/.source.replace( 'WC', _wordChar );
-
-	var _trackRe = new RegExp( ''
-		+ '^'
-		+ _directoryRe
-		+ _nodeRe
-		+ _objectRe
-		+ _propertyRe
-		+ '$'
-	);
-
-	var _supportedObjectNames = [ 'material', 'materials', 'bones' ];
+	var RESERVED_CHARS_RE = '\\[\\]\\.:\\/';
 
 	function Composite( targetGroup, path, optionalParsedPath ) {
 
@@ -43441,63 +42152,105 @@ var Spacekit = (function (exports) {
 		 * @param {string} name Node name to be sanitized.
 		 * @return {string}
 		 */
-		sanitizeNodeName: function ( name ) {
+		sanitizeNodeName: ( function () {
 
-			return name.replace( /\s/g, '_' ).replace( _reservedRe, '' );
+			var reservedRe = new RegExp( '[' + RESERVED_CHARS_RE + ']', 'g' );
 
-		},
+			return function sanitizeNodeName( name ) {
 
-		parseTrackName: function ( trackName ) {
+				return name.replace( /\s/g, '_' ).replace( reservedRe, '' );
 
-			var matches = _trackRe.exec( trackName );
-
-			if ( ! matches ) {
-
-				throw new Error( 'PropertyBinding: Cannot parse trackName: ' + trackName );
-
-			}
-
-			var results = {
-				// directoryName: matches[ 1 ], // (tschw) currently unused
-				nodeName: matches[ 2 ],
-				objectName: matches[ 3 ],
-				objectIndex: matches[ 4 ],
-				propertyName: matches[ 5 ], // required
-				propertyIndex: matches[ 6 ]
 			};
 
-			var lastDot = results.nodeName && results.nodeName.lastIndexOf( '.' );
+		}() ),
 
-			if ( lastDot !== undefined && lastDot !== - 1 ) {
+		parseTrackName: function () {
 
-				var objectName = results.nodeName.substring( lastDot + 1 );
+			// Attempts to allow node names from any language. ES5's `\w` regexp matches
+			// only latin characters, and the unicode \p{L} is not yet supported. So
+			// instead, we exclude reserved characters and match everything else.
+			var wordChar = '[^' + RESERVED_CHARS_RE + ']';
+			var wordCharOrDot = '[^' + RESERVED_CHARS_RE.replace( '\\.', '' ) + ']';
 
-				// Object names must be checked against a whitelist. Otherwise, there
-				// is no way to parse 'foo.bar.baz': 'baz' must be a property, but
-				// 'bar' could be the objectName, or part of a nodeName (which can
-				// include '.' characters).
-				if ( _supportedObjectNames.indexOf( objectName ) !== - 1 ) {
+			// Parent directories, delimited by '/' or ':'. Currently unused, but must
+			// be matched to parse the rest of the track name.
+			var directoryRe = /((?:WC+[\/:])*)/.source.replace( 'WC', wordChar );
 
-					results.nodeName = results.nodeName.substring( 0, lastDot );
-					results.objectName = objectName;
+			// Target node. May contain word characters (a-zA-Z0-9_) and '.' or '-'.
+			var nodeRe = /(WCOD+)?/.source.replace( 'WCOD', wordCharOrDot );
+
+			// Object on target node, and accessor. May not contain reserved
+			// characters. Accessor may contain any character except closing bracket.
+			var objectRe = /(?:\.(WC+)(?:\[(.+)\])?)?/.source.replace( 'WC', wordChar );
+
+			// Property and accessor. May not contain reserved characters. Accessor may
+			// contain any non-bracket characters.
+			var propertyRe = /\.(WC+)(?:\[(.+)\])?/.source.replace( 'WC', wordChar );
+
+			var trackRe = new RegExp( ''
+				+ '^'
+				+ directoryRe
+				+ nodeRe
+				+ objectRe
+				+ propertyRe
+				+ '$'
+			);
+
+			var supportedObjectNames = [ 'material', 'materials', 'bones' ];
+
+			return function parseTrackName( trackName ) {
+
+				var matches = trackRe.exec( trackName );
+
+				if ( ! matches ) {
+
+					throw new Error( 'PropertyBinding: Cannot parse trackName: ' + trackName );
 
 				}
 
-			}
+				var results = {
+					// directoryName: matches[ 1 ], // (tschw) currently unused
+					nodeName: matches[ 2 ],
+					objectName: matches[ 3 ],
+					objectIndex: matches[ 4 ],
+					propertyName: matches[ 5 ], // required
+					propertyIndex: matches[ 6 ]
+				};
 
-			if ( results.propertyName === null || results.propertyName.length === 0 ) {
+				var lastDot = results.nodeName && results.nodeName.lastIndexOf( '.' );
 
-				throw new Error( 'PropertyBinding: can not parse propertyName from trackName: ' + trackName );
+				if ( lastDot !== undefined && lastDot !== - 1 ) {
 
-			}
+					var objectName = results.nodeName.substring( lastDot + 1 );
 
-			return results;
+					// Object names must be checked against a whitelist. Otherwise, there
+					// is no way to parse 'foo.bar.baz': 'baz' must be a property, but
+					// 'bar' could be the objectName, or part of a nodeName (which can
+					// include '.' characters).
+					if ( supportedObjectNames.indexOf( objectName ) !== - 1 ) {
 
-		},
+						results.nodeName = results.nodeName.substring( 0, lastDot );
+						results.objectName = objectName;
+
+					}
+
+				}
+
+				if ( results.propertyName === null || results.propertyName.length === 0 ) {
+
+					throw new Error( 'PropertyBinding: can not parse propertyName from trackName: ' + trackName );
+
+				}
+
+				return results;
+
+			};
+
+		}(),
 
 		findNode: function ( root, nodeName ) {
 
-			if ( ! nodeName || nodeName === "" || nodeName === "." || nodeName === - 1 || nodeName === root.name || nodeName === root.uuid ) {
+			if ( ! nodeName || nodeName === "" || nodeName === "root" || nodeName === "." || nodeName === - 1 || nodeName === root.name || nodeName === root.uuid ) {
 
 				return root;
 
@@ -44001,7 +42754,7 @@ var Spacekit = (function (exports) {
 
 	} );
 
-	// DECLARE ALIAS AFTER assign prototype
+	//!\ DECLARE ALIAS AFTER assign prototype !
 	Object.assign( PropertyBinding.prototype, {
 
 		// initial state of these methods that calls 'bind'
@@ -44043,7 +42796,7 @@ var Spacekit = (function (exports) {
 
 	function AnimationObjectGroup() {
 
-		this.uuid = MathUtils.generateUUID();
+		this.uuid = _Math.generateUUID();
 
 		// cached objects followed by the active ones
 		this._objects = Array.prototype.slice.call( arguments );
@@ -44397,12 +43150,11 @@ var Spacekit = (function (exports) {
 	 *
 	 */
 
-	function AnimationAction( mixer, clip, localRoot, blendMode ) {
+	function AnimationAction( mixer, clip, localRoot ) {
 
 		this._mixer = mixer;
 		this._clip = clip;
 		this._localRoot = localRoot || null;
-		this.blendMode = blendMode || clip.blendMode;
 
 		var tracks = clip.tracks,
 			nTracks = tracks.length,
@@ -44761,28 +43513,10 @@ var Spacekit = (function (exports) {
 				var interpolants = this._interpolants;
 				var propertyMixers = this._propertyBindings;
 
-				switch ( this.blendMode ) {
+				for ( var j = 0, m = interpolants.length; j !== m; ++ j ) {
 
-					case AdditiveAnimationBlendMode:
-
-						for ( var j = 0, m = interpolants.length; j !== m; ++ j ) {
-
-							interpolants[ j ].evaluate( clipTime );
-							propertyMixers[ j ].accumulateAdditive( weight );
-
-						}
-
-						break;
-
-					case NormalAnimationBlendMode:
-					default:
-
-						for ( var j = 0, m = interpolants.length; j !== m; ++ j ) {
-
-							interpolants[ j ].evaluate( clipTime );
-							propertyMixers[ j ].accumulate( accuIndex, weight );
-
-						}
+					interpolants[ j ].evaluate( clipTime );
+					propertyMixers[ j ].accumulate( accuIndex, weight );
 
 				}
 
@@ -45600,7 +44334,7 @@ var Spacekit = (function (exports) {
 		// return an action for a clip optionally using a custom root target
 		// object (this method allocates a lot of dynamic memory in case a
 		// previously unknown clip/root combination is specified)
-		clipAction: function ( clip, optionalRoot, blendMode ) {
+		clipAction: function ( clip, optionalRoot ) {
 
 			var root = optionalRoot || this._root,
 				rootUuid = root.uuid,
@@ -45613,26 +44347,12 @@ var Spacekit = (function (exports) {
 				actionsForClip = this._actionsByClip[ clipUuid ],
 				prototypeAction = null;
 
-			if ( blendMode === undefined ) {
-
-				if ( clipObject !== null ) {
-
-					blendMode = clipObject.blendMode;
-
-				} else {
-
-					blendMode = NormalAnimationBlendMode;
-
-				}
-
-			}
-
 			if ( actionsForClip !== undefined ) {
 
 				var existingAction =
 						actionsForClip.actionByRoot[ rootUuid ];
 
-				if ( existingAction !== undefined && existingAction.blendMode === blendMode ) {
+				if ( existingAction !== undefined ) {
 
 					return existingAction;
 
@@ -45652,7 +44372,7 @@ var Spacekit = (function (exports) {
 			if ( clipObject === null ) return null;
 
 			// allocate all resources required to run it
-			var newAction = new AnimationAction( this, clipObject, optionalRoot, blendMode );
+			var newAction = new AnimationAction( this, clipObject, optionalRoot );
 
 			this._bindAction( newAction, prototypeAction );
 
@@ -45748,20 +44468,6 @@ var Spacekit = (function (exports) {
 			}
 
 			return this;
-
-		},
-
-		// Allows you to seek to a specific time in an animation.
-		setTime: function ( timeInSeconds ) {
-
-			this.time = 0; // Zero out time attribute for AnimationMixer object;
-			for ( var i = 0; i < this._actions.length; i ++ ) {
-
-				this._actions[ i ].time = 0; // Zero out time attribute for all associated AnimationAction objects.
-
-			}
-
-			return this.update( timeInSeconds ); // Update used to set exact time. Returns "this" AnimationMixer object.
 
 		},
 
@@ -45933,12 +44639,10 @@ var Spacekit = (function (exports) {
 
 		this.near = near || 0;
 		this.far = far || Infinity;
-		this.camera = null;
-		this.layers = new Layers();
 
 		this.params = {
 			Mesh: {},
-			Line: { threshold: 1 },
+			Line: {},
 			LOD: {},
 			Points: { threshold: 1 },
 			Sprite: {}
@@ -45965,11 +44669,9 @@ var Spacekit = (function (exports) {
 
 	function intersectObject( object, raycaster, intersects, recursive ) {
 
-		if ( object.layers.test( raycaster.layers ) ) {
+		if ( object.visible === false ) return;
 
-			object.raycast( raycaster, intersects );
-
-		}
+		object.raycast( raycaster, intersects );
 
 		if ( recursive === true ) {
 
@@ -45987,6 +44689,8 @@ var Spacekit = (function (exports) {
 
 	Object.assign( Raycaster.prototype, {
 
+		linePrecision: 1,
+
 		set: function ( origin, direction ) {
 
 			// direction is assumed to be normalized (for accurate distance calculations)
@@ -46001,13 +44705,13 @@ var Spacekit = (function (exports) {
 
 				this.ray.origin.setFromMatrixPosition( camera.matrixWorld );
 				this.ray.direction.set( coords.x, coords.y, 0.5 ).unproject( camera ).sub( this.ray.origin ).normalize();
-				this.camera = camera;
+				this._camera = camera;
 
 			} else if ( ( camera && camera.isOrthographicCamera ) ) {
 
 				this.ray.origin.set( coords.x, coords.y, ( camera.near + camera.far ) / ( camera.near - camera.far ) ).unproject( camera ); // set origin in plane of camera
 				this.ray.direction.set( 0, 0, - 1 ).transformDirection( camera.matrixWorld );
-				this.camera = camera;
+				this._camera = camera;
 
 			} else {
 
@@ -46061,7 +44765,7 @@ var Spacekit = (function (exports) {
 	 * Ref: https://en.wikipedia.org/wiki/Spherical_coordinate_system
 	 *
 	 * The polar angle (phi) is measured from the positive y-axis. The positive y-axis is up.
-	 * The azimuthal angle (theta) is measured from the positive z-axis.
+	 * The azimuthal angle (theta) is measured from the positive z-axiz.
 	 */
 
 	function Spherical( radius, phi, theta ) {
@@ -46130,7 +44834,7 @@ var Spacekit = (function (exports) {
 			} else {
 
 				this.theta = Math.atan2( x, z );
-				this.phi = Math.acos( MathUtils.clamp( y / this.radius, - 1, 1 ) );
+				this.phi = Math.acos( _Math.clamp( y / this.radius, - 1, 1 ) );
 
 			}
 
@@ -46207,8 +44911,6 @@ var Spacekit = (function (exports) {
 	 * @author bhouston / http://clara.io
 	 */
 
-	var _vector$7 = new Vector2();
-
 	function Box2( min, max ) {
 
 		this.min = ( min !== undefined ) ? min : new Vector2( + Infinity, + Infinity );
@@ -46241,15 +44943,21 @@ var Spacekit = (function (exports) {
 
 		},
 
-		setFromCenterAndSize: function ( center, size ) {
+		setFromCenterAndSize: function () {
 
-			var halfSize = _vector$7.copy( size ).multiplyScalar( 0.5 );
-			this.min.copy( center ).sub( halfSize );
-			this.max.copy( center ).add( halfSize );
+			var v1 = new Vector2();
 
-			return this;
+			return function setFromCenterAndSize( center, size ) {
 
-		},
+				var halfSize = v1.copy( size ).multiplyScalar( 0.5 );
+				this.min.copy( center ).sub( halfSize );
+				this.max.copy( center ).add( halfSize );
+
+				return this;
+
+			};
+
+		}(),
 
 		clone: function () {
 
@@ -46391,12 +45099,18 @@ var Spacekit = (function (exports) {
 
 		},
 
-		distanceToPoint: function ( point ) {
+		distanceToPoint: function () {
 
-			var clampedPoint = _vector$7.copy( point ).clamp( this.min, this.max );
-			return clampedPoint.sub( point ).length();
+			var v1 = new Vector2();
 
-		},
+			return function distanceToPoint( point ) {
+
+				var clampedPoint = v1.copy( point ).clamp( this.min, this.max );
+				return clampedPoint.sub( point ).length();
+
+			};
+
+		}(),
 
 		intersect: function ( box ) {
 
@@ -46437,8 +45151,7 @@ var Spacekit = (function (exports) {
 	 * @author bhouston / http://clara.io
 	 */
 
-	var _startP = new Vector3();
-	var _startEnd = new Vector3();
+	var _startP, _startEnd;
 
 	function Line3( start, end ) {
 
@@ -46526,6 +45239,13 @@ var Spacekit = (function (exports) {
 
 		closestPointToPointParameter: function ( point, clampToLine ) {
 
+			if ( _startP === undefined ) {
+
+				_startP = new Vector3();
+				_startEnd = new Vector3();
+
+			}
+
 			_startP.subVectors( point, this.start );
 			_startEnd.subVectors( this.end, this.start );
 
@@ -46536,7 +45256,7 @@ var Spacekit = (function (exports) {
 
 			if ( clampToLine ) {
 
-				t = MathUtils.clamp( t, 0, 1 );
+				t = _Math.clamp( t, 0, 1 );
 
 			}
 
@@ -46595,12 +45315,154 @@ var Spacekit = (function (exports) {
 	ImmediateRenderObject.prototype.isImmediateRenderObject = true;
 
 	/**
-	 * @author alteredq / http://alteredqualia.com/
 	 * @author mrdoob / http://mrdoob.com/
 	 * @author WestLangley / http://github.com/WestLangley
 	 */
 
-	var _vector$8 = new Vector3();
+	function VertexNormalsHelper( object, size, hex, linewidth ) {
+
+		this.object = object;
+
+		this.size = ( size !== undefined ) ? size : 1;
+
+		var color = ( hex !== undefined ) ? hex : 0xff0000;
+
+		var width = ( linewidth !== undefined ) ? linewidth : 1;
+
+		//
+
+		var nNormals = 0;
+
+		var objGeometry = this.object.geometry;
+
+		if ( objGeometry && objGeometry.isGeometry ) {
+
+			nNormals = objGeometry.faces.length * 3;
+
+		} else if ( objGeometry && objGeometry.isBufferGeometry ) {
+
+			nNormals = objGeometry.attributes.normal.count;
+
+		}
+
+		//
+
+		var geometry = new BufferGeometry();
+
+		var positions = new Float32BufferAttribute( nNormals * 2 * 3, 3 );
+
+		geometry.addAttribute( 'position', positions );
+
+		LineSegments.call( this, geometry, new LineBasicMaterial( { color: color, linewidth: width } ) );
+
+		//
+
+		this.matrixAutoUpdate = false;
+
+		this.update();
+
+	}
+
+	VertexNormalsHelper.prototype = Object.create( LineSegments.prototype );
+	VertexNormalsHelper.prototype.constructor = VertexNormalsHelper;
+
+	VertexNormalsHelper.prototype.update = ( function () {
+
+		var v1 = new Vector3();
+		var v2 = new Vector3();
+		var normalMatrix = new Matrix3();
+
+		return function update() {
+
+			var keys = [ 'a', 'b', 'c' ];
+
+			this.object.updateMatrixWorld( true );
+
+			normalMatrix.getNormalMatrix( this.object.matrixWorld );
+
+			var matrixWorld = this.object.matrixWorld;
+
+			var position = this.geometry.attributes.position;
+
+			//
+
+			var objGeometry = this.object.geometry;
+
+			if ( objGeometry && objGeometry.isGeometry ) {
+
+				var vertices = objGeometry.vertices;
+
+				var faces = objGeometry.faces;
+
+				var idx = 0;
+
+				for ( var i = 0, l = faces.length; i < l; i ++ ) {
+
+					var face = faces[ i ];
+
+					for ( var j = 0, jl = face.vertexNormals.length; j < jl; j ++ ) {
+
+						var vertex = vertices[ face[ keys[ j ] ] ];
+
+						var normal = face.vertexNormals[ j ];
+
+						v1.copy( vertex ).applyMatrix4( matrixWorld );
+
+						v2.copy( normal ).applyMatrix3( normalMatrix ).normalize().multiplyScalar( this.size ).add( v1 );
+
+						position.setXYZ( idx, v1.x, v1.y, v1.z );
+
+						idx = idx + 1;
+
+						position.setXYZ( idx, v2.x, v2.y, v2.z );
+
+						idx = idx + 1;
+
+					}
+
+				}
+
+			} else if ( objGeometry && objGeometry.isBufferGeometry ) {
+
+				var objPos = objGeometry.attributes.position;
+
+				var objNorm = objGeometry.attributes.normal;
+
+				var idx = 0;
+
+				// for simplicity, ignore index and drawcalls, and render every normal
+
+				for ( var j = 0, jl = objPos.count; j < jl; j ++ ) {
+
+					v1.set( objPos.getX( j ), objPos.getY( j ), objPos.getZ( j ) ).applyMatrix4( matrixWorld );
+
+					v2.set( objNorm.getX( j ), objNorm.getY( j ), objNorm.getZ( j ) );
+
+					v2.applyMatrix3( normalMatrix ).normalize().multiplyScalar( this.size ).add( v1 );
+
+					position.setXYZ( idx, v1.x, v1.y, v1.z );
+
+					idx = idx + 1;
+
+					position.setXYZ( idx, v2.x, v2.y, v2.z );
+
+					idx = idx + 1;
+
+				}
+
+			}
+
+			position.needsUpdate = true;
+
+		};
+
+	}() );
+
+	/**
+	 * @author alteredq / http://alteredqualia.com/
+	 * @author mrdoob / http://mrdoob.com/
+	 * @author WestLangley / http://github.com/WestLangley
+	 */
 
 	function SpotLightHelper( light, color ) {
 
@@ -46636,9 +45498,9 @@ var Spacekit = (function (exports) {
 
 		}
 
-		geometry.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
+		geometry.addAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
 
-		var material = new LineBasicMaterial( { fog: false, toneMapped: false } );
+		var material = new LineBasicMaterial( { fog: false } );
 
 		this.cone = new LineSegments( geometry, material );
 		this.add( this.cone );
@@ -46659,28 +45521,34 @@ var Spacekit = (function (exports) {
 
 	SpotLightHelper.prototype.update = function () {
 
-		this.light.updateMatrixWorld();
+		var vector = new Vector3();
 
-		var coneLength = this.light.distance ? this.light.distance : 1000;
-		var coneWidth = coneLength * Math.tan( this.light.angle );
+		return function update() {
 
-		this.cone.scale.set( coneWidth, coneWidth, coneLength );
+			this.light.updateMatrixWorld();
 
-		_vector$8.setFromMatrixPosition( this.light.target.matrixWorld );
+			var coneLength = this.light.distance ? this.light.distance : 1000;
+			var coneWidth = coneLength * Math.tan( this.light.angle );
 
-		this.cone.lookAt( _vector$8 );
+			this.cone.scale.set( coneWidth, coneWidth, coneLength );
 
-		if ( this.color !== undefined ) {
+			vector.setFromMatrixPosition( this.light.target.matrixWorld );
 
-			this.cone.material.color.set( this.color );
+			this.cone.lookAt( vector );
 
-		} else {
+			if ( this.color !== undefined ) {
 
-			this.cone.material.color.copy( this.light.color );
+				this.cone.material.color.set( this.color );
 
-		}
+			} else {
 
-	};
+				this.cone.material.color.copy( this.light.color );
+
+			}
+
+		};
+
+	}();
 
 	/**
 	 * @author Sean Griffin / http://twitter.com/sgrif
@@ -46689,10 +45557,6 @@ var Spacekit = (function (exports) {
 	 * @author ikerr / http://verold.com
 	 * @author Mugen87 / https://github.com/Mugen87
 	 */
-
-	var _vector$9 = new Vector3();
-	var _boneMatrix = new Matrix4();
-	var _matrixWorldInv = new Matrix4();
 
 	function getBoneList( object ) {
 
@@ -46741,14 +45605,12 @@ var Spacekit = (function (exports) {
 
 		}
 
-		geometry.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		geometry.setAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
+		geometry.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		geometry.addAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
 
-		var material = new LineBasicMaterial( { vertexColors: true, depthTest: false, depthWrite: false, toneMapped: false, transparent: true } );
+		var material = new LineBasicMaterial( { vertexColors: VertexColors, depthTest: false, depthWrite: false, transparent: true } );
 
 		LineSegments.call( this, geometry, material );
-
-		this.type = 'SkeletonHelper';
 
 		this.root = object;
 		this.bones = bones;
@@ -46761,42 +45623,49 @@ var Spacekit = (function (exports) {
 	SkeletonHelper.prototype = Object.create( LineSegments.prototype );
 	SkeletonHelper.prototype.constructor = SkeletonHelper;
 
-	SkeletonHelper.prototype.isSkeletonHelper = true;
+	SkeletonHelper.prototype.updateMatrixWorld = function () {
 
-	SkeletonHelper.prototype.updateMatrixWorld = function ( force ) {
+		var vector = new Vector3();
 
-		var bones = this.bones;
+		var boneMatrix = new Matrix4();
+		var matrixWorldInv = new Matrix4();
 
-		var geometry = this.geometry;
-		var position = geometry.getAttribute( 'position' );
+		return function updateMatrixWorld( force ) {
 
-		_matrixWorldInv.getInverse( this.root.matrixWorld );
+			var bones = this.bones;
 
-		for ( var i = 0, j = 0; i < bones.length; i ++ ) {
+			var geometry = this.geometry;
+			var position = geometry.getAttribute( 'position' );
 
-			var bone = bones[ i ];
+			matrixWorldInv.getInverse( this.root.matrixWorld );
 
-			if ( bone.parent && bone.parent.isBone ) {
+			for ( var i = 0, j = 0; i < bones.length; i ++ ) {
 
-				_boneMatrix.multiplyMatrices( _matrixWorldInv, bone.matrixWorld );
-				_vector$9.setFromMatrixPosition( _boneMatrix );
-				position.setXYZ( j, _vector$9.x, _vector$9.y, _vector$9.z );
+				var bone = bones[ i ];
 
-				_boneMatrix.multiplyMatrices( _matrixWorldInv, bone.parent.matrixWorld );
-				_vector$9.setFromMatrixPosition( _boneMatrix );
-				position.setXYZ( j + 1, _vector$9.x, _vector$9.y, _vector$9.z );
+				if ( bone.parent && bone.parent.isBone ) {
 
-				j += 2;
+					boneMatrix.multiplyMatrices( matrixWorldInv, bone.matrixWorld );
+					vector.setFromMatrixPosition( boneMatrix );
+					position.setXYZ( j, vector.x, vector.y, vector.z );
+
+					boneMatrix.multiplyMatrices( matrixWorldInv, bone.parent.matrixWorld );
+					vector.setFromMatrixPosition( boneMatrix );
+					position.setXYZ( j + 1, vector.x, vector.y, vector.z );
+
+					j += 2;
+
+				}
 
 			}
 
-		}
+			geometry.getAttribute( 'position' ).needsUpdate = true;
 
-		geometry.getAttribute( 'position' ).needsUpdate = true;
+			Object3D.prototype.updateMatrixWorld.call( this, force );
 
-		Object3D.prototype.updateMatrixWorld.call( this, force );
+		};
 
-	};
+	}();
 
 	/**
 	 * @author alteredq / http://alteredqualia.com/
@@ -46811,11 +45680,9 @@ var Spacekit = (function (exports) {
 		this.color = color;
 
 		var geometry = new SphereBufferGeometry( sphereSize, 4, 2 );
-		var material = new MeshBasicMaterial( { wireframe: true, fog: false, toneMapped: false } );
+		var material = new MeshBasicMaterial( { wireframe: true, fog: false } );
 
 		Mesh.call( this, geometry, material );
-
-		this.type = 'PointLightHelper';
 
 		this.matrix = this.light.matrixWorld;
 		this.matrixAutoUpdate = false;
@@ -46887,14 +45754,86 @@ var Spacekit = (function (exports) {
 	};
 
 	/**
+	 * @author abelnation / http://github.com/abelnation
+	 * @author Mugen87 / http://github.com/Mugen87
+	 * @author WestLangley / http://github.com/WestLangley
+	 *
+	 *  This helper must be added as a child of the light
+	 */
+
+	function RectAreaLightHelper( light, color ) {
+
+		this.type = 'RectAreaLightHelper';
+
+		this.light = light;
+
+		this.color = color; // optional hardwired color for the helper
+
+		var positions = [ 1, 1, 0, - 1, 1, 0, - 1, - 1, 0, 1, - 1, 0, 1, 1, 0 ];
+
+		var geometry = new BufferGeometry();
+		geometry.addAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
+		geometry.computeBoundingSphere();
+
+		var material = new LineBasicMaterial( { fog: false } );
+
+		Line.call( this, geometry, material );
+
+		//
+
+		var positions2 = [ 1, 1, 0, - 1, 1, 0, - 1, - 1, 0, 1, 1, 0, - 1, - 1, 0, 1, - 1, 0 ];
+
+		var geometry2 = new BufferGeometry();
+		geometry2.addAttribute( 'position', new Float32BufferAttribute( positions2, 3 ) );
+		geometry2.computeBoundingSphere();
+
+		this.add( new Mesh( geometry2, new MeshBasicMaterial( { side: BackSide, fog: false } ) ) );
+
+		this.update();
+
+	}
+
+	RectAreaLightHelper.prototype = Object.create( Line.prototype );
+	RectAreaLightHelper.prototype.constructor = RectAreaLightHelper;
+
+	RectAreaLightHelper.prototype.update = function () {
+
+		this.scale.set( 0.5 * this.light.width, 0.5 * this.light.height, 1 );
+
+		if ( this.color !== undefined ) {
+
+			this.material.color.set( this.color );
+			this.children[ 0 ].material.color.set( this.color );
+
+		} else {
+
+			this.material.color.copy( this.light.color ).multiplyScalar( this.light.intensity );
+
+			// prevent hue shift
+			var c = this.material.color;
+			var max = Math.max( c.r, c.g, c.b );
+			if ( max > 1 ) c.multiplyScalar( 1 / max );
+
+			this.children[ 0 ].material.color.copy( this.material.color );
+
+		}
+
+	};
+
+	RectAreaLightHelper.prototype.dispose = function () {
+
+		this.geometry.dispose();
+		this.material.dispose();
+		this.children[ 0 ].geometry.dispose();
+		this.children[ 0 ].material.dispose();
+
+	};
+
+	/**
 	 * @author alteredq / http://alteredqualia.com/
 	 * @author mrdoob / http://mrdoob.com/
 	 * @author Mugen87 / https://github.com/Mugen87
 	 */
-
-	var _vector$a = new Vector3();
-	var _color1 = new Color();
-	var _color2 = new Color();
 
 	function HemisphereLightHelper( light, size, color ) {
 
@@ -46911,13 +45850,13 @@ var Spacekit = (function (exports) {
 		var geometry = new OctahedronBufferGeometry( size );
 		geometry.rotateY( Math.PI * 0.5 );
 
-		this.material = new MeshBasicMaterial( { wireframe: true, fog: false, toneMapped: false } );
-		if ( this.color === undefined ) this.material.vertexColors = true;
+		this.material = new MeshBasicMaterial( { wireframe: true, fog: false } );
+		if ( this.color === undefined ) this.material.vertexColors = VertexColors;
 
 		var position = geometry.getAttribute( 'position' );
 		var colors = new Float32Array( position.count * 3 );
 
-		geometry.setAttribute( 'color', new BufferAttribute( colors, 3 ) );
+		geometry.addAttribute( 'color', new BufferAttribute( colors, 3 ) );
 
 		this.add( new Mesh( geometry, this.material ) );
 
@@ -46937,34 +45876,193 @@ var Spacekit = (function (exports) {
 
 	HemisphereLightHelper.prototype.update = function () {
 
-		var mesh = this.children[ 0 ];
+		var vector = new Vector3();
 
-		if ( this.color !== undefined ) {
+		var color1 = new Color();
+		var color2 = new Color();
 
-			this.material.color.set( this.color );
+		return function update() {
 
-		} else {
+			var mesh = this.children[ 0 ];
 
-			var colors = mesh.geometry.getAttribute( 'color' );
+			if ( this.color !== undefined ) {
 
-			_color1.copy( this.light.color );
-			_color2.copy( this.light.groundColor );
+				this.material.color.set( this.color );
 
-			for ( var i = 0, l = colors.count; i < l; i ++ ) {
+			} else {
 
-				var color = ( i < ( l / 2 ) ) ? _color1 : _color2;
+				var colors = mesh.geometry.getAttribute( 'color' );
 
-				colors.setXYZ( i, color.r, color.g, color.b );
+				color1.copy( this.light.color );
+				color2.copy( this.light.groundColor );
+
+				for ( var i = 0, l = colors.count; i < l; i ++ ) {
+
+					var color = ( i < ( l / 2 ) ) ? color1 : color2;
+
+					colors.setXYZ( i, color.r, color.g, color.b );
+
+				}
+
+				colors.needsUpdate = true;
 
 			}
 
-			colors.needsUpdate = true;
+			mesh.lookAt( vector.setFromMatrixPosition( this.light.matrixWorld ).negate() );
 
-		}
+		};
 
-		mesh.lookAt( _vector$a.setFromMatrixPosition( this.light.matrixWorld ).negate() );
+	}();
+
+	/**
+	 * @author WestLangley / http://github.com/WestLangley
+	 */
+
+	function LightProbeHelper( lightProbe, size ) {
+
+		this.lightProbe = lightProbe;
+
+		this.size = size;
+
+		var defines = {};
+		defines[ 'GAMMA_OUTPUT' ] = "";
+
+		// material
+		var material = new ShaderMaterial( {
+
+			defines: defines,
+
+			uniforms: {
+
+				sh: { value: this.lightProbe.sh.coefficients }, // by reference
+
+				intensity: { value: this.lightProbe.intensity }
+
+			},
+
+			vertexShader: [
+
+				'varying vec3 vNormal;',
+
+				'void main() {',
+
+				'	vNormal = normalize( normalMatrix * normal );',
+
+				'	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );',
+
+				'}',
+
+			].join( '\n' ),
+
+			fragmentShader: [
+
+				'#define RECIPROCAL_PI 0.318309886',
+
+				'vec3 inverseTransformDirection( in vec3 normal, in mat4 matrix ) {',
+
+				'	// matrix is assumed to be orthogonal',
+
+				'	return normalize( ( vec4( normal, 0.0 ) * matrix ).xyz );',
+
+				'}',
+
+				'vec3 linearToOutput( in vec3 a ) {',
+
+				'	#ifdef GAMMA_OUTPUT',
+
+				'		return pow( a, vec3( 1.0 / float( GAMMA_FACTOR ) ) );',
+
+				'	#else',
+
+				'		return a;',
+
+				'	#endif',
+
+				'}',
+
+				'// source: https://graphics.stanford.edu/papers/envmap/envmap.pdf',
+				'vec3 shGetIrradianceAt( in vec3 normal, in vec3 shCoefficients[ 9 ] ) {',
+
+				'	// normal is assumed to have unit length',
+
+				'	float x = normal.x, y = normal.y, z = normal.z;',
+
+				'	// band 0',
+				'	vec3 result = shCoefficients[ 0 ] * 0.886227;',
+
+				'	// band 1',
+				'	result += shCoefficients[ 1 ] * 2.0 * 0.511664 * y;',
+				'	result += shCoefficients[ 2 ] * 2.0 * 0.511664 * z;',
+				'	result += shCoefficients[ 3 ] * 2.0 * 0.511664 * x;',
+
+				'	// band 2',
+				'	result += shCoefficients[ 4 ] * 2.0 * 0.429043 * x * y;',
+				'	result += shCoefficients[ 5 ] * 2.0 * 0.429043 * y * z;',
+				'	result += shCoefficients[ 6 ] * ( 0.743125 * z * z - 0.247708 );',
+				'	result += shCoefficients[ 7 ] * 2.0 * 0.429043 * x * z;',
+				'	result += shCoefficients[ 8 ] * 0.429043 * ( x * x - y * y );',
+
+				'	return result;',
+
+				'}',
+
+				'uniform vec3 sh[ 9 ]; // sh coefficients',
+
+				'uniform float intensity; // light probe intensity',
+
+				'varying vec3 vNormal;',
+
+				'void main() {',
+
+				'	vec3 normal = normalize( vNormal );',
+
+				'	vec3 worldNormal = inverseTransformDirection( normal, viewMatrix );',
+
+				'	vec3 irradiance = shGetIrradianceAt( worldNormal, sh );',
+
+				'	vec3 outgoingLight = RECIPROCAL_PI * irradiance * intensity;',
+
+				'	outgoingLight = linearToOutput( outgoingLight );',
+
+				'	gl_FragColor = vec4( outgoingLight, 1.0 );',
+
+				'}'
+
+			].join( '\n' )
+
+		} );
+
+		var geometry = new SphereBufferGeometry( 1, 32, 16 );
+
+		Mesh.call( this, geometry, material );
+
+		this.onBeforeRender();
+
+	}
+
+	LightProbeHelper.prototype = Object.create( Mesh.prototype );
+	LightProbeHelper.prototype.constructor = LightProbeHelper;
+
+	LightProbeHelper.prototype.dispose = function () {
+
+		this.geometry.dispose();
+		this.material.dispose();
 
 	};
+
+	LightProbeHelper.prototype.onBeforeRender = function () {
+
+		return function update() {
+
+			this.position.copy( this.lightProbe.position );
+
+			this.scale.set( 1, 1, 1 ).multiplyScalar( this.size );
+
+			this.material.uniforms.intensity.value = this.lightProbe.intensity;
+
+		};
+
+	}();
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -46998,14 +46096,12 @@ var Spacekit = (function (exports) {
 		}
 
 		var geometry = new BufferGeometry();
-		geometry.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		geometry.setAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
+		geometry.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		geometry.addAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
 
-		var material = new LineBasicMaterial( { vertexColors: true, toneMapped: false } );
+		var material = new LineBasicMaterial( { vertexColors: VertexColors } );
 
 		LineSegments.call( this, geometry, material );
-
-		this.type = 'GridHelper';
 
 	}
 
@@ -47107,14 +46203,12 @@ var Spacekit = (function (exports) {
 		}
 
 		var geometry = new BufferGeometry();
-		geometry.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		geometry.setAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
+		geometry.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		geometry.addAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
 
-		var material = new LineBasicMaterial( { vertexColors: true, toneMapped: false } );
+		var material = new LineBasicMaterial( { vertexColors: VertexColors } );
 
 		LineSegments.call( this, geometry, material );
-
-		this.type = 'PolarGridHelper';
 
 	}
 
@@ -47122,14 +46216,219 @@ var Spacekit = (function (exports) {
 	PolarGridHelper.prototype.constructor = PolarGridHelper;
 
 	/**
-	 * @author alteredq / http://alteredqualia.com/
+	 * @author Mugen87 / http://github.com/Mugen87
+	 */
+
+	function PositionalAudioHelper( audio, range, divisionsInnerAngle, divisionsOuterAngle ) {
+
+		this.audio = audio;
+		this.range = range || 1;
+		this.divisionsInnerAngle = divisionsInnerAngle || 16;
+		this.divisionsOuterAngle = divisionsOuterAngle || 2;
+
+		var geometry = new BufferGeometry();
+		var divisions = this.divisionsInnerAngle + this.divisionsOuterAngle * 2;
+		var positions = new Float32Array( ( divisions * 3 + 3 ) * 3 );
+		geometry.addAttribute( 'position', new BufferAttribute( positions, 3 ) );
+
+		var materialInnerAngle = new LineBasicMaterial( { color: 0x00ff00 } );
+		var materialOuterAngle = new LineBasicMaterial( { color: 0xffff00 } );
+
+		Line.call( this, geometry, [ materialOuterAngle, materialInnerAngle ] );
+
+		this.update();
+
+	}
+
+	PositionalAudioHelper.prototype = Object.create( Line.prototype );
+	PositionalAudioHelper.prototype.constructor = PositionalAudioHelper;
+
+	PositionalAudioHelper.prototype.update = function () {
+
+		var audio = this.audio;
+		var range = this.range;
+		var divisionsInnerAngle = this.divisionsInnerAngle;
+		var divisionsOuterAngle = this.divisionsOuterAngle;
+
+		var coneInnerAngle = _Math.degToRad( audio.panner.coneInnerAngle );
+		var coneOuterAngle = _Math.degToRad( audio.panner.coneOuterAngle );
+
+		var halfConeInnerAngle = coneInnerAngle / 2;
+		var halfConeOuterAngle = coneOuterAngle / 2;
+
+		var start = 0;
+		var count = 0;
+		var i, stride;
+
+		var geometry = this.geometry;
+		var positionAttribute = geometry.attributes.position;
+
+		geometry.clearGroups();
+
+		//
+
+		function generateSegment( from, to, divisions, materialIndex ) {
+
+			var step = ( to - from ) / divisions;
+
+			positionAttribute.setXYZ( start, 0, 0, 0 );
+			count ++;
+
+			for ( i = from; i < to; i += step ) {
+
+				stride = start + count;
+
+				positionAttribute.setXYZ( stride, Math.sin( i ) * range, 0, Math.cos( i ) * range );
+				positionAttribute.setXYZ( stride + 1, Math.sin( Math.min( i + step, to ) ) * range, 0, Math.cos( Math.min( i + step, to ) ) * range );
+				positionAttribute.setXYZ( stride + 2, 0, 0, 0 );
+
+				count += 3;
+
+			}
+
+			geometry.addGroup( start, count, materialIndex );
+
+			start += count;
+			count = 0;
+
+		}
+
+		//
+
+		generateSegment( - halfConeOuterAngle, - halfConeInnerAngle, divisionsOuterAngle, 0 );
+		generateSegment( - halfConeInnerAngle, halfConeInnerAngle, divisionsInnerAngle, 1 );
+		generateSegment( halfConeInnerAngle, halfConeOuterAngle, divisionsOuterAngle, 0 );
+
+		//
+
+		positionAttribute.needsUpdate = true;
+
+		if ( coneInnerAngle === coneOuterAngle ) this.material[ 0 ].visible = false;
+
+	};
+
+	PositionalAudioHelper.prototype.dispose = function () {
+
+		this.geometry.dispose();
+		this.material[ 0 ].dispose();
+		this.material[ 1 ].dispose();
+
+	};
+
+	/**
 	 * @author mrdoob / http://mrdoob.com/
 	 * @author WestLangley / http://github.com/WestLangley
 	 */
 
-	var _v1$5 = new Vector3();
-	var _v2$3 = new Vector3();
-	var _v3$1 = new Vector3();
+	function FaceNormalsHelper( object, size, hex, linewidth ) {
+
+		// FaceNormalsHelper only supports THREE.Geometry
+
+		this.object = object;
+
+		this.size = ( size !== undefined ) ? size : 1;
+
+		var color = ( hex !== undefined ) ? hex : 0xffff00;
+
+		var width = ( linewidth !== undefined ) ? linewidth : 1;
+
+		//
+
+		var nNormals = 0;
+
+		var objGeometry = this.object.geometry;
+
+		if ( objGeometry && objGeometry.isGeometry ) {
+
+			nNormals = objGeometry.faces.length;
+
+		} else {
+
+			console.warn( 'THREE.FaceNormalsHelper: only THREE.Geometry is supported. Use THREE.VertexNormalsHelper, instead.' );
+
+		}
+
+		//
+
+		var geometry = new BufferGeometry();
+
+		var positions = new Float32BufferAttribute( nNormals * 2 * 3, 3 );
+
+		geometry.addAttribute( 'position', positions );
+
+		LineSegments.call( this, geometry, new LineBasicMaterial( { color: color, linewidth: width } ) );
+
+		//
+
+		this.matrixAutoUpdate = false;
+		this.update();
+
+	}
+
+	FaceNormalsHelper.prototype = Object.create( LineSegments.prototype );
+	FaceNormalsHelper.prototype.constructor = FaceNormalsHelper;
+
+	FaceNormalsHelper.prototype.update = ( function () {
+
+		var v1 = new Vector3();
+		var v2 = new Vector3();
+		var normalMatrix = new Matrix3();
+
+		return function update() {
+
+			this.object.updateMatrixWorld( true );
+
+			normalMatrix.getNormalMatrix( this.object.matrixWorld );
+
+			var matrixWorld = this.object.matrixWorld;
+
+			var position = this.geometry.attributes.position;
+
+			//
+
+			var objGeometry = this.object.geometry;
+
+			var vertices = objGeometry.vertices;
+
+			var faces = objGeometry.faces;
+
+			var idx = 0;
+
+			for ( var i = 0, l = faces.length; i < l; i ++ ) {
+
+				var face = faces[ i ];
+
+				var normal = face.normal;
+
+				v1.copy( vertices[ face.a ] )
+					.add( vertices[ face.b ] )
+					.add( vertices[ face.c ] )
+					.divideScalar( 3 )
+					.applyMatrix4( matrixWorld );
+
+				v2.copy( normal ).applyMatrix3( normalMatrix ).normalize().multiplyScalar( this.size ).add( v1 );
+
+				position.setXYZ( idx, v1.x, v1.y, v1.z );
+
+				idx = idx + 1;
+
+				position.setXYZ( idx, v2.x, v2.y, v2.z );
+
+				idx = idx + 1;
+
+			}
+
+			position.needsUpdate = true;
+
+		};
+
+	}() );
+
+	/**
+	 * @author alteredq / http://alteredqualia.com/
+	 * @author mrdoob / http://mrdoob.com/
+	 * @author WestLangley / http://github.com/WestLangley
+	 */
 
 	function DirectionalLightHelper( light, size, color ) {
 
@@ -47146,7 +46445,7 @@ var Spacekit = (function (exports) {
 		if ( size === undefined ) size = 1;
 
 		var geometry = new BufferGeometry();
-		geometry.setAttribute( 'position', new Float32BufferAttribute( [
+		geometry.addAttribute( 'position', new Float32BufferAttribute( [
 			- size, size, 0,
 			size, size, 0,
 			size, - size, 0,
@@ -47154,13 +46453,13 @@ var Spacekit = (function (exports) {
 			- size, size, 0
 		], 3 ) );
 
-		var material = new LineBasicMaterial( { fog: false, toneMapped: false } );
+		var material = new LineBasicMaterial( { fog: false } );
 
 		this.lightPlane = new Line( geometry, material );
 		this.add( this.lightPlane );
 
 		geometry = new BufferGeometry();
-		geometry.setAttribute( 'position', new Float32BufferAttribute( [ 0, 0, 0, 0, 0, 1 ], 3 ) );
+		geometry.addAttribute( 'position', new Float32BufferAttribute( [ 0, 0, 0, 0, 0, 1 ], 3 ) );
 
 		this.targetLine = new Line( geometry, material );
 		this.add( this.targetLine );
@@ -47183,28 +46482,36 @@ var Spacekit = (function (exports) {
 
 	DirectionalLightHelper.prototype.update = function () {
 
-		_v1$5.setFromMatrixPosition( this.light.matrixWorld );
-		_v2$3.setFromMatrixPosition( this.light.target.matrixWorld );
-		_v3$1.subVectors( _v2$3, _v1$5 );
+		var v1 = new Vector3();
+		var v2 = new Vector3();
+		var v3 = new Vector3();
 
-		this.lightPlane.lookAt( _v2$3 );
+		return function update() {
 
-		if ( this.color !== undefined ) {
+			v1.setFromMatrixPosition( this.light.matrixWorld );
+			v2.setFromMatrixPosition( this.light.target.matrixWorld );
+			v3.subVectors( v2, v1 );
 
-			this.lightPlane.material.color.set( this.color );
-			this.targetLine.material.color.set( this.color );
+			this.lightPlane.lookAt( v2 );
 
-		} else {
+			if ( this.color !== undefined ) {
 
-			this.lightPlane.material.color.copy( this.light.color );
-			this.targetLine.material.color.copy( this.light.color );
+				this.lightPlane.material.color.set( this.color );
+				this.targetLine.material.color.set( this.color );
 
-		}
+			} else {
 
-		this.targetLine.lookAt( _v2$3 );
-		this.targetLine.scale.z = _v3$1.length();
+				this.lightPlane.material.color.copy( this.light.color );
+				this.targetLine.material.color.copy( this.light.color );
 
-	};
+			}
+
+			this.targetLine.lookAt( v2 );
+			this.targetLine.scale.z = v3.length();
+
+		};
+
+	}();
 
 	/**
 	 * @author alteredq / http://alteredqualia.com/
@@ -47216,13 +46523,10 @@ var Spacekit = (function (exports) {
 	 *		http://evanw.github.com/lightgl.js/tests/shadowmap.html
 	 */
 
-	var _vector$b = new Vector3();
-	var _camera = new Camera();
-
 	function CameraHelper( camera ) {
 
 		var geometry = new BufferGeometry();
-		var material = new LineBasicMaterial( { color: 0xffffff, vertexColors: true, toneMapped: false } );
+		var material = new LineBasicMaterial( { color: 0xffffff, vertexColors: FaceColors } );
 
 		var vertices = [];
 		var colors = [];
@@ -47306,12 +46610,10 @@ var Spacekit = (function (exports) {
 
 		}
 
-		geometry.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		geometry.setAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
+		geometry.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		geometry.addAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
 
 		LineSegments.call( this, geometry, material );
-
-		this.type = 'CameraHelper';
 
 		this.camera = camera;
 		if ( this.camera.updateProjectionMatrix ) this.camera.updateProjectionMatrix();
@@ -47330,83 +46632,90 @@ var Spacekit = (function (exports) {
 
 	CameraHelper.prototype.update = function () {
 
-		var geometry = this.geometry;
-		var pointMap = this.pointMap;
+		var geometry, pointMap;
 
-		var w = 1, h = 1;
+		var vector = new Vector3();
+		var camera = new Camera();
 
-		// we need just camera projection matrix inverse
-		// world matrix must be identity
+		function setPoint( point, x, y, z ) {
 
-		_camera.projectionMatrixInverse.copy( this.camera.projectionMatrixInverse );
+			vector.set( x, y, z ).unproject( camera );
 
-		// center / target
+			var points = pointMap[ point ];
 
-		setPoint( 'c', pointMap, geometry, _camera, 0, 0, - 1 );
-		setPoint( 't', pointMap, geometry, _camera, 0, 0, 1 );
+			if ( points !== undefined ) {
 
-		// near
+				var position = geometry.getAttribute( 'position' );
 
-		setPoint( 'n1', pointMap, geometry, _camera, - w, - h, - 1 );
-		setPoint( 'n2', pointMap, geometry, _camera, w, - h, - 1 );
-		setPoint( 'n3', pointMap, geometry, _camera, - w, h, - 1 );
-		setPoint( 'n4', pointMap, geometry, _camera, w, h, - 1 );
+				for ( var i = 0, l = points.length; i < l; i ++ ) {
 
-		// far
+					position.setXYZ( points[ i ], vector.x, vector.y, vector.z );
 
-		setPoint( 'f1', pointMap, geometry, _camera, - w, - h, 1 );
-		setPoint( 'f2', pointMap, geometry, _camera, w, - h, 1 );
-		setPoint( 'f3', pointMap, geometry, _camera, - w, h, 1 );
-		setPoint( 'f4', pointMap, geometry, _camera, w, h, 1 );
-
-		// up
-
-		setPoint( 'u1', pointMap, geometry, _camera, w * 0.7, h * 1.1, - 1 );
-		setPoint( 'u2', pointMap, geometry, _camera, - w * 0.7, h * 1.1, - 1 );
-		setPoint( 'u3', pointMap, geometry, _camera, 0, h * 2, - 1 );
-
-		// cross
-
-		setPoint( 'cf1', pointMap, geometry, _camera, - w, 0, 1 );
-		setPoint( 'cf2', pointMap, geometry, _camera, w, 0, 1 );
-		setPoint( 'cf3', pointMap, geometry, _camera, 0, - h, 1 );
-		setPoint( 'cf4', pointMap, geometry, _camera, 0, h, 1 );
-
-		setPoint( 'cn1', pointMap, geometry, _camera, - w, 0, - 1 );
-		setPoint( 'cn2', pointMap, geometry, _camera, w, 0, - 1 );
-		setPoint( 'cn3', pointMap, geometry, _camera, 0, - h, - 1 );
-		setPoint( 'cn4', pointMap, geometry, _camera, 0, h, - 1 );
-
-		geometry.getAttribute( 'position' ).needsUpdate = true;
-
-	};
-
-	function setPoint( point, pointMap, geometry, camera, x, y, z ) {
-
-		_vector$b.set( x, y, z ).unproject( camera );
-
-		var points = pointMap[ point ];
-
-		if ( points !== undefined ) {
-
-			var position = geometry.getAttribute( 'position' );
-
-			for ( var i = 0, l = points.length; i < l; i ++ ) {
-
-				position.setXYZ( points[ i ], _vector$b.x, _vector$b.y, _vector$b.z );
+				}
 
 			}
 
 		}
 
-	}
+		return function update() {
+
+			geometry = this.geometry;
+			pointMap = this.pointMap;
+
+			var w = 1, h = 1;
+
+			// we need just camera projection matrix inverse
+			// world matrix must be identity
+
+			camera.projectionMatrixInverse.copy( this.camera.projectionMatrixInverse );
+
+			// center / target
+
+			setPoint( 'c', 0, 0, - 1 );
+			setPoint( 't', 0, 0, 1 );
+
+			// near
+
+			setPoint( 'n1', - w, - h, - 1 );
+			setPoint( 'n2', w, - h, - 1 );
+			setPoint( 'n3', - w, h, - 1 );
+			setPoint( 'n4', w, h, - 1 );
+
+			// far
+
+			setPoint( 'f1', - w, - h, 1 );
+			setPoint( 'f2', w, - h, 1 );
+			setPoint( 'f3', - w, h, 1 );
+			setPoint( 'f4', w, h, 1 );
+
+			// up
+
+			setPoint( 'u1', w * 0.7, h * 1.1, - 1 );
+			setPoint( 'u2', - w * 0.7, h * 1.1, - 1 );
+			setPoint( 'u3', 0, h * 2, - 1 );
+
+			// cross
+
+			setPoint( 'cf1', - w, 0, 1 );
+			setPoint( 'cf2', w, 0, 1 );
+			setPoint( 'cf3', 0, - h, 1 );
+			setPoint( 'cf4', 0, h, 1 );
+
+			setPoint( 'cn1', - w, 0, - 1 );
+			setPoint( 'cn2', w, 0, - 1 );
+			setPoint( 'cn3', 0, - h, - 1 );
+			setPoint( 'cn4', 0, h, - 1 );
+
+			geometry.getAttribute( 'position' ).needsUpdate = true;
+
+		};
+
+	}();
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
 	 * @author Mugen87 / http://github.com/Mugen87
 	 */
-
-	var _box$3 = new Box3();
 
 	function BoxHelper( object, color ) {
 
@@ -47419,11 +46728,9 @@ var Spacekit = (function (exports) {
 
 		var geometry = new BufferGeometry();
 		geometry.setIndex( new BufferAttribute( indices, 1 ) );
-		geometry.setAttribute( 'position', new BufferAttribute( positions, 3 ) );
+		geometry.addAttribute( 'position', new BufferAttribute( positions, 3 ) );
 
-		LineSegments.call( this, geometry, new LineBasicMaterial( { color: color, toneMapped: false } ) );
-
-		this.type = 'BoxHelper';
+		LineSegments.call( this, geometry, new LineBasicMaterial( { color: color } ) );
 
 		this.matrixAutoUpdate = false;
 
@@ -47434,59 +46741,64 @@ var Spacekit = (function (exports) {
 	BoxHelper.prototype = Object.create( LineSegments.prototype );
 	BoxHelper.prototype.constructor = BoxHelper;
 
-	BoxHelper.prototype.update = function ( object ) {
+	BoxHelper.prototype.update = ( function () {
 
-		if ( object !== undefined ) {
+		var box = new Box3();
 
-			console.warn( 'THREE.BoxHelper: .update() has no longer arguments.' );
+		return function update( object ) {
 
-		}
+			if ( object !== undefined ) {
 
-		if ( this.object !== undefined ) {
+				console.warn( 'THREE.BoxHelper: .update() has no longer arguments.' );
 
-			_box$3.setFromObject( this.object );
+			}
 
-		}
+			if ( this.object !== undefined ) {
 
-		if ( _box$3.isEmpty() ) return;
+				box.setFromObject( this.object );
 
-		var min = _box$3.min;
-		var max = _box$3.max;
+			}
 
-		/*
-		  5____4
-		1/___0/|
-		| 6__|_7
-		2/___3/
+			if ( box.isEmpty() ) return;
 
-		0: max.x, max.y, max.z
-		1: min.x, max.y, max.z
-		2: min.x, min.y, max.z
-		3: max.x, min.y, max.z
-		4: max.x, max.y, min.z
-		5: min.x, max.y, min.z
-		6: min.x, min.y, min.z
-		7: max.x, min.y, min.z
-		*/
+			var min = box.min;
+			var max = box.max;
 
-		var position = this.geometry.attributes.position;
-		var array = position.array;
+			/*
+			  5____4
+			1/___0/|
+			| 6__|_7
+			2/___3/
 
-		array[ 0 ] = max.x; array[ 1 ] = max.y; array[ 2 ] = max.z;
-		array[ 3 ] = min.x; array[ 4 ] = max.y; array[ 5 ] = max.z;
-		array[ 6 ] = min.x; array[ 7 ] = min.y; array[ 8 ] = max.z;
-		array[ 9 ] = max.x; array[ 10 ] = min.y; array[ 11 ] = max.z;
-		array[ 12 ] = max.x; array[ 13 ] = max.y; array[ 14 ] = min.z;
-		array[ 15 ] = min.x; array[ 16 ] = max.y; array[ 17 ] = min.z;
-		array[ 18 ] = min.x; array[ 19 ] = min.y; array[ 20 ] = min.z;
-		array[ 21 ] = max.x; array[ 22 ] = min.y; array[ 23 ] = min.z;
+			0: max.x, max.y, max.z
+			1: min.x, max.y, max.z
+			2: min.x, min.y, max.z
+			3: max.x, min.y, max.z
+			4: max.x, max.y, min.z
+			5: min.x, max.y, min.z
+			6: min.x, min.y, min.z
+			7: max.x, min.y, min.z
+			*/
 
-		position.needsUpdate = true;
+			var position = this.geometry.attributes.position;
+			var array = position.array;
 
-		this.geometry.computeBoundingSphere();
+			array[ 0 ] = max.x; array[ 1 ] = max.y; array[ 2 ] = max.z;
+			array[ 3 ] = min.x; array[ 4 ] = max.y; array[ 5 ] = max.z;
+			array[ 6 ] = min.x; array[ 7 ] = min.y; array[ 8 ] = max.z;
+			array[ 9 ] = max.x; array[ 10 ] = min.y; array[ 11 ] = max.z;
+			array[ 12 ] = max.x; array[ 13 ] = max.y; array[ 14 ] = min.z;
+			array[ 15 ] = min.x; array[ 16 ] = max.y; array[ 17 ] = min.z;
+			array[ 18 ] = min.x; array[ 19 ] = min.y; array[ 20 ] = min.z;
+			array[ 21 ] = max.x; array[ 22 ] = min.y; array[ 23 ] = min.z;
 
+			position.needsUpdate = true;
 
-	};
+			this.geometry.computeBoundingSphere();
+
+		};
+
+	} )();
 
 	BoxHelper.prototype.setFromObject = function ( object ) {
 
@@ -47533,11 +46845,9 @@ var Spacekit = (function (exports) {
 
 		geometry.setIndex( new BufferAttribute( indices, 1 ) );
 
-		geometry.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
+		geometry.addAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
 
-		LineSegments.call( this, geometry, new LineBasicMaterial( { color: color, toneMapped: false } ) );
-
-		this.type = 'Box3Helper';
+		LineSegments.call( this, geometry, new LineBasicMaterial( { color: color } ) );
 
 		this.geometry.computeBoundingSphere();
 
@@ -47568,6 +46878,8 @@ var Spacekit = (function (exports) {
 
 	function PlaneHelper( plane, size, hex ) {
 
+		this.type = 'PlaneHelper';
+
 		this.plane = plane;
 
 		this.size = ( size === undefined ) ? 1 : size;
@@ -47577,22 +46889,20 @@ var Spacekit = (function (exports) {
 		var positions = [ 1, - 1, 1, - 1, 1, 1, - 1, - 1, 1, 1, 1, 1, - 1, 1, 1, - 1, - 1, 1, 1, - 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0 ];
 
 		var geometry = new BufferGeometry();
-		geometry.setAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
+		geometry.addAttribute( 'position', new Float32BufferAttribute( positions, 3 ) );
 		geometry.computeBoundingSphere();
 
-		Line.call( this, geometry, new LineBasicMaterial( { color: color, toneMapped: false } ) );
-
-		this.type = 'PlaneHelper';
+		Line.call( this, geometry, new LineBasicMaterial( { color: color } ) );
 
 		//
 
 		var positions2 = [ 1, 1, 1, - 1, 1, 1, - 1, - 1, 1, 1, 1, 1, - 1, - 1, 1, 1, - 1, 1 ];
 
 		var geometry2 = new BufferGeometry();
-		geometry2.setAttribute( 'position', new Float32BufferAttribute( positions2, 3 ) );
+		geometry2.addAttribute( 'position', new Float32BufferAttribute( positions2, 3 ) );
 		geometry2.computeBoundingSphere();
 
-		this.add( new Mesh( geometry2, new MeshBasicMaterial( { color: color, opacity: 0.2, transparent: true, depthWrite: false, toneMapped: false } ) ) );
+		this.add( new Mesh( geometry2, new MeshBasicMaterial( { color: color, opacity: 0.2, transparent: true, depthWrite: false } ) ) );
 
 	}
 
@@ -47631,16 +46941,13 @@ var Spacekit = (function (exports) {
 	 *  headWidth - Number
 	 */
 
-	var _axis = new Vector3();
-	var _lineGeometry, _coneGeometry;
+	var lineGeometry, coneGeometry;
 
 	function ArrowHelper( dir, origin, length, color, headLength, headWidth ) {
 
 		// dir is assumed to be normalized
 
 		Object3D.call( this );
-
-		this.type = 'ArrowHelper';
 
 		if ( dir === undefined ) dir = new Vector3( 0, 0, 1 );
 		if ( origin === undefined ) origin = new Vector3( 0, 0, 0 );
@@ -47649,23 +46956,23 @@ var Spacekit = (function (exports) {
 		if ( headLength === undefined ) headLength = 0.2 * length;
 		if ( headWidth === undefined ) headWidth = 0.2 * headLength;
 
-		if ( _lineGeometry === undefined ) {
+		if ( lineGeometry === undefined ) {
 
-			_lineGeometry = new BufferGeometry();
-			_lineGeometry.setAttribute( 'position', new Float32BufferAttribute( [ 0, 0, 0, 0, 1, 0 ], 3 ) );
+			lineGeometry = new BufferGeometry();
+			lineGeometry.addAttribute( 'position', new Float32BufferAttribute( [ 0, 0, 0, 0, 1, 0 ], 3 ) );
 
-			_coneGeometry = new CylinderBufferGeometry( 0, 0.5, 1, 5, 1 );
-			_coneGeometry.translate( 0, - 0.5, 0 );
+			coneGeometry = new CylinderBufferGeometry( 0, 0.5, 1, 5, 1 );
+			coneGeometry.translate( 0, - 0.5, 0 );
 
 		}
 
 		this.position.copy( origin );
 
-		this.line = new Line( _lineGeometry, new LineBasicMaterial( { color: color, toneMapped: false } ) );
+		this.line = new Line( lineGeometry, new LineBasicMaterial( { color: color } ) );
 		this.line.matrixAutoUpdate = false;
 		this.add( this.line );
 
-		this.cone = new Mesh( _coneGeometry, new MeshBasicMaterial( { color: color, toneMapped: false } ) );
+		this.cone = new Mesh( coneGeometry, new MeshBasicMaterial( { color: color } ) );
 		this.cone.matrixAutoUpdate = false;
 		this.add( this.cone );
 
@@ -47677,36 +46984,43 @@ var Spacekit = (function (exports) {
 	ArrowHelper.prototype = Object.create( Object3D.prototype );
 	ArrowHelper.prototype.constructor = ArrowHelper;
 
-	ArrowHelper.prototype.setDirection = function ( dir ) {
+	ArrowHelper.prototype.setDirection = ( function () {
 
-		// dir is assumed to be normalized
+		var axis = new Vector3();
+		var radians;
 
-		if ( dir.y > 0.99999 ) {
+		return function setDirection( dir ) {
 
-			this.quaternion.set( 0, 0, 0, 1 );
+			// dir is assumed to be normalized
 
-		} else if ( dir.y < - 0.99999 ) {
+			if ( dir.y > 0.99999 ) {
 
-			this.quaternion.set( 1, 0, 0, 0 );
+				this.quaternion.set( 0, 0, 0, 1 );
 
-		} else {
+			} else if ( dir.y < - 0.99999 ) {
 
-			_axis.set( dir.z, 0, - dir.x ).normalize();
+				this.quaternion.set( 1, 0, 0, 0 );
 
-			var radians = Math.acos( dir.y );
+			} else {
 
-			this.quaternion.setFromAxisAngle( _axis, radians );
+				axis.set( dir.z, 0, - dir.x ).normalize();
 
-		}
+				radians = Math.acos( dir.y );
 
-	};
+				this.quaternion.setFromAxisAngle( axis, radians );
+
+			}
+
+		};
+
+	}() );
 
 	ArrowHelper.prototype.setLength = function ( length, headLength, headWidth ) {
 
 		if ( headLength === undefined ) headLength = 0.2 * length;
 		if ( headWidth === undefined ) headWidth = 0.2 * headLength;
 
-		this.line.scale.set( 1, Math.max( 0.0001, length - headLength ), 1 ); // see #17458
+		this.line.scale.set( 1, Math.max( 0, length - headLength ), 1 );
 		this.line.updateMatrix();
 
 		this.cone.scale.set( headWidth, headLength, headWidth );
@@ -47761,867 +47075,17 @@ var Spacekit = (function (exports) {
 		];
 
 		var geometry = new BufferGeometry();
-		geometry.setAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
-		geometry.setAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
+		geometry.addAttribute( 'position', new Float32BufferAttribute( vertices, 3 ) );
+		geometry.addAttribute( 'color', new Float32BufferAttribute( colors, 3 ) );
 
-		var material = new LineBasicMaterial( { vertexColors: true, toneMapped: false } );
+		var material = new LineBasicMaterial( { vertexColors: VertexColors } );
 
 		LineSegments.call( this, geometry, material );
-
-		this.type = 'AxesHelper';
 
 	}
 
 	AxesHelper.prototype = Object.create( LineSegments.prototype );
 	AxesHelper.prototype.constructor = AxesHelper;
-
-	/**
-	 * @author Emmett Lalish / elalish
-	 *
-	 * This class generates a Prefiltered, Mipmapped Radiance Environment Map
-	 * (PMREM) from a cubeMap environment texture. This allows different levels of
-	 * blur to be quickly accessed based on material roughness. It is packed into a
-	 * special CubeUV format that allows us to perform custom interpolation so that
-	 * we can support nonlinear formats such as RGBE. Unlike a traditional mipmap
-	 * chain, it only goes down to the LOD_MIN level (above), and then creates extra
-	 * even more filtered 'mips' at the same LOD_MIN resolution, associated with
-	 * higher roughness levels. In this way we maintain resolution to smoothly
-	 * interpolate diffuse lighting while limiting sampling computation.
-	 */
-
-	var LOD_MIN = 4;
-	var LOD_MAX = 8;
-	var SIZE_MAX = Math.pow( 2, LOD_MAX );
-
-	// The standard deviations (radians) associated with the extra mips. These are
-	// chosen to approximate a Trowbridge-Reitz distribution function times the
-	// geometric shadowing function. These sigma values squared must match the
-	// variance #defines in cube_uv_reflection_fragment.glsl.js.
-	var EXTRA_LOD_SIGMA = [ 0.125, 0.215, 0.35, 0.446, 0.526, 0.582 ];
-
-	var TOTAL_LODS = LOD_MAX - LOD_MIN + 1 + EXTRA_LOD_SIGMA.length;
-
-	// The maximum length of the blur for loop. Smaller sigmas will use fewer
-	// samples and exit early, but not recompile the shader.
-	var MAX_SAMPLES = 20;
-
-	var ENCODINGS = {
-		[ LinearEncoding ]: 0,
-		[ sRGBEncoding ]: 1,
-		[ RGBEEncoding ]: 2,
-		[ RGBM7Encoding ]: 3,
-		[ RGBM16Encoding ]: 4,
-		[ RGBDEncoding ]: 5,
-		[ GammaEncoding ]: 6
-	};
-
-	var _flatCamera = new OrthographicCamera();
-	var { _lodPlanes, _sizeLods, _sigmas } = _createPlanes();
-	var _oldTarget = null;
-
-	// Golden Ratio
-	var PHI = ( 1 + Math.sqrt( 5 ) ) / 2;
-	var INV_PHI = 1 / PHI;
-
-	// Vertices of a dodecahedron (except the opposites, which represent the
-	// same axis), used as axis directions evenly spread on a sphere.
-	var _axisDirections = [
-		new Vector3( 1, 1, 1 ),
-		new Vector3( - 1, 1, 1 ),
-		new Vector3( 1, 1, - 1 ),
-		new Vector3( - 1, 1, - 1 ),
-		new Vector3( 0, PHI, INV_PHI ),
-		new Vector3( 0, PHI, - INV_PHI ),
-		new Vector3( INV_PHI, 0, PHI ),
-		new Vector3( - INV_PHI, 0, PHI ),
-		new Vector3( PHI, INV_PHI, 0 ),
-		new Vector3( - PHI, INV_PHI, 0 ) ];
-
-	function PMREMGenerator( renderer ) {
-
-		this._renderer = renderer;
-		this._pingPongRenderTarget = null;
-
-		this._blurMaterial = _getBlurShader( MAX_SAMPLES );
-		this._equirectShader = null;
-		this._cubemapShader = null;
-
-		this._compileMaterial( this._blurMaterial );
-
-	}
-
-	PMREMGenerator.prototype = {
-
-		constructor: PMREMGenerator,
-
-		/**
-		 * Generates a PMREM from a supplied Scene, which can be faster than using an
-		 * image if networking bandwidth is low. Optional sigma specifies a blur radius
-		 * in radians to be applied to the scene before PMREM generation. Optional near
-		 * and far planes ensure the scene is rendered in its entirety (the cubeCamera
-		 * is placed at the origin).
-		 */
-		fromScene: function ( scene, sigma = 0, near = 0.1, far = 100 ) {
-
-			_oldTarget = this._renderer.getRenderTarget();
-			var cubeUVRenderTarget = this._allocateTargets();
-
-			this._sceneToCubeUV( scene, near, far, cubeUVRenderTarget );
-			if ( sigma > 0 ) {
-
-				this._blur( cubeUVRenderTarget, 0, 0, sigma );
-
-			}
-
-			this._applyPMREM( cubeUVRenderTarget );
-			this._cleanup( cubeUVRenderTarget );
-
-			return cubeUVRenderTarget;
-
-		},
-
-		/**
-		 * Generates a PMREM from an equirectangular texture, which can be either LDR
-		 * (RGBFormat) or HDR (RGBEFormat). The ideal input image size is 1k (1024 x 512),
-		 * as this matches best with the 256 x 256 cubemap output.
-		 */
-		fromEquirectangular: function ( equirectangular ) {
-
-			equirectangular.magFilter = NearestFilter;
-			equirectangular.minFilter = NearestFilter;
-			equirectangular.generateMipmaps = false;
-
-			return this.fromCubemap( equirectangular );
-
-		},
-
-		/**
-		 * Generates a PMREM from an cubemap texture, which can be either LDR
-		 * (RGBFormat) or HDR (RGBEFormat). The ideal input cube size is 256 x 256,
-		 * as this matches best with the 256 x 256 cubemap output.
-		 */
-		fromCubemap: function ( cubemap ) {
-
-			_oldTarget = this._renderer.getRenderTarget();
-			var cubeUVRenderTarget = this._allocateTargets( cubemap );
-			this._textureToCubeUV( cubemap, cubeUVRenderTarget );
-			this._applyPMREM( cubeUVRenderTarget );
-			this._cleanup( cubeUVRenderTarget );
-
-			return cubeUVRenderTarget;
-
-		},
-
-		/**
-		 * Pre-compiles the cubemap shader. You can get faster start-up by invoking this method during
-		 * your texture's network fetch for increased concurrency.
-		 */
-		compileCubemapShader: function () {
-
-			if ( this._cubemapShader === null ) {
-
-				this._cubemapShader = _getCubemapShader();
-				this._compileMaterial( this._cubemapShader );
-
-			}
-
-		},
-
-		/**
-		 * Pre-compiles the equirectangular shader. You can get faster start-up by invoking this method during
-		 * your texture's network fetch for increased concurrency.
-		 */
-		compileEquirectangularShader: function () {
-
-			if ( this._equirectShader === null ) {
-
-				this._equirectShader = _getEquirectShader();
-				this._compileMaterial( this._equirectShader );
-
-			}
-
-		},
-
-		/**
-		 * Disposes of the PMREMGenerator's internal memory. Note that PMREMGenerator is a static class,
-		 * so you should not need more than one PMREMGenerator object. If you do, calling dispose() on
-		 * one of them will cause any others to also become unusable.
-		 */
-		dispose: function () {
-
-			this._blurMaterial.dispose();
-
-			if ( this._cubemapShader !== null ) this._cubemapShader.dispose();
-			if ( this._equirectShader !== null ) this._equirectShader.dispose();
-
-			for ( var i = 0; i < _lodPlanes.length; i ++ ) {
-
-				_lodPlanes[ i ].dispose();
-
-			}
-
-		},
-
-		// private interface
-
-		_cleanup: function ( outputTarget ) {
-
-			this._pingPongRenderTarget.dispose();
-			this._renderer.setRenderTarget( _oldTarget );
-			outputTarget.scissorTest = false;
-			// reset viewport and scissor
-			outputTarget.setSize( outputTarget.width, outputTarget.height );
-
-		},
-
-		_allocateTargets: function ( equirectangular ) {
-
-			var params = {
-				magFilter: NearestFilter,
-				minFilter: NearestFilter,
-				generateMipmaps: false,
-				type: UnsignedByteType,
-				format: RGBEFormat,
-				encoding: _isLDR( equirectangular ) ? equirectangular.encoding : RGBEEncoding,
-				depthBuffer: false,
-				stencilBuffer: false
-			};
-
-			var cubeUVRenderTarget = _createRenderTarget( params );
-			cubeUVRenderTarget.depthBuffer = equirectangular ? false : true;
-			this._pingPongRenderTarget = _createRenderTarget( params );
-			return cubeUVRenderTarget;
-
-		},
-
-		_compileMaterial: function ( material ) {
-
-			var tmpScene = new Scene();
-			tmpScene.add( new Mesh( _lodPlanes[ 0 ], material ) );
-			this._renderer.compile( tmpScene, _flatCamera );
-
-		},
-
-		_sceneToCubeUV: function ( scene, near, far, cubeUVRenderTarget ) {
-
-			var fov = 90;
-			var aspect = 1;
-			var cubeCamera = new PerspectiveCamera( fov, aspect, near, far );
-			var upSign = [ 1, 1, 1, 1, - 1, 1 ];
-			var forwardSign = [ 1, 1, - 1, - 1, - 1, 1 ];
-			var renderer = this._renderer;
-
-			var outputEncoding = renderer.outputEncoding;
-			var toneMapping = renderer.toneMapping;
-			var toneMappingExposure = renderer.toneMappingExposure;
-			var clearColor = renderer.getClearColor();
-			var clearAlpha = renderer.getClearAlpha();
-
-			renderer.toneMapping = LinearToneMapping;
-			renderer.toneMappingExposure = 1.0;
-			renderer.outputEncoding = LinearEncoding;
-			scene.scale.z *= - 1;
-
-			var background = scene.background;
-			if ( background && background.isColor ) {
-
-				background.convertSRGBToLinear();
-				// Convert linear to RGBE
-				var maxComponent = Math.max( background.r, background.g, background.b );
-				var fExp = Math.min( Math.max( Math.ceil( Math.log2( maxComponent ) ), - 128.0 ), 127.0 );
-				background = background.multiplyScalar( Math.pow( 2.0, - fExp ) );
-				var alpha = ( fExp + 128.0 ) / 255.0;
-				renderer.setClearColor( background, alpha );
-				scene.background = null;
-
-			}
-
-			for ( var i = 0; i < 6; i ++ ) {
-
-				var col = i % 3;
-				if ( col == 0 ) {
-
-					cubeCamera.up.set( 0, upSign[ i ], 0 );
-					cubeCamera.lookAt( forwardSign[ i ], 0, 0 );
-
-				} else if ( col == 1 ) {
-
-					cubeCamera.up.set( 0, 0, upSign[ i ] );
-					cubeCamera.lookAt( 0, forwardSign[ i ], 0 );
-
-				} else {
-
-					cubeCamera.up.set( 0, upSign[ i ], 0 );
-					cubeCamera.lookAt( 0, 0, forwardSign[ i ] );
-
-				}
-
-				_setViewport( cubeUVRenderTarget,
-					col * SIZE_MAX, i > 2 ? SIZE_MAX : 0, SIZE_MAX, SIZE_MAX );
-				renderer.setRenderTarget( cubeUVRenderTarget );
-				renderer.render( scene, cubeCamera );
-
-			}
-
-			renderer.toneMapping = toneMapping;
-			renderer.toneMappingExposure = toneMappingExposure;
-			renderer.outputEncoding = outputEncoding;
-			renderer.setClearColor( clearColor, clearAlpha );
-			scene.scale.z *= - 1;
-
-		},
-
-		_textureToCubeUV: function ( texture, cubeUVRenderTarget ) {
-
-			var scene = new Scene();
-			var renderer = this._renderer;
-
-			if ( texture.isCubeTexture ) {
-
-				if ( this._cubemapShader == null ) {
-
-					this._cubemapShader = _getCubemapShader();
-
-				}
-
-			} else {
-
-				if ( this._equirectShader == null ) {
-
-					this._equirectShader = _getEquirectShader();
-
-				}
-
-			}
-
-			var material = texture.isCubeTexture ? this._cubemapShader : this._equirectShader;
-			scene.add( new Mesh( _lodPlanes[ 0 ], material ) );
-
-			var uniforms = material.uniforms;
-
-			uniforms[ 'envMap' ].value = texture;
-
-			if ( ! texture.isCubeTexture ) {
-
-				uniforms[ 'texelSize' ].value.set( 1.0 / texture.image.width, 1.0 / texture.image.height );
-
-			}
-
-			uniforms[ 'inputEncoding' ].value = ENCODINGS[ texture.encoding ];
-			uniforms[ 'outputEncoding' ].value = ENCODINGS[ cubeUVRenderTarget.texture.encoding ];
-
-			_setViewport( cubeUVRenderTarget, 0, 0, 3 * SIZE_MAX, 2 * SIZE_MAX );
-
-			renderer.setRenderTarget( cubeUVRenderTarget );
-			renderer.render( scene, _flatCamera );
-
-		},
-
-		_applyPMREM: function ( cubeUVRenderTarget ) {
-
-			var renderer = this._renderer;
-			var autoClear = renderer.autoClear;
-			renderer.autoClear = false;
-
-			for ( var i = 1; i < TOTAL_LODS; i ++ ) {
-
-				var sigma = Math.sqrt( _sigmas[ i ] * _sigmas[ i ] - _sigmas[ i - 1 ] * _sigmas[ i - 1 ] );
-
-				var poleAxis = _axisDirections[ ( i - 1 ) % _axisDirections.length ];
-
-				this._blur( cubeUVRenderTarget, i - 1, i, sigma, poleAxis );
-
-			}
-
-			renderer.autoClear = autoClear;
-
-		},
-
-		/**
-		 * This is a two-pass Gaussian blur for a cubemap. Normally this is done
-		 * vertically and horizontally, but this breaks down on a cube. Here we apply
-		 * the blur latitudinally (around the poles), and then longitudinally (towards
-		 * the poles) to approximate the orthogonally-separable blur. It is least
-		 * accurate at the poles, but still does a decent job.
-		 */
-		_blur: function ( cubeUVRenderTarget, lodIn, lodOut, sigma, poleAxis ) {
-
-			var pingPongRenderTarget = this._pingPongRenderTarget;
-
-			this._halfBlur(
-				cubeUVRenderTarget,
-				pingPongRenderTarget,
-				lodIn,
-				lodOut,
-				sigma,
-				'latitudinal',
-				poleAxis );
-
-			this._halfBlur(
-				pingPongRenderTarget,
-				cubeUVRenderTarget,
-				lodOut,
-				lodOut,
-				sigma,
-				'longitudinal',
-				poleAxis );
-
-		},
-
-		_halfBlur: function ( targetIn, targetOut, lodIn, lodOut, sigmaRadians, direction, poleAxis ) {
-
-			var renderer = this._renderer;
-			var blurMaterial = this._blurMaterial;
-
-			if ( direction !== 'latitudinal' && direction !== 'longitudinal' ) {
-
-				console.error(
-					'blur direction must be either latitudinal or longitudinal!' );
-
-			}
-
-			// Number of standard deviations at which to cut off the discrete approximation.
-			var STANDARD_DEVIATIONS = 3;
-
-			var blurScene = new Scene();
-			blurScene.add( new Mesh( _lodPlanes[ lodOut ], blurMaterial ) );
-			var blurUniforms = blurMaterial.uniforms;
-
-			var pixels = _sizeLods[ lodIn ] - 1;
-			var radiansPerPixel = isFinite( sigmaRadians ) ? Math.PI / ( 2 * pixels ) : 2 * Math.PI / ( 2 * MAX_SAMPLES - 1 );
-			var sigmaPixels = sigmaRadians / radiansPerPixel;
-			var samples = isFinite( sigmaRadians ) ? 1 + Math.floor( STANDARD_DEVIATIONS * sigmaPixels ) : MAX_SAMPLES;
-
-			if ( samples > MAX_SAMPLES ) {
-
-				console.warn( `sigmaRadians, ${
-				sigmaRadians}, is too large and will clip, as it requested ${
-				samples} samples when the maximum is set to ${MAX_SAMPLES}` );
-
-			}
-
-			var weights = [];
-			var sum = 0;
-
-			for ( var i = 0; i < MAX_SAMPLES; ++ i ) {
-
-				var x = i / sigmaPixels;
-				var weight = Math.exp( - x * x / 2 );
-				weights.push( weight );
-
-				if ( i == 0 ) {
-
-					sum += weight;
-
-				} else if ( i < samples ) {
-
-					sum += 2 * weight;
-
-				}
-
-			}
-
-			for ( var i = 0; i < weights.length; i ++ ) {
-
-				weights[ i ] = weights[ i ] / sum;
-
-			}
-
-			blurUniforms[ 'envMap' ].value = targetIn.texture;
-			blurUniforms[ 'samples' ].value = samples;
-			blurUniforms[ 'weights' ].value = weights;
-			blurUniforms[ 'latitudinal' ].value = direction === 'latitudinal';
-
-			if ( poleAxis ) {
-
-				blurUniforms[ 'poleAxis' ].value = poleAxis;
-
-			}
-
-			blurUniforms[ 'dTheta' ].value = radiansPerPixel;
-			blurUniforms[ 'mipInt' ].value = LOD_MAX - lodIn;
-			blurUniforms[ 'inputEncoding' ].value = ENCODINGS[ targetIn.texture.encoding ];
-			blurUniforms[ 'outputEncoding' ].value = ENCODINGS[ targetIn.texture.encoding ];
-
-			var outputSize = _sizeLods[ lodOut ];
-			var x = 3 * Math.max( 0, SIZE_MAX - 2 * outputSize );
-			var y = ( lodOut === 0 ? 0 : 2 * SIZE_MAX ) + 2 * outputSize * ( lodOut > LOD_MAX - LOD_MIN ? lodOut - LOD_MAX + LOD_MIN : 0 );
-
-			_setViewport( targetOut, x, y, 3 * outputSize, 2 * outputSize );
-			renderer.setRenderTarget( targetOut );
-			renderer.render( blurScene, _flatCamera );
-
-		}
-
-	};
-
-	function _isLDR( texture ) {
-
-		if ( texture === undefined || texture.type !== UnsignedByteType ) return false;
-
-		return texture.encoding === LinearEncoding || texture.encoding === sRGBEncoding || texture.encoding === GammaEncoding;
-
-	}
-
-	function _createPlanes() {
-
-		var _lodPlanes = [];
-		var _sizeLods = [];
-		var _sigmas = [];
-
-		var lod = LOD_MAX;
-
-		for ( var i = 0; i < TOTAL_LODS; i ++ ) {
-
-			var sizeLod = Math.pow( 2, lod );
-			_sizeLods.push( sizeLod );
-			var sigma = 1.0 / sizeLod;
-
-			if ( i > LOD_MAX - LOD_MIN ) {
-
-				sigma = EXTRA_LOD_SIGMA[ i - LOD_MAX + LOD_MIN - 1 ];
-
-			} else if ( i == 0 ) {
-
-				sigma = 0;
-
-			}
-
-			_sigmas.push( sigma );
-
-			var texelSize = 1.0 / ( sizeLod - 1 );
-			var min = - texelSize / 2;
-			var max = 1 + texelSize / 2;
-			var uv1 = [ min, min, max, min, max, max, min, min, max, max, min, max ];
-
-			var cubeFaces = 6;
-			var vertices = 6;
-			var positionSize = 3;
-			var uvSize = 2;
-			var faceIndexSize = 1;
-
-			var position = new Float32Array( positionSize * vertices * cubeFaces );
-			var uv = new Float32Array( uvSize * vertices * cubeFaces );
-			var faceIndex = new Float32Array( faceIndexSize * vertices * cubeFaces );
-
-			for ( var face = 0; face < cubeFaces; face ++ ) {
-
-				var x = ( face % 3 ) * 2 / 3 - 1;
-				var y = face > 2 ? 0 : - 1;
-				var coordinates = [
-					x, y, 0,
-					x + 2 / 3, y, 0,
-					x + 2 / 3, y + 1, 0,
-					x, y, 0,
-					x + 2 / 3, y + 1, 0,
-					x, y + 1, 0
-				];
-				position.set( coordinates, positionSize * vertices * face );
-				uv.set( uv1, uvSize * vertices * face );
-				var fill = [ face, face, face, face, face, face ];
-				faceIndex.set( fill, faceIndexSize * vertices * face );
-
-			}
-
-			var planes = new BufferGeometry();
-			planes.setAttribute( 'position', new BufferAttribute( position, positionSize ) );
-			planes.setAttribute( 'uv', new BufferAttribute( uv, uvSize ) );
-			planes.setAttribute( 'faceIndex', new BufferAttribute( faceIndex, faceIndexSize ) );
-			_lodPlanes.push( planes );
-
-			if ( lod > LOD_MIN ) {
-
-				lod --;
-
-			}
-
-		}
-
-		return { _lodPlanes, _sizeLods, _sigmas };
-
-	}
-
-	function _createRenderTarget( params ) {
-
-		var cubeUVRenderTarget = new WebGLRenderTarget( 3 * SIZE_MAX, 3 * SIZE_MAX, params );
-		cubeUVRenderTarget.texture.mapping = CubeUVReflectionMapping;
-		cubeUVRenderTarget.texture.name = 'PMREM.cubeUv';
-		cubeUVRenderTarget.scissorTest = true;
-		return cubeUVRenderTarget;
-
-	}
-
-	function _setViewport( target, x, y, width, height ) {
-
-		target.viewport.set( x, y, width, height );
-		target.scissor.set( x, y, width, height );
-
-	}
-
-	function _getBlurShader( maxSamples ) {
-
-		var weights = new Float32Array( maxSamples );
-		var poleAxis = new Vector3( 0, 1, 0 );
-		var shaderMaterial = new RawShaderMaterial( {
-
-			defines: { 'n': maxSamples },
-
-			uniforms: {
-				'envMap': { value: null },
-				'samples': { value: 1 },
-				'weights': { value: weights },
-				'latitudinal': { value: false },
-				'dTheta': { value: 0 },
-				'mipInt': { value: 0 },
-				'poleAxis': { value: poleAxis },
-				'inputEncoding': { value: ENCODINGS[ LinearEncoding ] },
-				'outputEncoding': { value: ENCODINGS[ LinearEncoding ] }
-			},
-
-			vertexShader: _getCommonVertexShader(),
-
-			fragmentShader: `
-precision mediump float;
-precision mediump int;
-varying vec3 vOutputDirection;
-uniform sampler2D envMap;
-uniform int samples;
-uniform float weights[n];
-uniform bool latitudinal;
-uniform float dTheta;
-uniform float mipInt;
-uniform vec3 poleAxis;
-
-${_getEncodings()}
-
-#define ENVMAP_TYPE_CUBE_UV
-#include <cube_uv_reflection_fragment>
-
-vec3 getSample(float theta, vec3 axis) {
-	float cosTheta = cos(theta);
-	// Rodrigues' axis-angle rotation
-	vec3 sampleDirection = vOutputDirection * cosTheta
-		+ cross(axis, vOutputDirection) * sin(theta)
-		+ axis * dot(axis, vOutputDirection) * (1.0 - cosTheta);
-	return bilinearCubeUV(envMap, sampleDirection, mipInt);
-}
-
-void main() {
-	vec3 axis = latitudinal ? poleAxis : cross(poleAxis, vOutputDirection);
-	if (all(equal(axis, vec3(0.0))))
-		axis = vec3(vOutputDirection.z, 0.0, - vOutputDirection.x);
-	axis = normalize(axis);
-	gl_FragColor = vec4(0.0);
-	gl_FragColor.rgb += weights[0] * getSample(0.0, axis);
-	for (int i = 1; i < n; i++) {
-		if (i >= samples)
-			break;
-		float theta = dTheta * float(i);
-		gl_FragColor.rgb += weights[i] * getSample(-1.0 * theta, axis);
-		gl_FragColor.rgb += weights[i] * getSample(theta, axis);
-	}
-	gl_FragColor = linearToOutputTexel(gl_FragColor);
-}
-		`,
-
-			blending: NoBlending,
-			depthTest: false,
-			depthWrite: false
-
-		} );
-
-		shaderMaterial.type = 'SphericalGaussianBlur';
-
-		return shaderMaterial;
-
-	}
-
-	function _getEquirectShader() {
-
-		var texelSize = new Vector2( 1, 1 );
-		var shaderMaterial = new RawShaderMaterial( {
-
-			uniforms: {
-				'envMap': { value: null },
-				'texelSize': { value: texelSize },
-				'inputEncoding': { value: ENCODINGS[ LinearEncoding ] },
-				'outputEncoding': { value: ENCODINGS[ LinearEncoding ] }
-			},
-
-			vertexShader: _getCommonVertexShader(),
-
-			fragmentShader: `
-precision mediump float;
-precision mediump int;
-varying vec3 vOutputDirection;
-uniform sampler2D envMap;
-uniform vec2 texelSize;
-
-${_getEncodings()}
-
-#define RECIPROCAL_PI 0.31830988618
-#define RECIPROCAL_PI2 0.15915494
-
-void main() {
-	gl_FragColor = vec4(0.0);
-	vec3 outputDirection = normalize(vOutputDirection);
-	vec2 uv;
-	uv.y = asin(clamp(outputDirection.y, -1.0, 1.0)) * RECIPROCAL_PI + 0.5;
-	uv.x = atan(outputDirection.z, outputDirection.x) * RECIPROCAL_PI2 + 0.5;
-	vec2 f = fract(uv / texelSize - 0.5);
-	uv -= f * texelSize;
-	vec3 tl = envMapTexelToLinear(texture2D(envMap, uv)).rgb;
-	uv.x += texelSize.x;
-	vec3 tr = envMapTexelToLinear(texture2D(envMap, uv)).rgb;
-	uv.y += texelSize.y;
-	vec3 br = envMapTexelToLinear(texture2D(envMap, uv)).rgb;
-	uv.x -= texelSize.x;
-	vec3 bl = envMapTexelToLinear(texture2D(envMap, uv)).rgb;
-	vec3 tm = mix(tl, tr, f.x);
-	vec3 bm = mix(bl, br, f.x);
-	gl_FragColor.rgb = mix(tm, bm, f.y);
-	gl_FragColor = linearToOutputTexel(gl_FragColor);
-}
-		`,
-
-			blending: NoBlending,
-			depthTest: false,
-			depthWrite: false
-
-		} );
-
-		shaderMaterial.type = 'EquirectangularToCubeUV';
-
-		return shaderMaterial;
-
-	}
-
-	function _getCubemapShader() {
-
-		var shaderMaterial = new RawShaderMaterial( {
-
-			uniforms: {
-				'envMap': { value: null },
-				'inputEncoding': { value: ENCODINGS[ LinearEncoding ] },
-				'outputEncoding': { value: ENCODINGS[ LinearEncoding ] }
-			},
-
-			vertexShader: _getCommonVertexShader(),
-
-			fragmentShader: `
-precision mediump float;
-precision mediump int;
-varying vec3 vOutputDirection;
-uniform samplerCube envMap;
-
-${_getEncodings()}
-
-void main() {
-	gl_FragColor = vec4(0.0);
-	gl_FragColor.rgb = envMapTexelToLinear(textureCube(envMap, vec3( - vOutputDirection.x, vOutputDirection.yz ))).rgb;
-	gl_FragColor = linearToOutputTexel(gl_FragColor);
-}
-		`,
-
-			blending: NoBlending,
-			depthTest: false,
-			depthWrite: false
-
-		} );
-
-		shaderMaterial.type = 'CubemapToCubeUV';
-
-		return shaderMaterial;
-
-	}
-
-	function _getCommonVertexShader() {
-
-		return `
-precision mediump float;
-precision mediump int;
-attribute vec3 position;
-attribute vec2 uv;
-attribute float faceIndex;
-varying vec3 vOutputDirection;
-vec3 getDirection(vec2 uv, float face) {
-	uv = 2.0 * uv - 1.0;
-	vec3 direction = vec3(uv, 1.0);
-	if (face == 0.0) {
-		direction = direction.zyx;
-		direction.z *= -1.0;
-	} else if (face == 1.0) {
-		direction = direction.xzy;
-		direction.z *= -1.0;
-	} else if (face == 3.0) {
-		direction = direction.zyx;
-		direction.x *= -1.0;
-	} else if (face == 4.0) {
-		direction = direction.xzy;
-		direction.y *= -1.0;
-	} else if (face == 5.0) {
-		direction.xz *= -1.0;
-	}
-	return direction;
-}
-void main() {
-	vOutputDirection = getDirection(uv, faceIndex);
-	gl_Position = vec4( position, 1.0 );
-}
-	`;
-
-	}
-
-	function _getEncodings() {
-
-		return `
-uniform int inputEncoding;
-uniform int outputEncoding;
-
-#include <encodings_pars_fragment>
-
-vec4 inputTexelToLinear(vec4 value){
-	if(inputEncoding == 0){
-		return value;
-	}else if(inputEncoding == 1){
-		return sRGBToLinear(value);
-	}else if(inputEncoding == 2){
-		return RGBEToLinear(value);
-	}else if(inputEncoding == 3){
-		return RGBMToLinear(value, 7.0);
-	}else if(inputEncoding == 4){
-		return RGBMToLinear(value, 16.0);
-	}else if(inputEncoding == 5){
-		return RGBDToLinear(value, 256.0);
-	}else{
-		return GammaToLinear(value, 2.2);
-	}
-}
-
-vec4 linearToOutputTexel(vec4 value){
-	if(outputEncoding == 0){
-		return value;
-	}else if(outputEncoding == 1){
-		return LinearTosRGB(value);
-	}else if(outputEncoding == 2){
-		return LinearToRGBE(value);
-	}else if(outputEncoding == 3){
-		return LinearToRGBM(value, 7.0);
-	}else if(outputEncoding == 4){
-		return LinearToRGBM(value, 16.0);
-	}else if(outputEncoding == 5){
-		return LinearToRGBD(value, 256.0);
-	}else{
-		return LinearToGamma(value, 2.2);
-	}
-}
-
-vec4 envMapTexelToLinear(vec4 color) {
-	return inputTexelToLinear(color);
-}
-	`;
-
-	}
 
 	/**
 	 * @author mrdoob / http://mrdoob.com/
@@ -48635,10 +47099,8 @@ vec4 envMapTexelToLinear(vec4 color) {
 	}
 
 	var LineStrip = 0;
+
 	var LinePieces = 1;
-	var NoColors = 0;
-	var FaceColors = 1;
-	var VertexColors = 2;
 
 	function MeshFaceMaterial( materials ) {
 
@@ -48659,7 +47121,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 			return materials.slice();
 
 		};
-
 		return materials;
 
 	}
@@ -48717,8 +47178,8 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 	function DynamicBufferAttribute( array, itemSize ) {
 
-		console.warn( 'THREE.DynamicBufferAttribute has been removed. Use new THREE.BufferAttribute().setUsage( THREE.DynamicDrawUsage ) instead.' );
-		return new BufferAttribute( array, itemSize ).setUsage( DynamicDrawUsage );
+		console.warn( 'THREE.DynamicBufferAttribute has been removed. Use new THREE.BufferAttribute().setDynamic( true ) instead.' );
+		return new BufferAttribute( array, itemSize ).setDynamic( true );
 
 	}
 
@@ -48851,7 +47312,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 		fromPoints: function ( points ) {
 
 			console.warn( 'THREE.Path: .fromPoints() has been renamed to .setFromPoints().' );
-			return this.setFromPoints( points );
+			this.setFromPoints( points );
 
 		}
 
@@ -48972,22 +47433,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 	} );
 
-	Loader.Handlers = {
-
-		add: function ( /* regex, loader */ ) {
-
-			console.error( 'THREE.Loader: Handlers.add() has been removed. Use LoadingManager.addHandler() instead.' );
-
-		},
-
-		get: function ( /* file */ ) {
-
-			console.error( 'THREE.Loader: Handlers.get() has been removed. Use LoadingManager.getHandler() instead.' );
-
-		}
-
-	};
-
 	function XHRLoader( manager ) {
 
 		console.warn( 'THREE.XHRLoader has been renamed to THREE.FileLoader.' );
@@ -49077,24 +47522,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 		}
 	} );
 
-	Object.assign( Sphere.prototype, {
-
-		empty: function () {
-
-			console.warn( 'THREE.Sphere: .empty() has been renamed to .isEmpty().' );
-			return this.isEmpty();
-
-		},
-
-	} );
-
-	Frustum.prototype.setFromMatrix = function ( m ) {
-
-		console.warn( 'THREE.Frustum: .setFromMatrix() has been renamed to .setFromProjectionMatrix().' );
-		return this.setFromProjectionMatrix( m );
-
-	};
-
 	Line3.prototype.center = function ( optionalTarget ) {
 
 		console.warn( 'THREE.Line3: .center() has been renamed to .getCenter().' );
@@ -49102,7 +47529,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 	};
 
-	Object.assign( MathUtils, {
+	Object.assign( _Math, {
 
 		random16: function () {
 
@@ -49114,14 +47541,14 @@ vec4 envMapTexelToLinear(vec4 color) {
 		nearestPowerOfTwo: function ( value ) {
 
 			console.warn( 'THREE.Math: .nearestPowerOfTwo() has been renamed to .floorPowerOfTwo().' );
-			return MathUtils.floorPowerOfTwo( value );
+			return _Math.floorPowerOfTwo( value );
 
 		},
 
 		nextPowerOfTwo: function ( value ) {
 
 			console.warn( 'THREE.Math: .nextPowerOfTwo() has been renamed to .ceilPowerOfTwo().' );
-			return MathUtils.ceilPowerOfTwo( value );
+			return _Math.ceilPowerOfTwo( value );
 
 		}
 
@@ -49146,10 +47573,10 @@ vec4 envMapTexelToLinear(vec4 color) {
 			console.error( 'THREE.Matrix3: .multiplyVector3Array() has been removed.' );
 
 		},
-		applyToBufferAttribute: function ( attribute ) {
+		applyToBuffer: function ( buffer /*, offset, length */ ) {
 
-			console.warn( 'THREE.Matrix3: .applyToBufferAttribute() has been removed. Use attribute.applyMatrix3( matrix ) instead.' );
-			return attribute.applyMatrix3( this );
+			console.warn( 'THREE.Matrix3: .applyToBuffer() has been removed. Use matrix.applyToBufferAttribute( attribute ) instead.' );
+			return this.applyToBufferAttribute( buffer );
 
 		},
 		applyToVector3Array: function ( /* array, offset, length */ ) {
@@ -49176,10 +47603,17 @@ vec4 envMapTexelToLinear(vec4 color) {
 		},
 		getPosition: function () {
 
-			console.warn( 'THREE.Matrix4: .getPosition() has been removed. Use Vector3.setFromMatrixPosition( matrix ) instead.' );
-			return new Vector3().setFromMatrixColumn( this, 3 );
+			var v1;
 
-		},
+			return function getPosition() {
+
+				if ( v1 === undefined ) v1 = new Vector3();
+				console.warn( 'THREE.Matrix4: .getPosition() has been removed. Use Vector3.setFromMatrixPosition( matrix ) instead.' );
+				return v1.setFromMatrixColumn( this, 3 );
+
+			};
+
+		}(),
 		setRotationFromQuaternion: function ( q ) {
 
 			console.warn( 'THREE.Matrix4: .setRotationFromQuaternion() has been renamed to .makeRotationFromQuaternion().' );
@@ -49245,10 +47679,10 @@ vec4 envMapTexelToLinear(vec4 color) {
 			console.error( 'THREE.Matrix4: .rotateByAxis() has been removed.' );
 
 		},
-		applyToBufferAttribute: function ( attribute ) {
+		applyToBuffer: function ( buffer /*, offset, length */ ) {
 
-			console.warn( 'THREE.Matrix4: .applyToBufferAttribute() has been removed. Use attribute.applyMatrix4( matrix ) instead.' );
-			return attribute.applyMatrix4( this );
+			console.warn( 'THREE.Matrix4: .applyToBuffer() has been removed. Use matrix.applyToBufferAttribute( attribute ) instead.' );
+			return this.applyToBufferAttribute( buffer );
 
 		},
 		applyToVector3Array: function ( /* array, offset, length */ ) {
@@ -49487,12 +47921,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 			console.error( 'THREE.Geometry: .computeLineDistances() has been removed. Use THREE.Line.computeLineDistances() instead.' );
 
-		},
-		applyMatrix: function ( matrix ) {
-
-			console.warn( 'THREE.Geometry: .applyMatrix() has been renamed to .applyMatrix4().' );
-			return this.applyMatrix4( matrix );
-
 		}
 
 	} );
@@ -49519,12 +47947,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 		getWorldRotation: function () {
 
 			console.error( 'THREE.Object3D: .getWorldRotation() has been removed. Use THREE.Object3D.getWorldQuaternion( target ) instead.' );
-
-		},
-		applyMatrix: function ( matrix ) {
-
-			console.warn( 'THREE.Object3D: .applyMatrix() has been renamed to .applyMatrix4().' );
-			return this.applyMatrix4( matrix );
 
 		}
 
@@ -49555,34 +47977,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 			set: function () {
 
 				console.warn( 'THREE.Object3D: .useQuaternion has been removed. The library now uses quaternions by default.' );
-
-			}
-		}
-
-	} );
-
-	Object.assign( Mesh.prototype, {
-
-		setDrawMode: function () {
-
-			console.error( 'THREE.Mesh: .setDrawMode() has been removed. The renderer now always assumes THREE.TrianglesDrawMode. Transform your geometry via BufferGeometryUtils.toTrianglesDrawMode() if necessary.' );
-
-		},
-
-	} );
-
-	Object.defineProperties( Mesh.prototype, {
-
-		drawMode: {
-			get: function () {
-
-				console.error( 'THREE.Mesh: .drawMode has been removed. The renderer now always assumes THREE.TrianglesDrawMode.' );
-				return TrianglesDrawMode;
-
-			},
-			set: function () {
-
-				console.error( 'THREE.Mesh: .drawMode has been removed. The renderer now always assumes THREE.TrianglesDrawMode. Transform your geometry via BufferGeometryUtils.toTrianglesDrawMode() if necessary.' );
 
 			}
 		}
@@ -49770,41 +48164,12 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 			}
 		},
-		dynamic: {
-			get: function () {
-
-				console.warn( 'THREE.BufferAttribute: .dynamic has been deprecated. Use .usage instead.' );
-				return this.usage === DynamicDrawUsage;
-
-			},
-			set: function ( /* value */ ) {
-
-				console.warn( 'THREE.BufferAttribute: .dynamic has been deprecated. Use .usage instead.' );
-				this.setUsage( DynamicDrawUsage );
-
-			}
-		}
-
-	} );
-
-	Object.assign( BufferAttribute.prototype, {
-		setDynamic: function ( value ) {
-
-			console.warn( 'THREE.BufferAttribute: .setDynamic() has been deprecated. Use .setUsage() instead.' );
-			this.setUsage( value === true ? DynamicDrawUsage : StaticDrawUsage );
-			return this;
-
-		},
 		copyIndicesArray: function ( /* indices */ ) {
 
 			console.error( 'THREE.BufferAttribute: .copyIndicesArray() has been removed.' );
 
-		},
-		setArray: function ( /* array */ ) {
-
-			console.error( 'THREE.BufferAttribute: .setArray has been removed. Use BufferGeometry .setAttribute to replace/resize attribute buffers' );
-
 		}
+
 	} );
 
 	Object.assign( BufferGeometry.prototype, {
@@ -49815,30 +48180,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 			this.setIndex( index );
 
 		},
-		addAttribute: function ( name, attribute ) {
-
-			console.warn( 'THREE.BufferGeometry: .addAttribute() has been renamed to .setAttribute().' );
-
-			if ( ! ( attribute && attribute.isBufferAttribute ) && ! ( attribute && attribute.isInterleavedBufferAttribute ) ) {
-
-				console.warn( 'THREE.BufferGeometry: .addAttribute() now expects ( name, attribute ).' );
-
-				return this.setAttribute( name, new BufferAttribute( arguments[ 1 ], arguments[ 2 ] ) );
-
-			}
-
-			if ( name === 'index' ) {
-
-				console.warn( 'THREE.BufferGeometry.addAttribute: Use .setIndex() for index attribute.' );
-				this.setIndex( attribute );
-
-				return this;
-
-			}
-
-			return this.setAttribute( name, attribute );
-
-		},
 		addDrawCall: function ( start, count, indexOffset ) {
 
 			if ( indexOffset !== undefined ) {
@@ -49846,7 +48187,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 				console.warn( 'THREE.BufferGeometry: .addDrawCall() no longer supports indexOffset.' );
 
 			}
-
 			console.warn( 'THREE.BufferGeometry: .addDrawCall() is now .addGroup().' );
 			this.addGroup( start, count );
 
@@ -49865,19 +48205,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 		computeOffsets: function () {
 
 			console.warn( 'THREE.BufferGeometry: .computeOffsets() has been removed.' );
-
-		},
-		removeAttribute: function ( name ) {
-
-			console.warn( 'THREE.BufferGeometry: .removeAttribute() has been renamed to .deleteAttribute().' );
-
-			return this.deleteAttribute( name );
-
-		},
-		applyMatrix: function ( matrix ) {
-
-			console.warn( 'THREE.BufferGeometry: .applyMatrix() has been renamed to .applyMatrix4().' );
-			return this.applyMatrix4( matrix );
 
 		}
 
@@ -49902,59 +48229,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 			}
 		}
 
-	} );
-
-	Object.defineProperties( Raycaster.prototype, {
-
-		linePrecision: {
-			get: function () {
-
-				console.warn( 'THREE.Raycaster: .linePrecision has been deprecated. Use .params.Line.threshold instead.' );
-				return this.params.Line.threshold;
-
-			},
-			set: function ( value ) {
-
-				console.warn( 'THREE.Raycaster: .linePrecision has been deprecated. Use .params.Line.threshold instead.' );
-				this.params.Line.threshold = value;
-
-			}
-		}
-
-	} );
-
-	Object.defineProperties( InterleavedBuffer.prototype, {
-
-		dynamic: {
-			get: function () {
-
-				console.warn( 'THREE.InterleavedBuffer: .length has been deprecated. Use .usage instead.' );
-				return this.usage === DynamicDrawUsage;
-
-			},
-			set: function ( value ) {
-
-				console.warn( 'THREE.InterleavedBuffer: .length has been deprecated. Use .usage instead.' );
-				this.setUsage( value );
-
-			}
-		}
-
-	} );
-
-	Object.assign( InterleavedBuffer.prototype, {
-		setDynamic: function ( value ) {
-
-			console.warn( 'THREE.InterleavedBuffer: .setDynamic() has been deprecated. Use .setUsage() instead.' );
-			this.setUsage( value === true ? DynamicDrawUsage : StaticDrawUsage );
-			return this;
-
-		},
-		setArray: function ( /* array */ ) {
-
-			console.error( 'THREE.InterleavedBuffer: .setArray has been removed. Use BufferGeometry .setAttribute to replace/resize attribute buffers' );
-
-		}
 	} );
 
 	//
@@ -50052,21 +48326,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 				console.warn( 'THREE.' + this.type + ': .shading has been removed. Use the boolean .flatShading instead.' );
 				this.flatShading = ( value === FlatShading );
-
-			}
-		},
-
-		stencilMask: {
-			get: function () {
-
-				console.warn( 'THREE.' + this.type + ': .stencilMask has been removed. Use .stencilFuncMask instead.' );
-				return this.stencilFuncMask;
-
-			},
-			set: function ( value ) {
-
-				console.warn( 'THREE.' + this.type + ': .stencilMask has been removed. Use .stencilFuncMask instead.' );
-				this.stencilFuncMask = value;
 
 			}
 		}
@@ -50307,41 +48566,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 				return this.getContext();
 
 			}
-		},
-		vr: {
-			get: function () {
-
-				console.warn( 'THREE.WebGLRenderer: .vr has been renamed to .xr' );
-				return this.xr;
-
-			}
-		},
-		gammaInput: {
-			get: function () {
-
-				console.warn( 'THREE.WebGLRenderer: .gammaInput has been removed. Set the encoding for textures via Texture.encoding instead.' );
-				return false;
-
-			},
-			set: function () {
-
-				console.warn( 'THREE.WebGLRenderer: .gammaInput has been removed. Set the encoding for textures via Texture.encoding instead.' );
-
-			}
-		},
-		gammaOutput: {
-			get: function () {
-
-				console.warn( 'THREE.WebGLRenderer: .gammaOutput has been removed. Set WebGLRenderer.outputEncoding instead.' );
-				return false;
-
-			},
-			set: function ( value ) {
-
-				console.warn( 'THREE.WebGLRenderer: .gammaOutput has been removed. Set WebGLRenderer.outputEncoding instead.' );
-				this.outputEncoding = ( value === true ) ? sRGBEncoding : LinearEncoding;
-
-			}
 		}
 
 	} );
@@ -50390,12 +48614,26 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 	} );
 
-	function WebGLRenderTargetCube( width, height, options ) {
+	//
 
-		console.warn( 'THREE.WebGLRenderTargetCube( width, height, options ) is now WebGLCubeRenderTarget( size, options ).' );
-		return new WebGLCubeRenderTarget( width, options );
+	Object.defineProperties( WebGLRenderTargetCube.prototype, {
 
-	}
+		activeCubeFace: {
+			set: function ( /* value */ ) {
+
+				console.warn( 'THREE.WebGLRenderTargetCube: .activeCubeFace has been removed. It is now the second parameter of WebGLRenderer.setRenderTarget().' );
+
+			}
+		},
+		activeMipMapLevel: {
+			set: function ( /* value */ ) {
+
+				console.warn( 'THREE.WebGLRenderTargetCube: .activeMipMapLevel has been removed. It is now the third parameter of WebGLRenderer.setRenderTarget().' );
+
+			}
+		}
+
+	} );
 
 	//
 
@@ -50546,32 +48784,40 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 	//
 
-	Object.defineProperties( Audio.prototype, {
+	Object.defineProperties( WebVRManager.prototype, {
 
-		load: {
-			value: function ( file ) {
+		standing: {
+			set: function ( /* value */ ) {
 
-				console.warn( 'THREE.Audio: .load has been deprecated. Use THREE.AudioLoader instead.' );
-				var scope = this;
-				var audioLoader = new AudioLoader();
-				audioLoader.load( file, function ( buffer ) {
-
-					scope.setBuffer( buffer );
-
-				} );
-				return this;
+				console.warn( 'THREE.WebVRManager: .standing has been removed.' );
 
 			}
 		},
-		startTime: {
-			set: function () {
+		userHeight: {
+			set: function ( /* value */ ) {
 
-				console.warn( 'THREE.Audio: .startTime is now .play( delay ).' );
+				console.warn( 'THREE.WebVRManager: .userHeight has been removed.' );
 
 			}
 		}
 
 	} );
+
+	//
+
+	Audio.prototype.load = function ( file ) {
+
+		console.warn( 'THREE.Audio: .load has been deprecated. Use THREE.AudioLoader instead.' );
+		var scope = this;
+		var audioLoader = new AudioLoader();
+		audioLoader.load( file, function ( buffer ) {
+
+			scope.setBuffer( buffer );
+
+		} );
+		return this;
+
+	};
 
 	AudioAnalyser.prototype.getData = function () {
 
@@ -50686,19 +48932,19 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 		createMultiMaterialObject: function ( /* geometry, materials */ ) {
 
-			console.error( 'THREE.SceneUtils has been moved to /examples/jsm/utils/SceneUtils.js' );
+			console.error( 'THREE.SceneUtils has been moved to /examples/js/utils/SceneUtils.js' );
 
 		},
 
 		detach: function ( /* child, parent, scene */ ) {
 
-			console.error( 'THREE.SceneUtils has been moved to /examples/jsm/utils/SceneUtils.js' );
+			console.error( 'THREE.SceneUtils has been moved to /examples/js/utils/SceneUtils.js' );
 
 		},
 
 		attach: function ( /* child, scene, parent */ ) {
 
-			console.error( 'THREE.SceneUtils has been moved to /examples/jsm/utils/SceneUtils.js' );
+			console.error( 'THREE.SceneUtils has been moved to /examples/js/utils/SceneUtils.js' );
 
 		}
 
@@ -50708,17 +48954,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 	function LensFlare() {
 
-		console.error( 'THREE.LensFlare has been moved to /examples/jsm/objects/Lensflare.js' );
-
-	}
-
-	if ( typeof __THREE_DEVTOOLS__ !== 'undefined' ) {
-
-		/* eslint-disable no-undef */
-		__THREE_DEVTOOLS__.dispatchEvent( new CustomEvent( 'register', { detail: {
-			revision: REVISION,
-		} } ) );
-		/* eslint-enable no-undef */
+		console.error( 'THREE.LensFlare has been moved to /examples/js/objects/Lensflare.js' );
 
 	}
 
@@ -50726,7 +48962,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 		ACESFilmicToneMapping: ACESFilmicToneMapping,
 		AddEquation: AddEquation,
 		AddOperation: AddOperation,
-		AdditiveAnimationBlendMode: AdditiveAnimationBlendMode,
 		AdditiveBlending: AdditiveBlending,
 		AlphaFormat: AlphaFormat,
 		AlwaysDepth: AlwaysDepth,
@@ -50824,9 +49059,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 		DstAlphaFactor: DstAlphaFactor,
 		DstColorFactor: DstColorFactor,
 		DynamicBufferAttribute: DynamicBufferAttribute,
-		DynamicCopyUsage: DynamicCopyUsage,
-		DynamicDrawUsage: DynamicDrawUsage,
-		DynamicReadUsage: DynamicReadUsage,
 		EdgesGeometry: EdgesGeometry,
 		EdgesHelper: EdgesHelper,
 		EllipseCurve: EllipseCurve,
@@ -50841,6 +49073,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 		Face3: Face3,
 		Face4: Face4,
 		FaceColors: FaceColors,
+		FaceNormalsHelper: FaceNormalsHelper,
 		FileLoader: FileLoader,
 		FlatShading: FlatShading,
 		Float32Attribute: Float32Attribute,
@@ -50880,7 +49113,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 		InstancedBufferAttribute: InstancedBufferAttribute,
 		InstancedBufferGeometry: InstancedBufferGeometry,
 		InstancedInterleavedBuffer: InstancedInterleavedBuffer,
-		InstancedMesh: InstancedMesh,
 		Int16Attribute: Int16Attribute,
 		Int16BufferAttribute: Int16BufferAttribute,
 		Int32Attribute: Int32Attribute,
@@ -50909,6 +49141,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 		LessStencilFunc: LessStencilFunc,
 		Light: Light,
 		LightProbe: LightProbe,
+		LightProbeHelper: LightProbeHelper,
 		LightShadow: LightShadow,
 		Line: Line,
 		Line3: Line3,
@@ -50940,8 +49173,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 		MOUSE: MOUSE,
 		Material: Material,
 		MaterialLoader: MaterialLoader,
-		Math: MathUtils,
-		MathUtils: MathUtils,
+		Math: _Math,
 		Matrix3: Matrix3,
 		Matrix4: Matrix4,
 		MaxEquation: MaxEquation,
@@ -50973,7 +49205,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 		NoBlending: NoBlending,
 		NoColors: NoColors,
 		NoToneMapping: NoToneMapping,
-		NormalAnimationBlendMode: NormalAnimationBlendMode,
 		NormalBlending: NormalBlending,
 		NotEqualDepth: NotEqualDepth,
 		NotEqualStencilFunc: NotEqualStencilFunc,
@@ -50991,7 +49222,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 		OrthographicCamera: OrthographicCamera,
 		PCFShadowMap: PCFShadowMap,
 		PCFSoftShadowMap: PCFSoftShadowMap,
-		PMREMGenerator: PMREMGenerator,
 		ParametricBufferGeometry: ParametricBufferGeometry,
 		ParametricGeometry: ParametricGeometry,
 		Particle: Particle,
@@ -51014,6 +49244,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 		PolyhedronBufferGeometry: PolyhedronBufferGeometry,
 		PolyhedronGeometry: PolyhedronGeometry,
 		PositionalAudio: PositionalAudio,
+		PositionalAudioHelper: PositionalAudioHelper,
 		PropertyBinding: PropertyBinding,
 		PropertyMixer: PropertyMixer,
 		QuadraticBezierCurve: QuadraticBezierCurve,
@@ -51024,7 +49255,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 		REVISION: REVISION,
 		RGBADepthPacking: RGBADepthPacking,
 		RGBAFormat: RGBAFormat,
-		RGBAIntegerFormat: RGBAIntegerFormat,
 		RGBA_ASTC_10x10_Format: RGBA_ASTC_10x10_Format,
 		RGBA_ASTC_10x5_Format: RGBA_ASTC_10x5_Format,
 		RGBA_ASTC_10x6_Format: RGBA_ASTC_10x6_Format,
@@ -51039,8 +49269,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 		RGBA_ASTC_8x5_Format: RGBA_ASTC_8x5_Format,
 		RGBA_ASTC_8x6_Format: RGBA_ASTC_8x6_Format,
 		RGBA_ASTC_8x8_Format: RGBA_ASTC_8x8_Format,
-		RGBA_BPTC_Format: RGBA_BPTC_Format,
-		RGBA_ETC2_EAC_Format: RGBA_ETC2_EAC_Format,
 		RGBA_PVRTC_2BPPV1_Format: RGBA_PVRTC_2BPPV1_Format,
 		RGBA_PVRTC_4BPPV1_Format: RGBA_PVRTC_4BPPV1_Format,
 		RGBA_S3TC_DXT1_Format: RGBA_S3TC_DXT1_Format,
@@ -51050,42 +49278,24 @@ vec4 envMapTexelToLinear(vec4 color) {
 		RGBEEncoding: RGBEEncoding,
 		RGBEFormat: RGBEFormat,
 		RGBFormat: RGBFormat,
-		RGBIntegerFormat: RGBIntegerFormat,
 		RGBM16Encoding: RGBM16Encoding,
 		RGBM7Encoding: RGBM7Encoding,
 		RGB_ETC1_Format: RGB_ETC1_Format,
-		RGB_ETC2_Format: RGB_ETC2_Format,
 		RGB_PVRTC_2BPPV1_Format: RGB_PVRTC_2BPPV1_Format,
 		RGB_PVRTC_4BPPV1_Format: RGB_PVRTC_4BPPV1_Format,
 		RGB_S3TC_DXT1_Format: RGB_S3TC_DXT1_Format,
-		RGFormat: RGFormat,
-		RGIntegerFormat: RGIntegerFormat,
 		RawShaderMaterial: RawShaderMaterial,
 		Ray: Ray,
 		Raycaster: Raycaster,
 		RectAreaLight: RectAreaLight,
+		RectAreaLightHelper: RectAreaLightHelper,
 		RedFormat: RedFormat,
-		RedIntegerFormat: RedIntegerFormat,
 		ReinhardToneMapping: ReinhardToneMapping,
 		RepeatWrapping: RepeatWrapping,
 		ReplaceStencilOp: ReplaceStencilOp,
 		ReverseSubtractEquation: ReverseSubtractEquation,
 		RingBufferGeometry: RingBufferGeometry,
 		RingGeometry: RingGeometry,
-		SRGB8_ALPHA8_ASTC_10x10_Format: SRGB8_ALPHA8_ASTC_10x10_Format,
-		SRGB8_ALPHA8_ASTC_10x5_Format: SRGB8_ALPHA8_ASTC_10x5_Format,
-		SRGB8_ALPHA8_ASTC_10x6_Format: SRGB8_ALPHA8_ASTC_10x6_Format,
-		SRGB8_ALPHA8_ASTC_10x8_Format: SRGB8_ALPHA8_ASTC_10x8_Format,
-		SRGB8_ALPHA8_ASTC_12x10_Format: SRGB8_ALPHA8_ASTC_12x10_Format,
-		SRGB8_ALPHA8_ASTC_12x12_Format: SRGB8_ALPHA8_ASTC_12x12_Format,
-		SRGB8_ALPHA8_ASTC_4x4_Format: SRGB8_ALPHA8_ASTC_4x4_Format,
-		SRGB8_ALPHA8_ASTC_5x4_Format: SRGB8_ALPHA8_ASTC_5x4_Format,
-		SRGB8_ALPHA8_ASTC_5x5_Format: SRGB8_ALPHA8_ASTC_5x5_Format,
-		SRGB8_ALPHA8_ASTC_6x5_Format: SRGB8_ALPHA8_ASTC_6x5_Format,
-		SRGB8_ALPHA8_ASTC_6x6_Format: SRGB8_ALPHA8_ASTC_6x6_Format,
-		SRGB8_ALPHA8_ASTC_8x5_Format: SRGB8_ALPHA8_ASTC_8x5_Format,
-		SRGB8_ALPHA8_ASTC_8x6_Format: SRGB8_ALPHA8_ASTC_8x6_Format,
-		SRGB8_ALPHA8_ASTC_8x8_Format: SRGB8_ALPHA8_ASTC_8x8_Format,
 		Scene: Scene,
 		SceneUtils: SceneUtils,
 		ShaderChunk: ShaderChunk,
@@ -51119,13 +49329,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 		SrcAlphaFactor: SrcAlphaFactor,
 		SrcAlphaSaturateFactor: SrcAlphaSaturateFactor,
 		SrcColorFactor: SrcColorFactor,
-		StaticCopyUsage: StaticCopyUsage,
-		StaticDrawUsage: StaticDrawUsage,
-		StaticReadUsage: StaticReadUsage,
 		StereoCamera: StereoCamera,
-		StreamCopyUsage: StreamCopyUsage,
-		StreamDrawUsage: StreamDrawUsage,
-		StreamReadUsage: StreamReadUsage,
 		StringKeyframeTrack: StringKeyframeTrack,
 		SubtractEquation: SubtractEquation,
 		SubtractiveBlending: SubtractiveBlending,
@@ -51167,15 +49371,14 @@ vec4 envMapTexelToLinear(vec4 color) {
 		UnsignedShort5551Type: UnsignedShort5551Type,
 		UnsignedShort565Type: UnsignedShort565Type,
 		UnsignedShortType: UnsignedShortType,
-		VSMShadowMap: VSMShadowMap,
 		Vector2: Vector2,
 		Vector3: Vector3,
 		Vector4: Vector4,
 		VectorKeyframeTrack: VectorKeyframeTrack,
 		Vertex: Vertex,
 		VertexColors: VertexColors,
+		VertexNormalsHelper: VertexNormalsHelper,
 		VideoTexture: VideoTexture,
-		WebGLCubeRenderTarget: WebGLCubeRenderTarget,
 		WebGLMultisampleRenderTarget: WebGLMultisampleRenderTarget,
 		WebGLRenderTarget: WebGLRenderTarget,
 		WebGLRenderTargetCube: WebGLRenderTargetCube,
@@ -51210,11 +49413,9 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 	var OrbitControls = function ( object, domElement ) {
 
-		if ( domElement === undefined ) console.warn( 'THREE.OrbitControls: The second parameter "domElement" is now mandatory.' );
-		if ( domElement === document ) console.error( 'THREE.OrbitControls: "document" should not be used as the target "domElement". Please use "renderer.domElement" instead.' );
-
 		this.object = object;
-		this.domElement = domElement;
+
+		this.domElement = ( domElement !== undefined ) ? domElement : document;
 
 		// Set to false to disable this control
 		this.enabled = true;
@@ -51452,7 +49653,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 			document.removeEventListener( 'mousemove', onMouseMove, false );
 			document.removeEventListener( 'mouseup', onMouseUp, false );
 
-			scope.domElement.removeEventListener( 'keydown', onKeyDown, false );
+			window.removeEventListener( 'keydown', onKeyDown, false );
 
 			//scope.dispatchEvent( { type: 'dispose' } ); // should this be added here?
 
@@ -51574,7 +49775,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 			return function pan( deltaX, deltaY ) {
 
-				var element = scope.domElement;
+				var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
 
 				if ( scope.object.isPerspectiveCamera ) {
 
@@ -51608,7 +49809,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 		}();
 
-		function dollyOut( dollyScale ) {
+		function dollyIn( dollyScale ) {
 
 			if ( scope.object.isPerspectiveCamera ) {
 
@@ -51629,7 +49830,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 		}
 
-		function dollyIn( dollyScale ) {
+		function dollyOut( dollyScale ) {
 
 			if ( scope.object.isPerspectiveCamera ) {
 
@@ -51656,11 +49857,15 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 		function handleMouseDownRotate( event ) {
 
+			//console.log( 'handleMouseDownRotate' );
+
 			rotateStart.set( event.clientX, event.clientY );
 
 		}
 
 		function handleMouseDownDolly( event ) {
+
+			//console.log( 'handleMouseDownDolly' );
 
 			dollyStart.set( event.clientX, event.clientY );
 
@@ -51668,17 +49873,21 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 		function handleMouseDownPan( event ) {
 
+			//console.log( 'handleMouseDownPan' );
+
 			panStart.set( event.clientX, event.clientY );
 
 		}
 
 		function handleMouseMoveRotate( event ) {
 
+			//console.log( 'handleMouseMoveRotate' );
+
 			rotateEnd.set( event.clientX, event.clientY );
 
 			rotateDelta.subVectors( rotateEnd, rotateStart ).multiplyScalar( scope.rotateSpeed );
 
-			var element = scope.domElement;
+			var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
 
 			rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientHeight ); // yes, height
 
@@ -51692,17 +49901,19 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 		function handleMouseMoveDolly( event ) {
 
+			//console.log( 'handleMouseMoveDolly' );
+
 			dollyEnd.set( event.clientX, event.clientY );
 
 			dollyDelta.subVectors( dollyEnd, dollyStart );
 
 			if ( dollyDelta.y > 0 ) {
 
-				dollyOut( getZoomScale() );
+				dollyIn( getZoomScale() );
 
 			} else if ( dollyDelta.y < 0 ) {
 
-				dollyIn( getZoomScale() );
+				dollyOut( getZoomScale() );
 
 			}
 
@@ -51713,6 +49924,8 @@ vec4 envMapTexelToLinear(vec4 color) {
 		}
 
 		function handleMouseMovePan( event ) {
+
+			//console.log( 'handleMouseMovePan' );
 
 			panEnd.set( event.clientX, event.clientY );
 
@@ -51728,13 +49941,15 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 		function handleMouseWheel( event ) {
 
+			// console.log( 'handleMouseWheel' );
+
 			if ( event.deltaY < 0 ) {
 
-				dollyIn( getZoomScale() );
+				dollyOut( getZoomScale() );
 
 			} else if ( event.deltaY > 0 ) {
 
-				dollyOut( getZoomScale() );
+				dollyIn( getZoomScale() );
 
 			}
 
@@ -51743,6 +49958,8 @@ vec4 envMapTexelToLinear(vec4 color) {
 		}
 
 		function handleKeyDown( event ) {
+
+			// console.log( 'handleKeyDown' );
 
 			var needsUpdate = false;
 
@@ -51784,6 +50001,8 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 		function handleTouchStartRotate( event ) {
 
+			//console.log( 'handleTouchStartRotate' );
+
 			if ( event.touches.length == 1 ) {
 
 				rotateStart.set( event.touches[ 0 ].pageX, event.touches[ 0 ].pageY );
@@ -51800,6 +50019,8 @@ vec4 envMapTexelToLinear(vec4 color) {
 		}
 
 		function handleTouchStartPan( event ) {
+
+			//console.log( 'handleTouchStartPan' );
 
 			if ( event.touches.length == 1 ) {
 
@@ -51818,6 +50039,8 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 		function handleTouchStartDolly( event ) {
 
+			//console.log( 'handleTouchStartDolly' );
+
 			var dx = event.touches[ 0 ].pageX - event.touches[ 1 ].pageX;
 			var dy = event.touches[ 0 ].pageY - event.touches[ 1 ].pageY;
 
@@ -51829,6 +50052,8 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 		function handleTouchStartDollyPan( event ) {
 
+			//console.log( 'handleTouchStartDollyPan' );
+
 			if ( scope.enableZoom ) handleTouchStartDolly( event );
 
 			if ( scope.enablePan ) handleTouchStartPan( event );
@@ -51837,6 +50062,8 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 		function handleTouchStartDollyRotate( event ) {
 
+			//console.log( 'handleTouchStartDollyRotate' );
+
 			if ( scope.enableZoom ) handleTouchStartDolly( event );
 
 			if ( scope.enableRotate ) handleTouchStartRotate( event );
@@ -51844,6 +50071,8 @@ vec4 envMapTexelToLinear(vec4 color) {
 		}
 
 		function handleTouchMoveRotate( event ) {
+
+			//console.log( 'handleTouchMoveRotate' );
 
 			if ( event.touches.length == 1 ) {
 
@@ -51860,7 +50089,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 			rotateDelta.subVectors( rotateEnd, rotateStart ).multiplyScalar( scope.rotateSpeed );
 
-			var element = scope.domElement;
+			var element = scope.domElement === document ? scope.domElement.body : scope.domElement;
 
 			rotateLeft( 2 * Math.PI * rotateDelta.x / element.clientHeight ); // yes, height
 
@@ -51871,6 +50100,8 @@ vec4 envMapTexelToLinear(vec4 color) {
 		}
 
 		function handleTouchMovePan( event ) {
+
+			//console.log( 'handleTouchMoveRotate' );
 
 			if ( event.touches.length == 1 ) {
 
@@ -51895,6 +50126,8 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 		function handleTouchMoveDolly( event ) {
 
+			//console.log( 'handleTouchMoveRotate' );
+
 			var dx = event.touches[ 0 ].pageX - event.touches[ 1 ].pageX;
 			var dy = event.touches[ 0 ].pageY - event.touches[ 1 ].pageY;
 
@@ -51904,13 +50137,15 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 			dollyDelta.set( 0, Math.pow( dollyEnd.y / dollyStart.y, scope.zoomSpeed ) );
 
-			dollyOut( dollyDelta.y );
+			dollyIn( dollyDelta.y );
 
 			dollyStart.copy( dollyEnd );
 
 		}
 
 		function handleTouchMoveDollyPan( event ) {
+
+			//console.log( 'handleTouchMoveDollyPan' );
 
 			if ( scope.enableZoom ) handleTouchMoveDolly( event );
 
@@ -51919,6 +50154,8 @@ vec4 envMapTexelToLinear(vec4 color) {
 		}
 
 		function handleTouchMoveDollyRotate( event ) {
+
+			//console.log( 'handleTouchMoveDollyPan' );
 
 			if ( scope.enableZoom ) handleTouchMoveDolly( event );
 
@@ -51935,6 +50172,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 			if ( scope.enabled === false ) return;
 
 			// Prevent the browser from scrolling.
+
 			event.preventDefault();
 
 			// Manually set the focus since calling preventDefault above
@@ -51942,90 +50180,119 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 			scope.domElement.focus ? scope.domElement.focus() : window.focus();
 
-			var mouseAction;
-
 			switch ( event.button ) {
 
 				case 0:
 
-					mouseAction = scope.mouseButtons.LEFT;
+					switch ( scope.mouseButtons.LEFT ) {
+
+						case MOUSE.ROTATE:
+
+							if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+
+								if ( scope.enablePan === false ) return;
+
+								handleMouseDownPan( event );
+
+								state = STATE.PAN;
+
+							} else {
+
+								if ( scope.enableRotate === false ) return;
+
+								handleMouseDownRotate( event );
+
+								state = STATE.ROTATE;
+
+							}
+
+							break;
+
+						case MOUSE.PAN:
+
+							if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+
+								if ( scope.enableRotate === false ) return;
+
+								handleMouseDownRotate( event );
+
+								state = STATE.ROTATE;
+
+							} else {
+
+								if ( scope.enablePan === false ) return;
+
+								handleMouseDownPan( event );
+
+								state = STATE.PAN;
+
+							}
+
+							break;
+
+						default:
+
+							state = STATE.NONE;
+
+					}
+
 					break;
+
 
 				case 1:
 
-					mouseAction = scope.mouseButtons.MIDDLE;
+					switch ( scope.mouseButtons.MIDDLE ) {
+
+						case MOUSE.DOLLY:
+
+							if ( scope.enableZoom === false ) return;
+
+							handleMouseDownDolly( event );
+
+							state = STATE.DOLLY;
+
+							break;
+
+
+						default:
+
+							state = STATE.NONE;
+
+					}
+
 					break;
 
 				case 2:
 
-					mouseAction = scope.mouseButtons.RIGHT;
-					break;
+					switch ( scope.mouseButtons.RIGHT ) {
 
-				default:
+						case MOUSE.ROTATE:
 
-					mouseAction = - 1;
+							if ( scope.enableRotate === false ) return;
 
-			}
+							handleMouseDownRotate( event );
 
-			switch ( mouseAction ) {
+							state = STATE.ROTATE;
 
-				case MOUSE.DOLLY:
+							break;
 
-					if ( scope.enableZoom === false ) return;
+						case MOUSE.PAN:
 
-					handleMouseDownDolly( event );
+							if ( scope.enablePan === false ) return;
 
-					state = STATE.DOLLY;
+							handleMouseDownPan( event );
 
-					break;
+							state = STATE.PAN;
 
-				case MOUSE.ROTATE:
+							break;
 
-					if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
+						default:
 
-						if ( scope.enablePan === false ) return;
-
-						handleMouseDownPan( event );
-
-						state = STATE.PAN;
-
-					} else {
-
-						if ( scope.enableRotate === false ) return;
-
-						handleMouseDownRotate( event );
-
-						state = STATE.ROTATE;
+							state = STATE.NONE;
 
 					}
 
 					break;
-
-				case MOUSE.PAN:
-
-					if ( event.ctrlKey || event.metaKey || event.shiftKey ) {
-
-						if ( scope.enableRotate === false ) return;
-
-						handleMouseDownRotate( event );
-
-						state = STATE.ROTATE;
-
-					} else {
-
-						if ( scope.enablePan === false ) return;
-
-						handleMouseDownPan( event );
-
-						state = STATE.PAN;
-
-					}
-
-					break;
-
-				default:
-
-					state = STATE.NONE;
 
 			}
 
@@ -52116,7 +50383,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 			if ( scope.enabled === false ) return;
 
-			event.preventDefault(); // prevent scrolling
+			event.preventDefault();
 
 			switch ( event.touches.length ) {
 
@@ -52202,7 +50469,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 			if ( scope.enabled === false ) return;
 
-			event.preventDefault(); // prevent scrolling
+			event.preventDefault();
 			event.stopPropagation();
 
 			switch ( state ) {
@@ -52284,15 +50551,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 		scope.domElement.addEventListener( 'touchend', onTouchEnd, false );
 		scope.domElement.addEventListener( 'touchmove', onTouchMove, false );
 
-		scope.domElement.addEventListener( 'keydown', onKeyDown, false );
-
-		// make sure element can receive keys.
-
-		if ( scope.domElement.tabIndex === - 1 ) {
-
-			scope.domElement.tabIndex = 0;
-
-		}
+		window.addEventListener( 'keydown', onKeyDown, false );
 
 		// force an update at start
 
@@ -52303,6 +50562,130 @@ vec4 envMapTexelToLinear(vec4 color) {
 	OrbitControls.prototype = Object.create( EventDispatcher.prototype );
 	OrbitControls.prototype.constructor = OrbitControls;
 
+	Object.defineProperties( OrbitControls.prototype, {
+
+		center: {
+
+			get: function () {
+
+				console.warn( 'THREE.OrbitControls: .center has been renamed to .target' );
+				return this.target;
+
+			}
+
+		},
+
+		// backward compatibility
+
+		noZoom: {
+
+			get: function () {
+
+				console.warn( 'THREE.OrbitControls: .noZoom has been deprecated. Use .enableZoom instead.' );
+				return ! this.enableZoom;
+
+			},
+
+			set: function ( value ) {
+
+				console.warn( 'THREE.OrbitControls: .noZoom has been deprecated. Use .enableZoom instead.' );
+				this.enableZoom = ! value;
+
+			}
+
+		},
+
+		noRotate: {
+
+			get: function () {
+
+				console.warn( 'THREE.OrbitControls: .noRotate has been deprecated. Use .enableRotate instead.' );
+				return ! this.enableRotate;
+
+			},
+
+			set: function ( value ) {
+
+				console.warn( 'THREE.OrbitControls: .noRotate has been deprecated. Use .enableRotate instead.' );
+				this.enableRotate = ! value;
+
+			}
+
+		},
+
+		noPan: {
+
+			get: function () {
+
+				console.warn( 'THREE.OrbitControls: .noPan has been deprecated. Use .enablePan instead.' );
+				return ! this.enablePan;
+
+			},
+
+			set: function ( value ) {
+
+				console.warn( 'THREE.OrbitControls: .noPan has been deprecated. Use .enablePan instead.' );
+				this.enablePan = ! value;
+
+			}
+
+		},
+
+		noKeys: {
+
+			get: function () {
+
+				console.warn( 'THREE.OrbitControls: .noKeys has been deprecated. Use .enableKeys instead.' );
+				return ! this.enableKeys;
+
+			},
+
+			set: function ( value ) {
+
+				console.warn( 'THREE.OrbitControls: .noKeys has been deprecated. Use .enableKeys instead.' );
+				this.enableKeys = ! value;
+
+			}
+
+		},
+
+		staticMoving: {
+
+			get: function () {
+
+				console.warn( 'THREE.OrbitControls: .staticMoving has been deprecated. Use .enableDamping instead.' );
+				return ! this.enableDamping;
+
+			},
+
+			set: function ( value ) {
+
+				console.warn( 'THREE.OrbitControls: .staticMoving has been deprecated. Use .enableDamping instead.' );
+				this.enableDamping = ! value;
+
+			}
+
+		},
+
+		dynamicDampingFactor: {
+
+			get: function () {
+
+				console.warn( 'THREE.OrbitControls: .dynamicDampingFactor has been renamed. Use .dampingFactor instead.' );
+				return this.dampingFactor;
+
+			},
+
+			set: function ( value ) {
+
+				console.warn( 'THREE.OrbitControls: .dynamicDampingFactor has been renamed. Use .dampingFactor instead.' );
+				this.dampingFactor = value;
+
+			}
+
+		}
+
+	} );
 
 	// This set of controls performs orbiting, dollying (zooming), and panning.
 	// Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).
@@ -53902,7 +52285,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 	};
 
 	/**
-	 * postprocessing v6.13.5 build Wed May 06 2020
+	 * postprocessing v6.13.3 build Fri Apr 10 2020
 	 * https://github.com/vanruesc/postprocessing
 	 * Copyright 2020 Raoul van Rüschen
 	 * @license Zlib
@@ -53955,13 +52338,11 @@ vec4 envMapTexelToLinear(vec4 color) {
 				fragmentShader: fragmentShader$3,
 				vertexShader: vertexShader$2,
 
+				toneMapped: false,
 				depthWrite: false,
 				depthTest: false
 
 			});
-
-			/** @ignore */
-			this.toneMapped = false;
 
 			this.setTexelSize(texelSize.x, texelSize.y);
 
@@ -54068,19 +52449,17 @@ vec4 envMapTexelToLinear(vec4 color) {
 				fragmentShader: fragmentShader$4,
 				vertexShader,
 
+				toneMapped: false,
 				depthWrite: false,
 				depthTest: false
 
 			});
 
-			/** @ignore */
-			this.toneMapped = false;
-
 		}
 
 	}
 
-	var fragmentTemplate = "#include <common>\n#include <packing>\n#include <dithering_pars_fragment>\nuniform sampler2D inputBuffer;\n#ifdef GL_FRAGMENT_PRECISION_HIGH\nuniform highp sampler2D depthBuffer;\n#else\nuniform mediump sampler2D depthBuffer;\n#endif\nuniform vec2 resolution;uniform vec2 texelSize;uniform float cameraNear;uniform float cameraFar;uniform float aspect;uniform float time;varying vec2 vUv;float readDepth(const in vec2 uv){\n#if DEPTH_PACKING == 3201\nreturn unpackRGBAToDepth(texture2D(depthBuffer,uv));\n#else\nreturn texture2D(depthBuffer,uv).r;\n#endif\n}float getViewZ(const in float depth){\n#ifdef PERSPECTIVE_CAMERA\nreturn perspectiveDepthToViewZ(depth,cameraNear,cameraFar);\n#else\nreturn orthographicDepthToViewZ(depth,cameraNear,cameraFar);\n#endif\n}FRAGMENT_HEADvoid main(){FRAGMENT_MAIN_UVvec4 color0=texture2D(inputBuffer,UV);vec4 color1=vec4(0.0);FRAGMENT_MAIN_IMAGEgl_FragColor=color0;\n#ifdef ENCODE_OUTPUT\n#include <encodings_fragment>\n#endif\n#include <dithering_fragment>\n}";
+	var fragmentTemplate = "#include <common>\n#include <packing>\n#include <dithering_pars_fragment>\nuniform sampler2D inputBuffer;uniform sampler2D depthBuffer;uniform vec2 resolution;uniform vec2 texelSize;uniform float cameraNear;uniform float cameraFar;uniform float aspect;uniform float time;varying vec2 vUv;float readDepth(const in vec2 uv){\n#if DEPTH_PACKING == 3201\nreturn unpackRGBAToDepth(texture2D(depthBuffer,uv));\n#else\nreturn texture2D(depthBuffer,uv).r;\n#endif\n}float getViewZ(const in float depth){\n#ifdef PERSPECTIVE_CAMERA\nreturn perspectiveDepthToViewZ(depth,cameraNear,cameraFar);\n#else\nreturn orthographicDepthToViewZ(depth,cameraNear,cameraFar);\n#endif\n}FRAGMENT_HEADvoid main(){FRAGMENT_MAIN_UVvec4 color0=texture2D(inputBuffer,UV);vec4 color1=vec4(0.0);FRAGMENT_MAIN_IMAGEgl_FragColor=color0;\n#ifdef ENCODE_OUTPUT\n#include <encodings_fragment>\n#endif\n#include <dithering_fragment>\n}";
 
 	var vertexTemplate = "uniform vec2 resolution;uniform vec2 texelSize;uniform float cameraNear;uniform float cameraFar;uniform float aspect;uniform float time;varying vec2 vUv;VERTEX_HEADvoid main(){vUv=position.xy*0.5+0.5;VERTEX_MAIN_SUPPORTgl_Position=vec4(position.xy,1.0,1.0);}";
 
@@ -54126,14 +52505,12 @@ vec4 envMapTexelToLinear(vec4 color) {
 					time: new Uniform(0.0)
 				},
 
+				toneMapped: false,
 				depthWrite: false,
 				depthTest: false,
 				dithering
 
 			});
-
-			/** @ignore */
-			this.toneMapped = false;
 
 			if(shaderParts !== null) {
 
@@ -54174,6 +52551,8 @@ vec4 envMapTexelToLinear(vec4 color) {
 		 *
 		 * Use `BasicDepthPacking` or `RGBADepthPacking` if your depth texture
 		 * contains packed depth.
+		 *
+		 * You'll need to call {@link EffectPass#recompile} after changing this value.
 		 *
 		 * @type {Number}
 		 */
@@ -54368,13 +52747,11 @@ vec4 envMapTexelToLinear(vec4 color) {
 				fragmentShader: fragmentShader$8,
 				vertexShader,
 
+				toneMapped: false,
 				depthWrite: false,
 				depthTest: false
 
 			});
-
-			/** @ignore */
-			this.toneMapped = false;
 
 			this.colorOutput = colorOutput;
 			this.useThreshold = true;
@@ -54770,7 +53147,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 	 * @private
 	 */
 
-	let geometry = null;
+	let geometry$1 = null;
 
 	/**
 	 * Returns a shared fullscreen triangle.
@@ -54784,28 +53161,28 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 	function getFullscreenTriangle() {
 
-		if(geometry === null) {
+		if(geometry$1 === null) {
 
 			const vertices = new Float32Array([-1, -1, 0, 3, -1, 0, -1, 3, 0]);
 			const uvs = new Float32Array([0, 0, 2, 0, 0, 2]);
-			geometry = new BufferGeometry();
+			geometry$1 = new BufferGeometry();
 
 			// Added for backward compatibility (setAttribute was added in three r110).
-			if(geometry.setAttribute !== undefined) {
+			if(geometry$1.setAttribute !== undefined) {
 
-				geometry.setAttribute("position", new BufferAttribute(vertices, 3));
-				geometry.setAttribute("uv", new BufferAttribute(uvs, 2));
+				geometry$1.setAttribute("position", new BufferAttribute(vertices, 3));
+				geometry$1.setAttribute("uv", new BufferAttribute(uvs, 2));
 
 			} else {
 
-				geometry.addAttribute("position", new BufferAttribute(vertices, 3));
-				geometry.addAttribute("uv", new BufferAttribute(uvs, 2));
+				geometry$1.addAttribute("position", new BufferAttribute(vertices, 3));
+				geometry$1.addAttribute("uv", new BufferAttribute(uvs, 2));
 
 			}
 
 		}
 
-		return geometry;
+		return geometry$1;
 
 	}
 
@@ -58696,6 +57073,11 @@ vec4 envMapTexelToLinear(vec4 color) {
 	    return offset;
 	  }
 
+	  /**
+	   * Hides the particle at the given offset so it is no longer drawn. The particle still takes up space in the array
+	   * though.
+	   * @param offset
+	   */
 	  hideParticle(offset) {
 	    const attributes = this._attributes;
 	    attributes.size.set(
@@ -58782,8 +57164,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 		var material_library_pattern = /^mtllib /;
 		// usemtl material_name
 		var material_use_pattern = /^usemtl /;
-		// usemap map_name
-		var map_use_pattern = /^usemap /;
 
 		function ParserState() {
 
@@ -58796,7 +57176,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 				colors: [],
 				uvs: [],
 
-				materials: {},
 				materialLibraries: [],
 
 				startObject: function ( name, fromDeclaration ) {
@@ -59025,9 +57404,9 @@ vec4 envMapTexelToLinear(vec4 color) {
 					var src = this.colors;
 					var dst = this.object.geometry.colors;
 
-					if ( src[ a ] !== undefined ) dst.push( src[ a + 0 ], src[ a + 1 ], src[ a + 2 ] );
-					if ( src[ b ] !== undefined ) dst.push( src[ b + 0 ], src[ b + 1 ], src[ b + 2 ] );
-					if ( src[ c ] !== undefined ) dst.push( src[ c + 0 ], src[ c + 1 ], src[ c + 2 ] );
+					dst.push( src[ a + 0 ], src[ a + 1 ], src[ a + 2 ] );
+					dst.push( src[ b + 0 ], src[ b + 1 ], src[ b + 2 ] );
+					dst.push( src[ c + 0 ], src[ c + 1 ], src[ c + 2 ] );
 
 				},
 
@@ -59060,7 +57439,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 					var ic = this.parseVertexIndex( c, vLen );
 
 					this.addVertex( ia, ib, ic );
-					this.addColor( ia, ib, ic );
 
 					if ( ua !== undefined && ua !== '' ) {
 
@@ -59082,6 +57460,12 @@ vec4 envMapTexelToLinear(vec4 color) {
 						ic = na === nc ? ia : this.parseNormalIndex( nc, nLen );
 
 						this.addNormal( ia, ib, ic );
+
+					}
+
+					if ( this.colors.length > 0 ) {
+
+						this.addColor( ia, ib, ic );
 
 					}
 
@@ -59134,13 +57518,13 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 		function OBJLoader( manager ) {
 
-			Loader.call( this, manager );
+			this.manager = ( manager !== undefined ) ? manager : DefaultLoadingManager;
 
 			this.materials = null;
 
 		}
 
-		OBJLoader.prototype = Object.assign( Object.create( Loader.prototype ), {
+		OBJLoader.prototype = {
 
 			constructor: OBJLoader,
 
@@ -59158,6 +57542,14 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 			},
 
+			setPath: function ( value ) {
+
+				this.path = value;
+
+				return this;
+
+			},
+
 			setMaterials: function ( materials ) {
 
 				this.materials = materials;
@@ -59167,6 +57559,8 @@ vec4 envMapTexelToLinear(vec4 color) {
 			},
 
 			parse: function ( text ) {
+
+				console.time( 'OBJLoader' );
 
 				var state = new ParserState();
 
@@ -59228,14 +57622,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 									);
 
-								} else {
-
-									// if no colors are defined, add placeholders so color and vertex indices match
-
-									state.colors.push( undefined, undefined, undefined );
-
 								}
-
 								break;
 							case 'vn':
 								state.normals.push(
@@ -59312,7 +57699,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 							}
 
 						}
-
 						state.addLineGeometry( lineVertices, lineUVs );
 
 					} else if ( lineFirstChar === 'p' ) {
@@ -59345,13 +57731,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 						// mtl file
 
 						state.materialLibraries.push( line.substring( 7 ).trim() );
-
-					} else if ( map_use_pattern.test( line ) ) {
-
-						// the line is parsed but ignored since the loader assumes textures are defined MTL files
-						// (according to https://www.okino.com/conv/imp_wave.htm, 'usemap' is the old-style Wavefront texture reference method)
-
-						console.warn( 'THREE.OBJLoader: Rendering identifier "usemap" not supported. Textures must be defined in MTL files.' );
 
 					} else if ( lineFirstChar === 's' ) {
 
@@ -59388,7 +57767,6 @@ vec4 envMapTexelToLinear(vec4 color) {
 							state.object.smooth = true;
 
 						}
-
 						var material = state.object.currentMaterial();
 						if ( material ) material.smooth = state.object.smooth;
 
@@ -59397,7 +57775,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 						// Handle null terminated files without exception
 						if ( line === '\0' ) continue;
 
-						console.warn( 'THREE.OBJLoader: Unexpected line: "' + line + '"' );
+						throw new Error( 'THREE.OBJLoader: Unexpected line: "' + line + '"' );
 
 					}
 
@@ -59422,11 +57800,11 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 					var buffergeometry = new BufferGeometry();
 
-					buffergeometry.setAttribute( 'position', new Float32BufferAttribute( geometry.vertices, 3 ) );
+					buffergeometry.addAttribute( 'position', new Float32BufferAttribute( geometry.vertices, 3 ) );
 
 					if ( geometry.normals.length > 0 ) {
 
-						buffergeometry.setAttribute( 'normal', new Float32BufferAttribute( geometry.normals, 3 ) );
+						buffergeometry.addAttribute( 'normal', new Float32BufferAttribute( geometry.normals, 3 ) );
 
 					} else {
 
@@ -59437,13 +57815,13 @@ vec4 envMapTexelToLinear(vec4 color) {
 					if ( geometry.colors.length > 0 ) {
 
 						hasVertexColors = true;
-						buffergeometry.setAttribute( 'color', new Float32BufferAttribute( geometry.colors, 3 ) );
+						buffergeometry.addAttribute( 'color', new Float32BufferAttribute( geometry.colors, 3 ) );
 
 					}
 
 					if ( geometry.uvs.length > 0 ) {
 
-						buffergeometry.setAttribute( 'uv', new Float32BufferAttribute( geometry.uvs, 2 ) );
+						buffergeometry.addAttribute( 'uv', new Float32BufferAttribute( geometry.uvs, 2 ) );
 
 					}
 
@@ -59454,8 +57832,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 					for ( var mi = 0, miLen = materials.length; mi < miLen; mi ++ ) {
 
 						var sourceMaterial = materials[ mi ];
-						var materialHash = sourceMaterial.name + '_' + sourceMaterial.smooth + '_' + hasVertexColors;
-						var material = state.materials[ materialHash ];
+						var material = undefined;
 
 						if ( this.materials !== null ) {
 
@@ -59467,6 +57844,7 @@ vec4 envMapTexelToLinear(vec4 color) {
 								var materialLine = new LineBasicMaterial();
 								Material.prototype.copy.call( materialLine, material );
 								materialLine.color.copy( material.color );
+								materialLine.lights = false;
 								material = materialLine;
 
 							} else if ( isPoints && material && ! ( material instanceof PointsMaterial ) ) {
@@ -59475,13 +57853,14 @@ vec4 envMapTexelToLinear(vec4 color) {
 								Material.prototype.copy.call( materialPoints, material );
 								materialPoints.color.copy( material.color );
 								materialPoints.map = material.map;
+								materialPoints.lights = false;
 								material = materialPoints;
 
 							}
 
 						}
 
-						if ( material === undefined ) {
+						if ( ! material ) {
 
 							if ( isLine ) {
 
@@ -59498,12 +57877,11 @@ vec4 envMapTexelToLinear(vec4 color) {
 							}
 
 							material.name = sourceMaterial.name;
-							material.flatShading = sourceMaterial.smooth ? false : true;
-							material.vertexColors = hasVertexColors;
-
-							state.materials[ materialHash ] = material;
 
 						}
+
+						material.flatShading = sourceMaterial.smooth ? false : true;
+						material.vertexColors = hasVertexColors ? VertexColors : NoColors;
 
 						createdMaterials.push( material );
 
@@ -59560,11 +57938,13 @@ vec4 envMapTexelToLinear(vec4 color) {
 
 				}
 
+				console.timeEnd( 'OBJLoader' );
+
 				return container;
 
 			}
 
-		} );
+		};
 
 		return OBJLoader;
 
@@ -61793,9 +60173,9 @@ vec4 envMapTexelToLinear(vec4 color) {
 	  }
 	}
 
-	const THREE = _THREE;
+	const THREE$1 = _THREE;
 
-	exports.THREE = THREE;
+	exports.THREE = THREE$1;
 	exports.Camera = Camera$1;
 	exports.sphericalToCartesian = sphericalToCartesian;
 	exports.equatorialToEcliptic_Cartesian = equatorialToEcliptic_Cartesian;

--- a/build/spacekit.js
+++ b/build/spacekit.js
@@ -59842,7 +59842,7 @@ var Spacekit = (function (exports) {
 	      this._scene.remove(x);
 	    });
 
-	    if (typeof obj.removalCleanup == 'function') {
+	    if (typeof obj.removalCleanup === 'function') {
 	      obj.removalCleanup();
 	    }
 	    delete this._subscribedObjects[obj.getId()];

--- a/examples/test_add_remove_objects/index.html
+++ b/examples/test_add_remove_objects/index.html
@@ -1,0 +1,52 @@
+<html>
+<head>
+  <meta http-equiv="Content-type" content="text/html;charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    #main-container {
+      width: 100%;
+      height: 100%;
+    }
+
+    .sim-info {
+      position:absolute;
+      right: 0;
+      background-color:#ccc;
+      padding: 1em;
+    }
+  </style>
+<head>
+<body>
+<div class="sim-info">
+  <button id="btn-add-asteroid">Add Asteroid</button>
+  <button id="btn-remove-asteroid">Remove Asteroid</button>
+  <button id="btn-add-sun">Add Sun</button>
+  <button id="btn-remove-sun">Remove Sun</button>
+  <button id="btn-add-earth">Add Earth</button>
+  <button id="btn-remove-earth">Remove Earth</button>
+  <button id="btn-add-stars">Add Stars</button>
+  <button id="btn-remove-stars">Remove Stars</button>
+  <button id="btn-add-skybox">Add Skybox</button>
+  <button id="btn-remove-skybox">Remove Skybox</button>
+  <button id="btn-add-static">Add Static Particles</button>
+  <button id="btn-remove-static">Remove Static Particles</button>
+  <button id="btn-add-sphere">Add Static Sphere</button>
+  <button id="btn-remove-sphere">Remove Static Sphere</button>
+</div>
+<div id="main-container">
+</div>
+
+<script src="../../build/spacekit.js"></script>
+
+<script src="main.js"></script>
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-140394693-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-140394693-1');
+</script>
+</body>
+</html>

--- a/examples/test_add_remove_objects/main.js
+++ b/examples/test_add_remove_objects/main.js
@@ -1,0 +1,178 @@
+// Create the visualization and put it in our div.
+const viz = new Spacekit.Simulation(document.getElementById('main-container'), {
+  basePath: '../../src',
+  startDate: Date.now(),
+  startPaused: true,
+  camera: {
+    enableDrift: true,
+  },
+  unitsPerAu: 1,
+  camera: {
+    initialPosition: [
+      0.1739865009560048,
+      -0.12915937125168006,
+      0.10357994703146715,
+    ],
+  },
+});
+
+viz.createLight([5, 5, 1]);
+
+let asteroid = undefined;
+let skybox = undefined;
+let sun = undefined;
+let earth = undefined;
+let stars = undefined;
+let staticParticles = undefined;
+let sphere = undefined;
+
+// Create a skybox using NASA TYCHO artwork.
+
+// Create our first object - the sun - using a preset space object.
+
+// Then add some planets
+// viz.createObject('Mercury', Spacekit.SpaceObjectPresets.MERCURY);
+// viz.createObject('Venus', Spacekit.SpaceObjectPresets.VENUS);
+// viz.createObject('Earth', Spacekit.SpaceObjectPresets.EARTH);
+// viz.createObject('Mars', Spacekit.SpaceObjectPresets.MARS);
+// viz.createObject('Jupiter', Spacekit.SpaceObjectPresets.JUPITER);
+// viz.createObject('Saturn', Spacekit.SpaceObjectPresets.SATURN);
+// viz.createObject('Uranus', Spacekit.SpaceObjectPresets.URANUS);
+// viz.createObject('Neptune', Spacekit.SpaceObjectPresets.NEPTUNE);
+
+// Set up event listeners
+
+document.getElementById('btn-add-asteroid').onclick = function() {
+  if (!asteroid) {
+    const ephem = new Spacekit.Ephem(
+      {
+        epoch: 2458600.5,
+        a: 5.38533,
+        e: 0.19893,
+        i: 22.11137,
+        om: 294.42992,
+        w: 314.2889,
+        ma: 229.14238,
+      },
+      'deg',
+    );
+
+    asteroid = viz.createObject('Asteroid Aci', {
+      ephem,
+      ecliptic: {
+        displayLines: true,
+        lineColor: 0x333333,
+      },
+      labelText: 'My asteroid',
+    });
+  }
+};
+
+document.getElementById('btn-remove-asteroid').onclick = function() {
+  if (asteroid) {
+    viz.removeObject(asteroid);
+    asteroid = undefined;
+  }
+};
+
+document.getElementById('btn-add-sun').onclick = function() {
+  if (!sun) {
+    sun = viz.createObject('Sun', Spacekit.SpaceObjectPresets.SUN);
+  }
+};
+
+document.getElementById('btn-remove-sun').onclick = function() {
+  if (sun) {
+    viz.removeObject(sun);
+    sun = undefined;
+  }
+};
+
+document.getElementById('btn-add-earth').onclick = function() {
+  if (!earth) {
+    earth = viz.createObject('Earth', Spacekit.SpaceObjectPresets.EARTH);
+  }
+};
+
+document.getElementById('btn-remove-earth').onclick = function() {
+  if (earth) {
+    viz.removeObject(earth);
+    earth = undefined;
+  }
+};
+
+document.getElementById('btn-add-skybox').onclick = function() {
+  if (!skybox) {
+    skybox = viz.createSkybox(Spacekit.SkyboxPresets.NASA_TYCHO);
+  }
+};
+
+document.getElementById('btn-remove-skybox').onclick = function() {
+  if (skybox) {
+    viz.removeObject(skybox);
+    skybox = undefined;
+  }
+};
+
+document.getElementById('btn-add-stars').onclick = function() {
+  if (!stars) {
+    stars = viz.createStars();
+  }
+};
+
+document.getElementById('btn-remove-stars').onclick = function() {
+  if (stars) {
+    viz.removeObject(stars);
+    stars = undefined;
+  }
+};
+
+document.getElementById('btn-add-static').onclick = function() {
+  if (!staticParticles) {
+    staticParticles = viz.createStaticParticles(
+      'Particles',
+      [
+        [1, 1, 1],
+        [2, 2, 2],
+      ],
+      {},
+    );
+  }
+};
+
+document.getElementById('btn-remove-static').onclick = function() {
+  if (staticParticles) {
+    viz.removeObject(staticParticles);
+    staticParticles = undefined;
+  }
+};
+
+document.getElementById('btn-add-sphere').onclick = function() {
+  if (!sphere) {
+    sphere = viz.createSphere('fakePlanet', {
+      textureUrl: '../saturn/th_saturn.png',
+      radius: 0.75, // radius in AU, so Saturn is shown to scale
+      levelsOfDetail: [
+        { radii: 0, segments: 64 },
+        { radii: 30, segments: 16 },
+        { radii: 60, segments: 8 },
+      ],
+      atmosphere: {
+        enable: true,
+      },
+      occludeLabels: true,
+    });
+    sphere.addRings(
+      1 * 149598000,
+      1.5 * 149598000,
+      '../saturn/saturn_rings_top.png',
+    );
+  }
+};
+
+document.getElementById('btn-remove-sphere').onclick = function() {
+  if (sphere) {
+    viz.removeObject(sphere);
+    sphere = undefined;
+  }
+};

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,7 @@ const plugins = [resolve(), commonjs()];
 
 if (process.env.ENABLE_DEV_SERVER) {
   // envar set via `yarn build:watch`
-  plugins.push(livereload());
+  plugins.push(livereload({ watch: 'build' }));
   plugins.push(serve({ port: 8001, contentBase: ['.'] }));
 }
 

--- a/src/KeplerParticles.js
+++ b/src/KeplerParticles.js
@@ -196,19 +196,20 @@ export class KeplerParticles {
     return offset;
   }
 
+  /**
+   * Hides the particle at the given offset so it is no longer drawn. The particle still takes up space in the array
+   * though.
+   * @param offset
+   */
   hideParticle(offset) {
     const attributes = this._attributes;
-    attributes.size.set(
-      [0],
-      offset,
-    );
+    attributes.size.set([0], offset);
 
     for (const attributeKey in attributes) {
       if (attributes.hasOwnProperty(attributeKey)) {
         attributes[attributeKey].needsUpdate = true;
       }
     }
-
   }
 
   /**

--- a/src/KeplerParticles.js
+++ b/src/KeplerParticles.js
@@ -196,6 +196,21 @@ export class KeplerParticles {
     return offset;
   }
 
+  hideParticle(offset) {
+    const attributes = this._attributes;
+    attributes.size.set(
+      [0],
+      offset,
+    );
+
+    for (const attributeKey in attributes) {
+      if (attributes.hasOwnProperty(attributeKey)) {
+        attributes[attributeKey].needsUpdate = true;
+      }
+    }
+
+  }
+
   /**
    * Change the `origin` attribute of a particle.
    * @param {Number} offset The location of this particle in the attributes * array.

--- a/src/Orbit.js
+++ b/src/Orbit.js
@@ -81,6 +81,13 @@ export class Orbit {
     this._ellipsePoints = null;
 
     /**
+     * Cached ecliptic drop lines.
+     * @type {Array.<THREE.Vector3>}
+     */
+    this._eclipticDropLines = null;
+
+
+    /**
      * Cached ellipse.
      * @type {THREE.Line}
      */
@@ -430,6 +437,10 @@ export class Orbit {
    * @return {THREE.Geometry} A geometry with many line segments.
    */
   getLinesToEcliptic() {
+    if (this._eclipticDropLines) {
+      return this._eclipticDropLines;
+    }
+
     const points = this.getEllipsePoints();
     const geometry = new THREE.Geometry();
 
@@ -438,13 +449,15 @@ export class Orbit {
       geometry.vertices.push(new THREE.Vector3(vertex.x, vertex.y, 0));
     });
 
-    return new THREE.LineSegments(
+    this._eclipticDropLines = new THREE.LineSegments(
       geometry,
       new THREE.LineBasicMaterial({
         color: this._options.eclipticLineColor || 0x333333,
       }),
       THREE.LineStrip,
     );
+
+    return this._eclipticDropLines;
   }
 
   /**

--- a/src/Simulation.js
+++ b/src/Simulation.js
@@ -407,6 +407,9 @@ export class Simulation {
       this._scene.remove(x);
     });
 
+    if (typeof obj.removalCleanup == 'function') {
+      obj.removalCleanup();
+    }
     delete this._subscribedObjects[obj.getId()];
   }
 

--- a/src/SpaceObject.js
+++ b/src/SpaceObject.js
@@ -540,6 +540,17 @@ export class SpaceObject {
   isReady() {
     return this._initialized;
   }
+
+  removalCleanup() {
+    if (this._label) {
+      this._simulation.getSimulationElement().removeChild(this._label);
+      this._label = null;
+    }
+
+    if (this._particleIndex !== undefined) {
+      this._context.objects.particles.hideParticle(this._particleIndex);
+    }
+  }
 }
 
 const DEFAULT_PLANET_TEXTURE_URL = '{{assets}}/sprites/smallparticle.png';


### PR DESCRIPTION
## What does the pull request do?

The `Simulation.removeObject` currently has buggy behavior where object markers, labels, and drop lines to ecliptic aren't removed when the object is. This fixes that behavior.

## What is the current behavior?

See above...

## How was the solution implemented (if it's not obvious)?

 * Added a `hideParticle` method on the `KeplerianParticle` object so that a deleting object can hide the corresponding particle marker that it used for drawing it
 * Implemented a `removalCleanup` to the `SpaceObject` which knows to remove the text label from the DOM and to hide the particle marker if it used it
 * Added a call to `removalCleanup` method in the `Simualation.removeObject` method if the corresponding object supports that method (after a check). 

Ideally I think particle markers should probably be deleted not hidden since this could create a leak of sorts if objects are constantly added/removed during a run but for an initial fix this is a more streamlined update.